### PR TITLE
Delete user data; preparation for delete user

### DIFF
--- a/data/deduplicator/delegate/delegate_test.go
+++ b/data/deduplicator/delegate/delegate_test.go
@@ -111,6 +111,10 @@ func (t *TestDataStoreSession) DeleteOtherDatasetData(dataset *upload.Upload) er
 	panic("Unexpected invocation of DeleteOtherDatasetData on TestDataStoreSession")
 }
 
+func (t *TestDataStoreSession) DeleteDataForUser(userID string) error {
+	panic("Unexpected invocation of DeleteDataForUser on TestDataStoreSession")
+}
+
 var _ = Describe("Delegate", func() {
 	Context("NewFactory", func() {
 		It("returns an error if factories is nil", func() {

--- a/data/deduplicator/truncate/truncate_test.go
+++ b/data/deduplicator/truncate/truncate_test.go
@@ -87,6 +87,10 @@ func (t *TestDataStoreSession) DeleteOtherDatasetData(dataset *upload.Upload) er
 	return output
 }
 
+func (t *TestDataStoreSession) DeleteDataForUser(userID string) error {
+	panic("Unexpected invocation of DeleteDataForUser on TestDataStoreSession")
+}
+
 var _ = Describe("Truncate", func() {
 	Context("NewFactory", func() {
 		It("returns a new factory", func() {

--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -461,6 +461,32 @@ func (s *Session) DeleteOtherDatasetData(dataset *upload.Upload) error {
 	return nil
 }
 
+func (s *Session) DeleteDataForUser(userID string) error {
+	if userID == "" {
+		return app.Error("mongo", "user id is missing")
+	}
+
+	if s.IsClosed() {
+		return app.Error("mongo", "session closed")
+	}
+
+	startTime := time.Now()
+
+	selector := bson.M{
+		"_userId": userID,
+	}
+	removeInfo, err := s.C().RemoveAll(selector)
+
+	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	s.Logger().WithFields(loggerFields).WithError(err).Debug("DeleteDataForUser")
+
+	if err != nil {
+		return app.ExtError(err, "mongo", "unable to delete data for user")
+	}
+
+	return nil
+}
+
 func (s *Session) agentUserID() string {
 	if s.agent == nil {
 		return ""

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -37,6 +37,7 @@ type Session interface {
 	CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error
 	ActivateDatasetData(dataset *upload.Upload) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
+	DeleteDataForUser(userID string) error
 }
 
 type Agent interface {

--- a/dataservices/service/api/v1/users_data_delete.go
+++ b/dataservices/service/api/v1/users_data_delete.go
@@ -1,0 +1,42 @@
+package v1
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"net/http"
+
+	"github.com/tidepool-org/platform/dataservices/service"
+	commonService "github.com/tidepool-org/platform/service"
+)
+
+func UsersDataDelete(serviceContext service.Context) {
+	targetUserID := serviceContext.Request().PathParam("userid")
+	if targetUserID == "" {
+		serviceContext.RespondWithError(ErrorUserIDMissing())
+		return
+	}
+
+	if !serviceContext.AuthenticationDetails().IsServer() {
+		serviceContext.RespondWithError(commonService.ErrorUnauthorized())
+		return
+	}
+
+	if err := serviceContext.DataStoreSession().DeleteDataForUser(targetUserID); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to delete data for user", err)
+		return
+	}
+
+	if err := serviceContext.MetricServicesClient().RecordMetric(serviceContext, "users_data_delete"); err != nil {
+		serviceContext.Logger().WithError(err).Error("Unable to record metric")
+	}
+
+	serviceContext.RespondWithStatusAndData(http.StatusOK, []struct{}{})
+}

--- a/dataservices/service/api/v1/users_data_delete_test.go
+++ b/dataservices/service/api/v1/users_data_delete_test.go
@@ -1,0 +1,114 @@
+package v1_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"net/http"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/dataservices/service/api/v1"
+	"github.com/tidepool-org/platform/service"
+)
+
+var _ = Describe("UsersDataDelete", func() {
+	Context("Unit Tests", func() {
+		var targetUserID string
+		var context *TestContext
+
+		BeforeEach(func() {
+			targetUserID = app.NewID()
+			context = NewTestContext()
+			context.RequestImpl.PathParams["userid"] = targetUserID
+			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{true}
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{nil}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{nil}
+		})
+
+		It("succeeds if authenticated as server", func() {
+			v1.UsersDataDelete(context)
+			Expect(context.DataStoreSessionImpl.DeleteDataForUserInputs).To(Equal([]string{targetUserID}))
+			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "users_data_delete", nil}}))
+			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, []struct{}{}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("panics if context is missing", func() {
+			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			Expect(func() { v1.UsersDataDelete(nil) }).To(Panic())
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("panics if request is missing", func() {
+			context.RequestImpl = nil
+			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			Expect(func() { v1.UsersDataDelete(nil) }).To(Panic())
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if user id not provided as a parameter", func() {
+			delete(context.RequestImpl.PathParams, "userid")
+			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.UsersDataDelete(context)
+			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{v1.ErrorUserIDMissing()}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("panics if authentication details is missing", func() {
+			context.AuthenticationDetailsImpl = nil
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			Expect(func() { v1.UsersDataDelete(context) }).To(Panic())
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if not server", func() {
+			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{false}
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.UsersDataDelete(context)
+			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{service.ErrorUnauthorized()}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("panics if data store session is missing", func() {
+			context.DataStoreSessionImpl = nil
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			Expect(func() { v1.UsersDataDelete(context) }).To(Panic())
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if data store session delete data for user returns error", func() {
+			err := errors.New("other")
+			context.DataStoreSessionImpl.DeleteDataForUserOutputs = []error{err}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.UsersDataDelete(context)
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to delete data for user", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("panics if metric services client is missing", func() {
+			context.MetricServicesClientImpl = nil
+			Expect(func() { v1.UsersDataDelete(context) }).To(Panic())
+			Expect(context.DataStoreSessionImpl.DeleteDataForUserInputs).To(Equal([]string{targetUserID}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("logs and ignores if metric services record metric returns an error", func() {
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{errors.New("other")}
+			v1.UsersDataDelete(context)
+			Expect(context.DataStoreSessionImpl.DeleteDataForUserInputs).To(Equal([]string{targetUserID}))
+			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "users_data_delete", nil}}))
+			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, []struct{}{}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+	})
+})

--- a/dataservices/service/api/v1/v1.go
+++ b/dataservices/service/api/v1/v1.go
@@ -17,6 +17,7 @@ func Routes() []service.Route {
 		service.MakeRoute("POST", "/v1/datasets/:datasetid/data", Authenticate(DatasetsDataCreate)),
 		service.MakeRoute("DELETE", "/v1/datasets/:datasetid", Authenticate(DatasetsDelete)),
 		service.MakeRoute("PUT", "/v1/datasets/:datasetid", Authenticate(DatasetsUpdate)),
+		service.MakeRoute("DELETE", "/v1/users/:userid/data", Authenticate(UsersDataDelete)),
 		service.MakeRoute("POST", "/v1/users/:userid/datasets", Authenticate(UsersDatasetsCreate)),
 		service.MakeRoute("GET", "/v1/users/:userid/datasets", Authenticate(UsersDatasetsGet)),
 	}

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -86,6 +86,10 @@ func (t *TestUserServicesClient) GetUserGroupID(context service.Context, userID 
 	panic("Unexpected invocation of GetUserGroupID on TestUserServicesClient")
 }
 
+func (t *TestUserServicesClient) ServerToken() (string, error) {
+	panic("Unexpected invocation of ServerToken on TestUserServicesClient")
+}
+
 func (t *TestUserServicesClient) ValidateTest() bool {
 	return len(t.GetUserPermissionsOutputs) == 0
 }

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -128,6 +128,8 @@ type TestDataStoreSession struct {
 	GetDatasetOutputs         []GetDatasetOutput
 	DeleteDatasetInputs       []*upload.Upload
 	DeleteDatasetOutputs      []error
+	DeleteDataForUserInputs   []string
+	DeleteDataForUserOutputs  []error
 }
 
 func (t *TestDataStoreSession) IsClosed() bool {
@@ -181,6 +183,13 @@ func (t *TestDataStoreSession) ActivateDatasetData(dataset *upload.Upload) error
 
 func (t *TestDataStoreSession) DeleteOtherDatasetData(dataset *upload.Upload) error {
 	panic("Unexpected invocation of DeleteOtherDatasetData on TestDataStoreSession")
+}
+
+func (t *TestDataStoreSession) DeleteDataForUser(userID string) error {
+	t.DeleteDataForUserInputs = append(t.DeleteDataForUserInputs, userID)
+	output := t.DeleteDataForUserOutputs[0]
+	t.DeleteDataForUserOutputs = t.DeleteDataForUserOutputs[1:]
+	return output
 }
 
 func (t *TestDataStoreSession) ValidateTest() bool {

--- a/dataservices/service/service/standard.go
+++ b/dataservices/service/service/standard.go
@@ -114,7 +114,7 @@ func (s *Standard) initializeMetricServicesClient() error {
 
 	s.Logger().Debug("Creating metric services client")
 
-	metricServicesClient, err := metricservicesClient.NewStandard(s.VersionReporter(), s.Logger(), s.Name(), metricServicesClientConfig)
+	metricServicesClient, err := metricservicesClient.NewStandard(s.VersionReporter(), s.Name(), metricServicesClientConfig)
 	if err != nil {
 		return app.ExtError(err, "service", "unable to create metric services client")
 	}

--- a/metricservices/client/standard.go
+++ b/metricservices/client/standard.go
@@ -25,7 +25,6 @@ import (
 
 type Standard struct {
 	versionReporter version.Reporter
-	logger          log.Logger
 	name            string
 	config          *Config
 	httpClient      *http.Client
@@ -33,12 +32,9 @@ type Standard struct {
 
 const TidepoolAuthenticationTokenHeaderName = "X-Tidepool-Session-Token"
 
-func NewStandard(versionReporter version.Reporter, logger log.Logger, name string, config *Config) (*Standard, error) {
+func NewStandard(versionReporter version.Reporter, name string, config *Config) (*Standard, error) {
 	if versionReporter == nil {
 		return nil, app.Error("client", "version reporter is missing")
-	}
-	if logger == nil {
-		return nil, app.Error("client", "logger is missing")
 	}
 	if name == "" {
 		return nil, app.Error("client", "name is missing")
@@ -58,7 +54,6 @@ func NewStandard(versionReporter version.Reporter, logger log.Logger, name strin
 
 	return &Standard{
 		versionReporter: versionReporter,
-		logger:          logger,
 		name:            name,
 		config:          config,
 		httpClient:      httpClient,

--- a/metricservices/client/standard_test.go
+++ b/metricservices/client/standard_test.go
@@ -64,7 +64,6 @@ func (t *TestContext) ValidateTest() bool {
 
 var _ = Describe("Standard", func() {
 	var versionReporter version.Reporter
-	var logger log.Logger
 	var context *TestContext
 
 	BeforeEach(func() {
@@ -72,9 +71,8 @@ var _ = Describe("Standard", func() {
 		versionReporter, err = version.NewReporter("1.2.3", "4567890", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(versionReporter).ToNot(BeNil())
-		logger = log.NewNull()
 		context = &TestContext{
-			TestLogger:                logger,
+			TestLogger:                log.NewNull(),
 			TestRequest:               &rest.Request{},
 			TestAuthenticationDetails: &TestAuthenticationDetails{},
 		}
@@ -91,45 +89,39 @@ var _ = Describe("Standard", func() {
 		})
 
 		It("returns an error if version reporter is missing", func() {
-			standard, err := client.NewStandard(nil, logger, "testservices", config)
+			standard, err := client.NewStandard(nil, "testservices", config)
 			Expect(err).To(MatchError("client: version reporter is missing"))
 			Expect(standard).To(BeNil())
 		})
 
-		It("returns an error if logger is missing", func() {
-			standard, err := client.NewStandard(versionReporter, nil, "testservices", config)
-			Expect(err).To(MatchError("client: logger is missing"))
-			Expect(standard).To(BeNil())
-		})
-
 		It("returns an error if name is missing", func() {
-			standard, err := client.NewStandard(versionReporter, logger, "", config)
+			standard, err := client.NewStandard(versionReporter, "", config)
 			Expect(err).To(MatchError("client: name is missing"))
 			Expect(standard).To(BeNil())
 		})
 
 		It("returns an error if config is missing", func() {
-			standard, err := client.NewStandard(versionReporter, logger, "testservices", nil)
+			standard, err := client.NewStandard(versionReporter, "testservices", nil)
 			Expect(err).To(MatchError("client: config is missing"))
 			Expect(standard).To(BeNil())
 		})
 
 		It("returns an error if config address is invalid", func() {
 			config.Address = ""
-			standard, err := client.NewStandard(versionReporter, logger, "testservices", config)
+			standard, err := client.NewStandard(versionReporter, "testservices", config)
 			Expect(err).To(MatchError("client: config is invalid; client: address is missing"))
 			Expect(standard).To(BeNil())
 		})
 
 		It("returns an error if config request timeout is invalid", func() {
 			config.RequestTimeout = -1
-			standard, err := client.NewStandard(versionReporter, logger, "testservices", config)
+			standard, err := client.NewStandard(versionReporter, "testservices", config)
 			Expect(err).To(MatchError("client: config is invalid; client: request timeout is invalid"))
 			Expect(standard).To(BeNil())
 		})
 
 		It("returns success", func() {
-			standard, err := client.NewStandard(versionReporter, logger, "testservices", config)
+			standard, err := client.NewStandard(versionReporter, "testservices", config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(standard).ToNot(BeNil())
 		})
@@ -155,7 +147,7 @@ var _ = Describe("Standard", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			standard, err = client.NewStandard(versionReporter, logger, "testservices", config)
+			standard, err = client.NewStandard(versionReporter, "testservices", config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(standard).ToNot(BeNil())
 		})

--- a/userservices/client/client.go
+++ b/userservices/client/client.go
@@ -25,12 +25,11 @@ type AuthenticationDetails interface {
 }
 
 type Client interface {
-	Start() error
-	Close()
-
 	ValidateAuthenticationToken(context service.Context, authenticationToken string) (AuthenticationDetails, error)
 	GetUserPermissions(context service.Context, requestUserID string, targetUserID string) (Permissions, error)
 	GetUserGroupID(context service.Context, userID string) (string, error)
+
+	ServerToken() (string, error)
 }
 
 type Permission map[string]interface{}

--- a/userservices/client/standard.go
+++ b/userservices/client/standard.go
@@ -214,6 +214,19 @@ func (s *Standard) GetUserGroupID(context service.Context, userID string) (strin
 	return groupID, nil
 }
 
+func (s *Standard) ServerToken() (string, error) {
+	if s.closingChannel == nil {
+		return "", app.Error("client", "client is closed")
+	}
+
+	serverToken := s.serverToken()
+	if serverToken == "" {
+		return "", app.Error("client", "unable to obtain server token")
+	}
+
+	return serverToken, nil
+}
+
 // TODO: Current user related APIs return http.StatusUnauthorized for BOTH bad server token
 // AND bad session token. Since a bad server token is unlikely (though possible) we MUST assume
 // that it means bad session token.

--- a/userservices/client/standard_test.go
+++ b/userservices/client/standard_test.go
@@ -813,6 +813,21 @@ var _ = Describe("Standard", func() {
 					})
 				})
 			})
+
+			Context("ServerToken", func() {
+				It("returns a server token", func() {
+					serverToken, err := standard.ServerToken()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(serverToken).ToNot(BeEmpty())
+				})
+
+				It("returns error if client is closed", func() {
+					standard.Close()
+					serverToken, err := standard.ServerToken()
+					Expect(err).To(MatchError("client: client is closed"))
+					Expect(serverToken).To(BeEmpty())
+				})
+			})
 		})
 
 		Context("with client started and did NOT obtain a server token", func() {
@@ -858,6 +873,14 @@ var _ = Describe("Standard", func() {
 					Expect(groupID).To(Equal(""))
 					Expect(err.Error()).To(HavePrefix("client: unable to obtain server token for GET "))
 					Expect(server.ReceivedRequests()).To(HaveLen(1))
+				})
+			})
+
+			Context("ServerToken", func() {
+				It("returns an error", func() {
+					serverToken, err := standard.ServerToken()
+					Expect(err).To(MatchError("client: unable to obtain server token"))
+					Expect(serverToken).To(BeEmpty())
 				})
 			})
 		})

--- a/userservices/service/service/standard.go
+++ b/userservices/service/service/standard.go
@@ -90,7 +90,7 @@ func (s *Standard) initializeMetricServicesClient() error {
 
 	s.Logger().Debug("Creating metric services client")
 
-	metricServicesClient, err := metricservicesClient.NewStandard(s.VersionReporter(), s.Logger(), s.Name(), metricServicesClientConfig)
+	metricServicesClient, err := metricservicesClient.NewStandard(s.VersionReporter(), s.Name(), metricServicesClientConfig)
 	if err != nil {
 		return app.ExtError(err, "service", "unable to create metric services client")
 	}


### PR DESCRIPTION
@jh-bate Per our conversation last week, this PR includes just deleting the data for a user (in dataservices); plus some minor preparation for full on delete user.

Each commit still is complete by itself and includes comments on exactly what it includes.