### PR TITLE
Expect(err).ToNot(HaveOccurred()) better than Expect(err).To(Succeed())

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Config", func() {
 	BeforeEach(func() {
 		var err error
 		environmentReporter, err = environment.NewReporter("test")
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(environmentReporter).ToNot(BeNil())
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("Config", func() {
 
 		It("returns a new object if name is specified", func() {
 			loader, err := config.NewLoader("_fixtures/config", "TIDEPOOL_TEST", environmentReporter)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(loader).ToNot(BeNil())
 		})
 	})
@@ -69,7 +69,7 @@ var _ = Describe("Config", func() {
 		BeforeEach(func() {
 			var err error
 			loader, err = config.NewLoader("_fixtures/config", "TIDEPOOL_TEST", environmentReporter)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(loader).ToNot(BeNil())
 			testConfig = &TestConfig{}
 		})

--- a/data/context/standard_test.go
+++ b/data/context/standard_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Standard", func() {
 
 		It("exists", func() {
 			Expect(standard).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("has a contained Errors that is empty", func() {

--- a/data/normalizer/standard_test.go
+++ b/data/normalizer/standard_test.go
@@ -36,9 +36,9 @@ var _ = Describe("Standard", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			standard, err = normalizer.NewStandard(standardContext)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("exists", func() {

--- a/data/parser/standard_array_test.go
+++ b/data/parser/standard_array_test.go
@@ -25,9 +25,9 @@ var _ = Describe("StandardArray", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			standardArray, err = parser.NewStandardArray(standardContext, nil, parser.IgnoreNotParsed)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("exists", func() {
@@ -115,9 +115,9 @@ var _ = Describe("StandardArray", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			standardArray, err = parser.NewStandardArray(standardContext, &[]interface{}{}, parser.IgnoreNotParsed)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("exists", func() {
@@ -142,7 +142,7 @@ var _ = Describe("StandardArray", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("ParseBoolean", func() {

--- a/data/parser/standard_object_test.go
+++ b/data/parser/standard_object_test.go
@@ -25,9 +25,9 @@ var _ = Describe("StandardObject", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			standardObject, err = parser.NewStandardObject(standardContext, nil, parser.IgnoreNotParsed)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("exists", func() {
@@ -115,9 +115,9 @@ var _ = Describe("StandardObject", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			standardObject, err = parser.NewStandardObject(standardContext, &map[string]interface{}{}, parser.IgnoreNotParsed)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("exists", func() {
@@ -142,7 +142,7 @@ var _ = Describe("StandardObject", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("ParseBoolean", func() {

--- a/data/validator/standard_boolean_test.go
+++ b/data/validator/standard_boolean_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardBoolean", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_float_as_blood_glucose_value_test.go
+++ b/data/validator/standard_float_as_blood_glucose_value_test.go
@@ -27,7 +27,7 @@ var _ = Describe("StandardFloatAsBloodGlucoseValue", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_float_test.go
+++ b/data/validator/standard_float_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardFloat", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_integer_test.go
+++ b/data/validator/standard_integer_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardInteger", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_interface_array_test.go
+++ b/data/validator/standard_interface_array_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardInterfaceArray", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_interface_test.go
+++ b/data/validator/standard_interface_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardInterface", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_object_array_test.go
+++ b/data/validator/standard_object_array_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardObjectArray", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_object_test.go
+++ b/data/validator/standard_object_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardObject", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_string_array_test.go
+++ b/data/validator/standard_string_array_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardStringArray", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_string_as_blood_glucose_units_test.go
+++ b/data/validator/standard_string_as_blood_glucose_units_test.go
@@ -24,7 +24,7 @@ var _ = Describe("StandardStringAsBloodGlucoseUnits", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil units", func() {

--- a/data/validator/standard_string_as_time_test.go
+++ b/data/validator/standard_string_as_time_test.go
@@ -22,7 +22,7 @@ var _ = Describe("StandardStringAsTime", func() {
 		value := "2015-12-31T13:14:16-08:00"
 		standardContext, err := context.NewStandard(test.NewLogger())
 		Expect(standardContext).ToNot(BeNil())
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(validator.NewStandardStringAsTime(standardContext, "ghost", &value, "")).To(BeNil())
 	})
 
@@ -33,7 +33,7 @@ var _ = Describe("StandardStringAsTime", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_string_test.go
+++ b/data/validator/standard_string_test.go
@@ -23,7 +23,7 @@ var _ = Describe("StandardString", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("new validator with nil reference and nil value", func() {

--- a/data/validator/standard_test.go
+++ b/data/validator/standard_test.go
@@ -25,9 +25,9 @@ var _ = Describe("Standard", func() {
 			var err error
 			standardContext, err = context.NewStandard(test.NewLogger())
 			Expect(standardContext).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			standard, err = validator.NewStandard(standardContext)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("exists", func() {

--- a/environment/environment_test.go
+++ b/environment/environment_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Environment", func() {
 		Context("Name", func() {
 			It("returns the name", func() {
 				reporter, err := environment.NewReporter("brownie")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.Name()).To(Equal("brownie"))
 			})
@@ -33,14 +33,14 @@ var _ = Describe("Environment", func() {
 		Context("IsLocal", func() {
 			It("returns false if environment is not local", func() {
 				reporter, err := environment.NewReporter("brownie")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsLocal()).To(BeFalse())
 			})
 
 			It("returns true if environment is local", func() {
 				reporter, err := environment.NewReporter("local")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsLocal()).To(BeTrue())
 			})
@@ -49,14 +49,14 @@ var _ = Describe("Environment", func() {
 		Context("IsTest", func() {
 			It("returns false if environment is not test", func() {
 				reporter, err := environment.NewReporter("brownie")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsTest()).To(BeFalse())
 			})
 
 			It("returns true if environment is test", func() {
 				reporter, err := environment.NewReporter("test")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsTest()).To(BeTrue())
 			})
@@ -65,21 +65,21 @@ var _ = Describe("Environment", func() {
 		Context("IsDeployed", func() {
 			It("returns false if environment is local", func() {
 				reporter, err := environment.NewReporter("local")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsDeployed()).To(BeFalse())
 			})
 
 			It("returns false if environment is test", func() {
 				reporter, err := environment.NewReporter("test")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsDeployed()).To(BeFalse())
 			})
 
 			It("returns true if environment is not local nor test", func() {
 				reporter, err := environment.NewReporter("brownie")
-				Expect(err).To(Succeed())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(reporter).ToNot(BeNil())
 				Expect(reporter.IsDeployed()).To(BeTrue())
 			})

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Log", func() {
 	BeforeEach(func() {
 		var err error
 		versionReporter, err = version.NewReporter("0.0.0", "0000000", "0000000000000000000000000000000000000000")
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(versionReporter).ToNot(BeNil())
 	})
 
@@ -47,7 +47,7 @@ var _ = Describe("Log", func() {
 
 		It("returns successfully", func() {
 			reporter, err := log.NewLogger(&log.Config{Level: "debug"}, versionReporter)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(reporter).ToNot(BeNil())
 		})
 	})
@@ -58,7 +58,7 @@ var _ = Describe("Log", func() {
 		BeforeEach(func() {
 			var err error
 			logger, err = log.NewLogger(&log.Config{Level: "fatal"}, versionReporter)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(logger).ToNot(BeNil())
 		})
 

--- a/userservices/client/standard_test.go
+++ b/userservices/client/standard_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Standard", func() {
 		It("returns success", func() {
 			standard, err := client.NewStandard(logger, config)
 			Expect(standard).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -127,7 +127,7 @@ var _ = Describe("Standard", func() {
 			var err error
 			standard, err = client.NewStandard(logger, config)
 			Expect(standard).ToNot(BeNil())
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -425,7 +425,7 @@ var _ = Describe("Standard", func() {
 					It("returns the user id", func() {
 						sessionToken, err := standard.ValidateUserSession(context, "session-token")
 						Expect(sessionToken).To(Equal("session-user-id"))
-						Expect(err).To(Succeed())
+						Expect(err).ToNot(HaveOccurred())
 					})
 				})
 			})
@@ -618,7 +618,7 @@ var _ = Describe("Standard", func() {
 
 					It("returns no error", func() {
 						err := standard.ValidateTargetUserPermissions(context, "request-user-id", "target-user-id", client.ViewPermissions)
-						Expect(err).To(Succeed())
+						Expect(err).ToNot(HaveOccurred())
 						Expect(server.ReceivedRequests()).To(HaveLen(2))
 					})
 				})
@@ -636,7 +636,7 @@ var _ = Describe("Standard", func() {
 
 					It("returns no error", func() {
 						err := standard.ValidateTargetUserPermissions(context, "request-user-id", "target-user-id", client.Permissions{"upload": {}, "view": {}})
-						Expect(err).To(Succeed())
+						Expect(err).ToNot(HaveOccurred())
 						Expect(server.ReceivedRequests()).To(HaveLen(2))
 					})
 				})
@@ -654,7 +654,7 @@ var _ = Describe("Standard", func() {
 
 					It("returns no error", func() {
 						err := standard.ValidateTargetUserPermissions(context, "request-user-id", "target-user-id", client.ViewPermissions)
-						Expect(err).To(Succeed())
+						Expect(err).ToNot(HaveOccurred())
 						Expect(server.ReceivedRequests()).To(HaveLen(2))
 					})
 				})
@@ -792,7 +792,7 @@ var _ = Describe("Standard", func() {
 					It("returns the group id", func() {
 						groupID, err := standard.GetUserGroupID(context, "user-id")
 						Expect(groupID).To(Equal("session-group-id"))
-						Expect(err).To(Succeed())
+						Expect(err).ToNot(HaveOccurred())
 						Expect(server.ReceivedRequests()).To(HaveLen(2))
 					})
 				})

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Version", func() {
 
 		It("returns successfully", func() {
 			reporter, err := version.NewReporter("1.2.3", "4567890", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn")
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(reporter).ToNot(BeNil())
 		})
 	})
@@ -40,7 +40,7 @@ var _ = Describe("Version", func() {
 		BeforeEach(func() {
 			var err error
 			reporter, err = version.NewReporter("1.2.3", "4567890", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn")
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(reporter).ToNot(BeNil())
 		})
 


### PR DESCRIPTION
@jhbate Per you thoughts in an earlier PR. I agree, it does read better.