### PR TITLE
remove redundant `Timezone` and `Reasons`

### DIFF
--- a/data/types/base/device/timechange/change.go
+++ b/data/types/base/device/timechange/change.go
@@ -3,11 +3,9 @@ package timechange
 import "github.com/tidepool-org/platform/data"
 
 type Change struct {
-	From     *string   `json:"from,omitempty" bson:"from,omitempty"`
-	To       *string   `json:"to,omitempty" bson:"to,omitempty"`
-	Agent    *string   `json:"agent,omitempty" bson:"agent,omitempty"`
-	Timezone *string   `json:"timezone,omitempty" bson:"timezone,omitempty"`
-	Reasons  *[]string `json:"reasons,omitempty" bson:"reasons,omitempty"`
+	From  *string `json:"from,omitempty" bson:"from,omitempty"`
+	To    *string `json:"to,omitempty" bson:"to,omitempty"`
+	Agent *string `json:"agent,omitempty" bson:"agent,omitempty"`
 }
 
 func NewChange() *Change {
@@ -18,16 +16,12 @@ func (c *Change) Parse(parser data.ObjectParser) {
 	c.From = parser.ParseString("from")
 	c.To = parser.ParseString("to")
 	c.Agent = parser.ParseString("agent")
-	c.Timezone = parser.ParseString("timezone")
-	c.Reasons = parser.ParseStringArray("reasons")
 }
 
 func (c *Change) Validate(validator data.Validator) {
 	validator.ValidateStringAsTime("from", c.From, "2006-01-02T15:04:05").Exists()
 	validator.ValidateStringAsTime("to", c.To, "2006-01-02T15:04:05").Exists()
 	validator.ValidateString("agent", c.Agent).Exists().OneOf([]string{"manual", "automatic"})
-	validator.ValidateString("timezone", c.Timezone)
-	validator.ValidateStringArray("reasons", c.Reasons).EachOneOf([]string{"from_daylight_savings", "to_daylight_savings", "travel", "correction", "other"})
 }
 
 func (c *Change) Normalize(normalizer data.Normalizer) {

--- a/data/types/base/device/timechange/timechange_test.go
+++ b/data/types/base/device/timechange/timechange_test.go
@@ -15,10 +15,9 @@ func NewRawObject() map[string]interface{} {
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "timeChange"
 	rawObject["change"] = map[string]interface{}{
-		"from":    "2016-05-04T08:18:06",
-		"to":      "2016-05-04T07:21:31",
-		"agent":   "manual",
-		"reasons": []string{"travel", "correction"},
+		"from":  "2016-05-04T08:18:06",
+		"to":    "2016-05-04T07:21:31",
+		"agent": "manual",
 	}
 	return rawObject
 }
@@ -35,16 +34,16 @@ var _ = Describe("Timechange", func() {
 		Context("from", func() {
 			DescribeTable("valid when", testing.ExpectFieldIsValid,
 				Entry("is non zulu time", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"travel", "correction"}}),
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual"}),
 			)
 
 			DescribeTable("invalid when", testing.ExpectFieldNotValid,
 				Entry("is zulu time", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06Z", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"travel", "correction"}},
+					map[string]interface{}{"from": "2016-05-04T08:18:06Z", "to": "2016-05-04T07:21:31", "agent": "manual"},
 					[]*service.Error{testing.ComposeError(validator.ErrorTimeNotValid("2016-05-04T08:18:06Z", "2006-01-02T15:04:05"), "/change/from", NewMeta())},
 				),
 				Entry("is empty time", NewRawObject(), "change",
-					map[string]interface{}{"from": "", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"travel", "correction"}},
+					map[string]interface{}{"from": "", "to": "2016-05-04T07:21:31", "agent": "manual"},
 					[]*service.Error{testing.ComposeError(validator.ErrorTimeNotValid("", "2006-01-02T15:04:05"), "/change/from", NewMeta())},
 				),
 			)
@@ -53,16 +52,16 @@ var _ = Describe("Timechange", func() {
 		Context("to", func() {
 			DescribeTable("valid when", testing.ExpectFieldIsValid,
 				Entry("is non zulu time", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"travel", "correction"}}),
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual"}),
 			)
 
 			DescribeTable("invalid when", testing.ExpectFieldNotValid,
 				Entry("is zulu time", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31Z", "agent": "manual", "reasons": []string{"travel", "correction"}},
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31Z", "agent": "manual"},
 					[]*service.Error{testing.ComposeError(validator.ErrorTimeNotValid("2016-05-04T07:21:31Z", "2006-01-02T15:04:05"), "/change/to", NewMeta())},
 				),
 				Entry("is empty time", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "", "agent": "manual", "reasons": []string{"travel", "correction"}},
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "", "agent": "manual"},
 					[]*service.Error{testing.ComposeError(validator.ErrorTimeNotValid("", "2006-01-02T15:04:05"), "/change/to", NewMeta())},
 				),
 			)
@@ -71,58 +70,22 @@ var _ = Describe("Timechange", func() {
 		Context("agent", func() {
 			DescribeTable("valid when", testing.ExpectFieldIsValid,
 				Entry("is manual", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"travel", "correction"}}),
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual"}),
 				Entry("is automatic", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic", "reasons": []string{"travel", "correction"}}),
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic"}),
 			)
 
 			DescribeTable("invalid when", testing.ExpectFieldNotValid,
 				Entry("is empty", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "", "reasons": []string{"travel", "correction"}},
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": ""},
 					[]*service.Error{testing.ComposeError(validator.ErrorStringNotOneOf("", []string{"manual", "automatic"}), "/change/agent", NewMeta())},
 				),
 				Entry("is not predefined type", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "wrong", "reasons": []string{"travel", "correction"}},
+					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "wrong"},
 					[]*service.Error{testing.ComposeError(validator.ErrorStringNotOneOf("wrong", []string{"manual", "automatic"}), "/change/agent", NewMeta())},
 				),
 			)
 		})
 
-		Context("reasons", func() {
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
-				Entry("is travel", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"travel"}}),
-				Entry("is correction", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic", "reasons": []string{"correction"}}),
-				Entry("is from_daylight_savings", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic", "reasons": []string{"from_daylight_savings"}}),
-				Entry("is to_daylight_savings", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic", "reasons": []string{"to_daylight_savings"}}),
-				Entry("is other", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic", "reasons": []string{"other"}}),
-				Entry("is all allowed types", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic", "reasons": []string{"from_daylight_savings", "to_daylight_savings", "travel", "correction", "other"}}),
-			)
-
-			DescribeTable("invalid when", testing.ExpectFieldNotValid,
-				Entry("is empty", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{""}},
-					[]*service.Error{testing.ComposeError(validator.ErrorStringNotOneOf("", []string{"from_daylight_savings", "to_daylight_savings", "travel", "correction", "other"}), "/change/reasons/0", NewMeta())},
-				),
-				Entry("is not predefined type", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual", "reasons": []string{"wrong"}},
-					[]*service.Error{testing.ComposeError(validator.ErrorStringNotOneOf("wrong", []string{"from_daylight_savings", "to_daylight_savings", "travel", "correction", "other"}), "/change/reasons/0", NewMeta())},
-				),
-			)
-		})
-
-		Context("timezone", func() {
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
-				Entry("is set", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "timezone": "US/Central", "agent": "manual", "reasons": []string{"travel"}}),
-				Entry("is empty", NewRawObject(), "change",
-					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "timezone": "", "agent": "manual", "reasons": []string{"travel"}}),
-			)
-		})
 	})
 })


### PR DESCRIPTION
@darinkrauss updates due to fields that are redundant for the timechange event 

cc @jebeck 