### PR TITLE
Allow embedded deviceEvent/status in deviceEvent/alarm; cleanup calculator embedded bolus

### DIFF
--- a/data/types/base/bolus/calculator/calculator.go
+++ b/data/types/base/bolus/calculator/calculator.go
@@ -34,7 +34,7 @@ type Calculator struct {
 	BloodGlucoseInput        *float64 `json:"bgInput,omitempty" bson:"bgInput,omitempty"`
 	Units                    *string  `json:"units,omitempty" bson:"units,omitempty"`
 
-	//private field that will be used to build and normalize the embedded bolus
+	// Embedded bolus
 	bolus *data.Datum
 }
 
@@ -159,8 +159,10 @@ func (c *Calculator) Normalize(normalizer data.Normalizer) error {
 	}
 
 	if c.bolus != nil {
-		(*c.bolus).Normalize(normalizer.NewChildNormalizer("bolus"))
-		normalizer.AppendDatum(*c.bolus)
+		if err := (*c.bolus).Normalize(normalizer.NewChildNormalizer("bolus")); err != nil {
+			return err
+		}
+
 		switch (*c.bolus).(type) {
 		case *extended.Extended:
 			c.BolusID = &(*c.bolus).(*extended.Extended).ID
@@ -169,6 +171,8 @@ func (c *Calculator) Normalize(normalizer data.Normalizer) error {
 		case *combination.Combination:
 			c.BolusID = &(*c.bolus).(*combination.Combination).ID
 		}
+
+		normalizer.AppendDatum(*c.bolus)
 		c.bolus = nil
 	}
 

--- a/data/types/base/bolus/calculator/calculator_test.go
+++ b/data/types/base/bolus/calculator/calculator_test.go
@@ -28,7 +28,7 @@ func NewRawObjectWithMmolL() map[string]interface{} {
 	rawObject["recommended"] = map[string]interface{}{"net": 50, "correction": -50, "carb": 50}
 	rawObject["bgTarget"] = map[string]interface{}{"target": 8.0, "range": 1.0}
 
-	rawObject["bolus"] = embeddedBolus("bolus", "normal", 52.1, 0.0, 0)
+	rawObject["bolus"] = NewEmbeddedBolus("bolus", "normal", 52.1, 0.0, 0)
 
 	rawObject["units"] = bloodglucose.MmolL
 	return rawObject
@@ -52,7 +52,7 @@ func NewRawObjectWithMgdL() map[string]interface{} {
 	rawObject["recommended"] = map[string]interface{}{"net": 50, "correction": -50, "carb": 50}
 	rawObject["bgTarget"] = map[string]interface{}{"target": 100, "range": 10.0}
 
-	rawObject["bolus"] = embeddedBolus("bolus", "normal", 52.1, 0.0, 0)
+	rawObject["bolus"] = NewEmbeddedBolus("bolus", "normal", 52.1, 0.0, 0)
 
 	rawObject["units"] = bloodglucose.MgdL
 	return rawObject
@@ -70,7 +70,7 @@ func NewMeta() interface{} {
 	}
 }
 
-var embeddedBolus = func(datumType interface{}, subType interface{}, normal, extended float64, duration int) map[string]interface{} {
+func NewEmbeddedBolus(datumType interface{}, subType interface{}, normal, extended float64, duration int) map[string]interface{} {
 	var rawBolus = testing.RawBaseObject()
 
 	if datumType != nil {
@@ -252,19 +252,19 @@ var _ = Describe("Calculator", func() {
 
 	Context("bolus", func() {
 		DescribeTable("invalid when type", testing.ExpectFieldNotValid,
-			Entry("is missing", NewRawObjectWithMgdl(), "bolus", embeddedBolus(nil, "normal", 52.1, 0.0, 0),
+			Entry("is missing", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus(nil, "normal", 52.1, 0.0, 0),
 				[]*service.Error{testing.ComposeError(validator.ErrorValueNotExists(), "/bolus/type", NewMeta())},
 			),
-			Entry("is not valid", NewRawObjectWithMgdl(), "bolus", embeddedBolus("invalid", "normal", 52.1, 0.0, 0),
+			Entry("is not valid", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("invalid", "normal", 52.1, 0.0, 0),
 				[]*service.Error{testing.ComposeError(validator.ErrorStringNotOneOf("invalid", []string{"bolus"}), "/bolus/type", NewMeta())},
 			),
 		)
 
 		DescribeTable("invalid when subType", testing.ExpectFieldNotValid,
-			Entry("is missing", NewRawObjectWithMgdl(), "bolus", embeddedBolus("bolus", nil, 0.0, 52.1, 0),
+			Entry("is missing", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", nil, 0.0, 52.1, 0),
 				[]*service.Error{testing.ComposeError(validator.ErrorValueNotExists(), "/bolus/subType", NewMeta())},
 			),
-			Entry("is not valid", NewRawObjectWithMgdl(), "bolus", embeddedBolus("bolus", "invalid", 0.0, 52.1, 0),
+			Entry("is not valid", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", "invalid", 0.0, 52.1, 0),
 				[]*service.Error{testing.ComposeError(validator.ErrorStringNotOneOf("invalid", []string{"dual/square", "normal", "square"}), "/bolus/subType", NewMeta())},
 			),
 		)
@@ -329,9 +329,9 @@ var _ = Describe("Calculator", func() {
 				calculatorBolus := calculatorDatum.(*calculator.Calculator)
 				Expect(calculatorBolus.BolusID).To(Not(BeNil()))
 			},
-				Entry("is normal", NewRawObjectWithMgdl(), "bolus", embeddedBolus("bolus", "normal", 52.1, 0.0, 0)),
-				Entry("is square", NewRawObjectWithMgdl(), "bolus", embeddedBolus("bolus", "square", 0.0, 52.1, 1000)),
-				Entry("is dual/square", NewRawObjectWithMgdl(), "bolus", embeddedBolus("bolus", "dual/square", 52.1, 52.1, 1000)),
+				Entry("is normal", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", "normal", 52.1, 0.0, 0)),
+				Entry("is square", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", "square", 0.0, 52.1, 1000)),
+				Entry("is dual/square", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", "dual/square", 52.1, 52.1, 1000)),
 			)
 		})
 	})

--- a/data/types/base/device/alarm/alarm.go
+++ b/data/types/base/device/alarm/alarm.go
@@ -13,13 +13,18 @@ package alarm
 import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/base/device"
+	"github.com/tidepool-org/platform/data/types/base/device/status"
+	"github.com/tidepool-org/platform/data/validator"
 )
 
 type Alarm struct {
 	device.Device `bson:",inline"`
 
 	AlarmType *string `json:"alarmType,omitempty" bson:"alarmType,omitempty"`
-	Status    *string `json:"status,omitempty" bson:"status,omitempty"`
+	StatusID  *string `json:"status,omitempty" bson:"status,omitempty"`
+
+	// Embedded status
+	status *data.Datum
 }
 
 func SubType() string {
@@ -45,7 +50,9 @@ func (a *Alarm) Init() {
 	a.Device.SubType = SubType()
 
 	a.AlarmType = nil
-	a.Status = nil
+	a.StatusID = nil
+
+	a.status = nil
 }
 
 func (a *Alarm) Parse(parser data.ObjectParser) error {
@@ -54,7 +61,22 @@ func (a *Alarm) Parse(parser data.ObjectParser) error {
 	}
 
 	a.AlarmType = parser.ParseString("alarmType")
-	a.Status = parser.ParseString("status")
+
+	// TODO: This is a bit hacky to ensure we only parse true status data. Is there a better way?
+
+	if statusParser := parser.NewChildObjectParser("status"); statusParser.Object() != nil {
+		if statusType := statusParser.ParseString("type"); statusType == nil {
+			statusParser.AppendError("type", validator.ErrorValueNotExists())
+		} else if *statusType != device.Type() {
+			statusParser.AppendError("type", validator.ErrorStringNotOneOf(*statusType, []string{device.Type()}))
+		} else if statusSubType := statusParser.ParseString("subType"); statusSubType == nil {
+			statusParser.AppendError("subType", validator.ErrorValueNotExists())
+		} else if *statusSubType != status.SubType() {
+			statusParser.AppendError("subType", validator.ErrorStringNotOneOf(*statusSubType, []string{status.SubType()}))
+		} else {
+			a.status = parser.ParseDatum("status")
+		}
+	}
 
 	return nil
 }
@@ -78,7 +100,28 @@ func (a *Alarm) Validate(validator data.Validator) error {
 		},
 	)
 
-	validator.ValidateString("status", a.Status).LengthGreaterThan(1)
+	if a.status != nil {
+		(*a.status).Validate(validator.NewChildValidator("status"))
+	}
+
+	return nil
+}
+
+func (a *Alarm) Normalize(normalizer data.Normalizer) error {
+	if err := a.Device.Normalize(normalizer); err != nil {
+		return err
+	}
+
+	if a.status != nil {
+		if err := (*a.status).Normalize(normalizer.NewChildNormalizer("status")); err != nil {
+			return err
+		}
+
+		a.StatusID = &(*a.status).(*status.Status).ID
+
+		normalizer.AppendDatum(*a.status)
+		a.status = nil
+	}
 
 	return nil
 }


### PR DESCRIPTION
Minor cleanup and additional error checking in embedded bolus in calculator.

Pull out embedded deviceEvent/status from deviceEvent/alarm, do proper validation and normalization, store reference link (id) to embedded deviceEvent/status into containing deviceEvent/alarm.

@jh-bate @gniezen `@anyone`?