### PR TITLE
Add tapi tool for command-line testing; include dataset list/delete

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -37,6 +37,10 @@
 			"Rev": "fb7a3183cd987802d006408fe3a4a9e1f6002ece"
 		},
 		{
+			"ImportPath": "github.com/mitchellh/go-homedir",
+			"Rev": "756f7b183b7ab78acdbbee5c7f392838ed459dda"
+		},
+		{
 			"ImportPath": "github.com/onsi/ginkgo",
 			"Comment": "v1.2.0-70-g43e2af1",
 			"Rev": "43e2af1f01ace55adbb6d7d0f30416476db1baae"
@@ -225,6 +229,10 @@
 			"ImportPath": "github.com/urfave/cli",
 			"Comment": "v1.18.0-49-g207bb61",
 			"Rev": "207bb6185291cfced4895a7768cad642e08a68d8"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ssh/terminal",
+			"Rev": "6ab629be5e31660579425a738ba8870beb5b7404"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",

--- a/tools/tapi/README.md
+++ b/tools/tapi/README.md
@@ -1,0 +1,204 @@
+## tapi
+
+This tool will allow easy command-line access to many features of the Tidepool API. It currently has limited features, but additional features will be added over time.
+
+## Which Server?
+
+This tool must be configured with the appropriate HTTP endpoint in order to communicate with the Tidepool API. You can specify either the endpoint directly, or the Tidepool environment name and the endpoint will be determine automatically. It is recommended that you use specify the Tidepool environment name rather than the endpoint.
+
+Note: The endpoint takes precedence over the environment name.
+
+### Environment
+
+If you choose to specify the Tidepool environment name when invoking the tool it will automatically convert from all known environments (ie. `prd`, `int`, `stg`, `dev`, `local`) to the appropriate endpoint. For example:
+
+```
+$ tapi login --env=prd
+```
+
+#### TIDEPOOL_ENV
+
+Rather than specifying the `--env` argument on every command, you may define the `TIDEPOOL_ENV` environment variable. All subsequent invocations of the tool will use the environment specified in the `TIDEPOOL_ENV` environment variable. For example:
+
+```
+$ export TIDEPOOL_ENV=prd
+$ tapi login
+```
+
+Note: The command line argument takes precedence over the environment variable.
+
+### Endpoint
+
+Alternatively, you may choose the specify the HTTP endpoint directly. For example:
+
+```
+tapi login --endpoint=https://api.tidepool.org
+```
+
+#### TIDEPOOL_ENDPOINT
+
+Rather than specifying the `--endpoint` argument on every command, you may define the `TIDEPOOL_ENDPOINT` environment variable. All subsequent invocations of the tool will use the endpoint specified in the `TIDEPOOL_ENDPOINT` environment variable. For example:
+
+```
+$ export TIDEPOOL_ENDPOINT=https://api.tidepool.org
+$ tapi login
+```
+
+Note: The command line argument takes precedence over the environment variable.
+
+## Who Are You?
+
+You must authenticate with the Tidepool API in order to use most features of the tool. Once authenticated, the Tidepool session will be stored for future invocations of the tool. (For the curious, the Tidepool session is persisted in `~/.tidepool/session`.)
+
+### User
+
+To authenticate as a user:
+
+```
+$ tapi login
+Email: your-email@domain.com
+Password: ********
+Logged in.
+```
+
+Alternatively:
+
+```
+$ tapi login --email your-email@domain.com
+Password: ********
+Logged in.
+```
+
+### Server
+
+To use the tool on a Tidepool server instance, authenticate with the server login:
+
+```
+$ tapi server-login
+```
+
+Note: The `SERVER_SECRET` environment variable must be set as appropriate.
+
+### Additional
+
+To logout and destroy the Tidepool session:
+
+```
+$ tapi logout
+Logged out.
+```
+
+To verify the Tidepool session with the Tidepool API:
+
+```
+$ tapi whoami
+{"isserver":false,"userid":"1234567890"}
+```
+
+## Which User?
+
+Many of the Tidepool APIs operate on a particular user, specified via id. Therefore, many of the tool commands include a `--user-id` argument.
+
+If you are authenticated as a user, then this argument is optional. If not specified, the user id associated with the current Tidepool session will be used.
+
+If you are authenticated on a Tidepool server instance, then this argument is required. A Tidepool server session is not associated with any specific user.
+
+## Features
+
+To keep the following examples as succinct as possible, it is assumed that the tool has been previously authenticated with a user account and the `--user-id` argument is not specified.
+
+### Dataset
+
+This tool can manage datasets.
+
+#### List
+
+To list all datasets for a user:
+
+```
+$ tapi dataset list
+(... output ...)
+```
+
+##### Filter
+
+You may provide limited filtering of the datasets.
+
+###### Deleted
+
+Datasets that have been previously deleted are not normally included in the list of datasets. If you wish to include deleted datasets in the list, then specify the `--deleted` argument. For example:
+
+```
+$ tapi dataset list --deleted
+(... output ...)
+```
+
+##### Pagination
+
+By default, the Tidepool API returns datasets in pages with a default and maximum pages size of 100. To effectively list all datasets you will need to specify the `--page` and `--size` arguments to interate through all of the available datasets.  For example:
+
+```
+$ tapi dataset list --size 50 --page 0
+(... first 50 datasets ...)
+$ tapi dataset list --size 50 --page 1
+(... second 50 datasets ...)
+```
+
+The `--size` argument can be from 1 to 100. The `--page` argument can be zero or more.
+
+The last page will either contain less than `size` number of datasets or will be empty.
+
+#### Delete
+
+To delete a specific dataset, determine its dataset id, also known as `uploadId`, via the list command above, and then invoke the delete dataset command. For example:
+
+```
+$ tapi dataset delete --dataset-id ff2346e5623914b1234565661f093459
+Dataset deleted.
+```
+
+## Help
+
+For general help with the tool:
+
+```
+$ tapi --help
+```
+
+For more detailed help with a specific command:
+
+```
+$ tapi <command> --help
+```
+
+Replace \<command\> with one of the top-level commands.
+
+For more detailed help with a specific sub-command:
+
+```
+$ tapi <command> <sub-command> --help
+```
+
+Replace \<command\> with one of the top-level commands and \<sub-command\> with a sub-command.
+
+For example:
+
+```
+$ tapi dataset list --help
+NAME:
+   tapi dataset list - list datasets
+
+USAGE:
+   tapi dataset list [command options] [arguments...]
+
+OPTIONS:
+   --user-id USERID     USERID of the user to list datasets
+   --deleted            include deleted datasets in the list
+   --page PAGE          pagination PAGE (default: 0)
+   --size SIZE          pagination SIZE (default: 0)
+   --endpoint ENDPOINT  Tidepool API ENDPOINT (eg. 'https://api.tidepool.org') [$TIDEPOOL_ENDPOINT]
+   --env ENVIRONMENT    Tidepool ENVIRONMENT (ie. 'prd', 'int', 'stg', 'dev', 'local') [$TIDEPOOL_ENV]
+   --proxy URL          proxy URL [$HTTP_PROXY]
+   --pretty, -p         pretty print JSON
+   --verbose, -v        include info output
+```

--- a/tools/tapi/api/api.go
+++ b/tools/tapi/api/api.go
@@ -1,0 +1,164 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+type (
+	API struct {
+		Name     string
+		Endpoint string
+		Writer   io.Writer
+		Verbose  bool
+		client   *http.Client
+	}
+
+	Session struct {
+		Token    string `json:"token"`
+		IsServer bool   `json:"isServer"`
+		UserID   string `json:"userId,omitempty"`
+	}
+)
+
+const (
+	ConfigDirectoryName = ".tidepool"
+	SessionFileName     = "session"
+)
+
+func NewAPI(name string, endpoint string, proxy string) (*API, error) {
+	if name == "" {
+		return nil, errors.New("Name is missing")
+	}
+	if endpoint == "" {
+		return nil, errors.New("End point is missing")
+	}
+
+	client := &http.Client{}
+	if proxy != "" {
+		proxyURL, err := url.Parse(proxy)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing proxy URL: %s", err.Error())
+		}
+
+		client.Transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	}
+
+	return &API{Name: name, Endpoint: endpoint, Writer: os.Stdout, Verbose: false, client: client}, nil
+}
+
+func (a *API) info(infos ...interface{}) {
+	if a.Verbose {
+		infos = append([]interface{}{"INFO:"}, infos...)
+		fmt.Fprintln(a.Writer, infos...)
+	}
+}
+
+func (a *API) fetchSessionUserID() (string, error) {
+	session, err := a.fetchSession()
+	if err != nil {
+		return "", err
+	}
+
+	userID := session.UserID
+	if userID == "" {
+		return "", errors.New("User id is missing")
+	}
+
+	return userID, nil
+}
+
+func (a *API) fetchSession() (*Session, error) {
+	sessionFile, err := a.sessionFile()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionBytes, err := ioutil.ReadFile(sessionFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.New("Session not found")
+		}
+		return nil, err
+	}
+
+	session := &Session{}
+	if err = json.Unmarshal(sessionBytes, session); err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
+func (a *API) storeSession(session *Session) error {
+	if session == nil {
+		return errors.New("Session is missing")
+	}
+
+	sessionBytes, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
+
+	sessionFile, err := a.sessionFile()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(sessionFile, sessionBytes, 0600)
+}
+
+func (a *API) destroySession() error {
+	sessionFile, err := a.sessionFile()
+	if err != nil {
+		return err
+	}
+
+	if err = os.Remove(sessionFile); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (a *API) sessionFile() (string, error) {
+	configDirectory, err := a.configDirectory()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(configDirectory, SessionFileName), nil
+}
+
+func (a *API) configDirectory() (string, error) {
+	homeDirectory, err := homedir.Expand("~")
+	if err != nil {
+		return "", err
+	}
+
+	configDirectory := filepath.Join(homeDirectory, ConfigDirectoryName)
+	if err = os.Mkdir(configDirectory, 0700); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+
+	return configDirectory, nil
+}

--- a/tools/tapi/api/auth.go
+++ b/tools/tapi/api/auth.go
@@ -1,0 +1,84 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type (
+	Token struct {
+		IsServer bool   `json:"isserver"`
+		UserID   string `json:"userid"`
+	}
+)
+
+func (a *API) ServerLogin() error {
+	return a.asEmpty(a.request("POST", a.joinPaths("auth", "serverlogin"),
+		requestFuncs{a.addServerSecret()},
+		responseFuncs{a.expectStatusCode(http.StatusOK), a.storeTidepoolSession(true)}))
+}
+
+func (a *API) Login(email string, password string) (*User, error) {
+	if email == "" {
+		return nil, errors.New("Email is missing")
+	}
+	if password == "" {
+		return nil, errors.New("Password is missing")
+	}
+
+	return a.asUser(a.request("POST", a.joinPaths("auth", "login"),
+		requestFuncs{a.addBasicAuthorization(email, password)},
+		responseFuncs{a.expectStatusCode(http.StatusOK), a.storeTidepoolSession(false)}))
+}
+
+func (a *API) Logout() error {
+	return a.asEmpty(a.request("POST", a.joinPaths("auth", "logout"),
+		requestFuncs{a.addSessionToken()},
+		responseFuncs{a.expectStatusCode(http.StatusOK), a.destroyTidepoolSession()}))
+}
+
+func (a *API) RefreshToken() (*Token, error) {
+	return a.asToken(a.request("GET", a.joinPaths("auth", "login"),
+		requestFuncs{a.addSessionToken()},
+		responseFuncs{a.expectStatusCode(http.StatusOK), a.updateTidepoolSession()}))
+}
+
+func (a *API) CheckToken(token string) (*Token, error) {
+	if token == "" {
+		return nil, errors.New("Token is missing")
+	}
+
+	return a.asToken(a.request("GET", a.joinPaths("auth", "token", token),
+		requestFuncs{a.addSessionToken()},
+		responseFuncs{a.expectStatusCode(http.StatusOK)}))
+}
+
+func (a *API) asToken(responseBody io.Reader, err error) (*Token, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	var token *Token
+	if len(responseString) > 0 {
+		token = &Token{}
+		if err = json.Unmarshal([]byte(responseString), &token); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON Token from response body: %s", err.Error())
+		}
+	}
+
+	return token, nil
+}

--- a/tools/tapi/api/common.go
+++ b/tools/tapi/api/common.go
@@ -1,0 +1,46 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+func firstStringNotNil(strs ...*string) *string {
+	for _, str := range strs {
+		if str != nil {
+			return str
+		}
+	}
+	return nil
+}
+
+func firstStringArrayNotNil(strs ...*[]string) *[]string {
+	for _, str := range strs {
+		if str != nil {
+			return str
+		}
+	}
+	return nil
+}
+
+func subtractStringArray(minuend []string, subtrahend []string) []string {
+	difference := []string{}
+	for _, m := range minuend {
+		var found bool
+		for _, s := range subtrahend {
+			if m == s {
+				found = true
+				break
+			}
+		}
+		if !found {
+			difference = append(difference, m)
+		}
+	}
+	return difference
+}

--- a/tools/tapi/api/dataset.go
+++ b/tools/tapi/api/dataset.go
@@ -1,0 +1,67 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+type (
+	Filter struct {
+		Deleted *bool
+	}
+
+	Pagination struct {
+		Page *int
+		Size *int
+	}
+)
+
+func (a *API) ListDatasets(userID string, filter *Filter, pagination *Pagination) (*ResponseArray, error) {
+	if userID == "" {
+		var err error
+		userID, err = a.fetchSessionUserID()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	queryMap := map[string]string{}
+	if filter != nil {
+		if filter.Deleted != nil {
+			queryMap["deleted"] = strconv.FormatBool(*filter.Deleted)
+		}
+	}
+	if pagination != nil {
+		if pagination.Page != nil {
+			queryMap["page"] = strconv.Itoa(*pagination.Page)
+		}
+		if pagination.Size != nil {
+			queryMap["size"] = strconv.Itoa(*pagination.Size)
+		}
+	}
+
+	return a.asResponseArray(a.request("GET", a.addQuery(a.joinPaths("dataservices", "v1", "users", userID, "datasets"), queryMap),
+		requestFuncs{a.addSessionToken()},
+		responseFuncs{a.expectStatusCode(http.StatusOK)}))
+}
+
+func (a *API) DeleteDataset(datasetID string) error {
+	if datasetID == "" {
+		return errors.New("Dataset id is missing")
+	}
+
+	return a.asEmpty(a.request("DELETE", a.joinPaths("dataservices", "v1", "datasets", datasetID),
+		requestFuncs{a.addSessionToken()},
+		responseFuncs{a.expectStatusCode(http.StatusOK)}))
+}

--- a/tools/tapi/api/request.go
+++ b/tools/tapi/api/request.go
@@ -1,0 +1,300 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	TidepoolServerName   = "x-tidepool-server-name"
+	TidepoolServerSecret = "x-tidepool-server-secret"
+	TidepoolSessionToken = "x-tidepool-session-token"
+)
+
+type (
+	requestFunc   func(request *http.Request) error
+	requestFuncs  []requestFunc
+	responseFunc  func(response *http.Response) error
+	responseFuncs []responseFunc
+)
+
+func (a *API) joinPaths(paths ...string) string {
+	join := ""
+	for _, path := range paths {
+		if path != "" {
+			join = fmt.Sprintf("%s/%s", strings.TrimRight(join, "/"), strings.TrimLeft(path, "/"))
+		}
+	}
+	return join
+}
+
+func (a *API) addQuery(path string, query map[string]string) string {
+	var separator string
+	if strings.Contains(path, "?") {
+		separator = "&"
+	} else {
+		separator = "?"
+	}
+	for key, value := range query {
+		path = fmt.Sprintf("%s%s%s=%s", path, separator, url.QueryEscape(key), url.QueryEscape(value))
+		separator = "&"
+	}
+	return path
+}
+
+func (a *API) request(method string, path string, requestCallbacks requestFuncs, responseCallbacks responseFuncs) (io.Reader, error) {
+	if method == "" {
+		return nil, errors.New("Method is missing")
+	}
+	if path == "" {
+		return nil, errors.New("Path is missing")
+	}
+
+	urlString := fmt.Sprintf("%s/%s", strings.TrimRight(a.Endpoint, "/"), strings.TrimLeft(path, "/"))
+
+	request, err := http.NewRequest(method, urlString, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating new request: %s", err.Error())
+	}
+
+	for _, requestCallback := range requestCallbacks {
+		if err = requestCallback(request); err != nil {
+			return nil, err
+		}
+	}
+
+	a.info("Request method:", request.Method)
+	a.info("Request url:", request.URL.String())
+
+	response, err := a.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("Error sending session request: %s", err.Error())
+	}
+
+	for _, responseCallback := range responseCallbacks {
+		if err = responseCallback(response); err != nil {
+			return nil, err
+		}
+	}
+
+	return response.Body, nil
+}
+
+func (a *API) addServerSecret() requestFunc {
+	return func(request *http.Request) error {
+		serverSecret := os.Getenv("SERVER_SECRET")
+		if serverSecret == "" {
+			return errors.New("Environment variable SERVER_SECRET not exported")
+		}
+
+		a.info("Server secret found.")
+
+		request.Header.Add(TidepoolServerName, a.Name)
+		request.Header.Add(TidepoolServerSecret, serverSecret)
+		return nil
+	}
+}
+
+func (a *API) addBasicAuthorization(username string, password string) requestFunc {
+	return func(request *http.Request) error {
+		request.SetBasicAuth(username, password)
+		return nil
+	}
+}
+
+func (a *API) addSessionToken() requestFunc {
+	return func(request *http.Request) error {
+		session, err := a.fetchSession()
+		if err != nil {
+			return err
+		}
+
+		a.info("Session token found:", session.Token)
+
+		request.Header.Add(TidepoolSessionToken, session.Token)
+		return nil
+	}
+}
+
+func (a *API) addObjectBody(requestBody interface{}) requestFunc {
+	return func(request *http.Request) error {
+		if requestBody == nil {
+			return errors.New("Body is missing")
+		}
+
+		bytes, err := json.Marshal(requestBody)
+		if err != nil {
+			return fmt.Errorf("Error encoding request body to JSON: %s", err.Error())
+		}
+
+		return a.addStringBody(string(bytes), "application/json")(request)
+	}
+}
+
+func (a *API) addStringBody(requestBody string, contentType string) requestFunc {
+	return func(request *http.Request) error {
+		if len(requestBody) != 0 {
+			a.info("Request body:", requestBody)
+		}
+
+		return a.addBytesBody([]byte(requestBody), contentType)(request)
+	}
+}
+
+func (a *API) addBufferBody(requestBody *bytes.Buffer, contentType string) requestFunc {
+	return func(request *http.Request) error {
+		if requestBody == nil {
+			return errors.New("Body is missing")
+		}
+
+		return a.addBytesBody(requestBody.Bytes(), contentType)(request)
+	}
+}
+
+func (a *API) addBytesBody(requestBody []byte, contentType string) requestFunc {
+	return func(request *http.Request) error {
+		if requestBody == nil {
+			return errors.New("Body is missing")
+		}
+
+		a.info("Request body length:", len(requestBody))
+
+		return a.addBody(bytes.NewReader(requestBody), contentType)(request)
+	}
+}
+
+func (a *API) addBody(requestBody io.Reader, contentType string) requestFunc {
+	return func(request *http.Request) error {
+		if requestBody == nil {
+			return errors.New("Body is missing")
+		}
+		if contentType == "" {
+			return errors.New("Content type is missing")
+		}
+		if request.Body != nil {
+			return errors.New("Request body already specified")
+		}
+		if request.ContentLength != 0 {
+			return errors.New("Request content length already specified")
+		}
+		if request.Header.Get("Content-Type") != "" {
+			return errors.New("Request Content-Type header already specified")
+		}
+
+		if readCloser, ok := requestBody.(io.ReadCloser); ok {
+			request.Body = readCloser
+		} else {
+			request.Body = ioutil.NopCloser(requestBody)
+		}
+
+		switch t := requestBody.(type) {
+		case *bytes.Buffer:
+			request.ContentLength = int64(t.Len())
+		case *bytes.Reader:
+			request.ContentLength = int64(t.Len())
+		case *strings.Reader:
+			request.ContentLength = int64(t.Len())
+		}
+
+		request.Header.Set("Content-Type", contentType)
+		return nil
+	}
+}
+
+func (a *API) expectStatusCode(statusCode int) responseFunc {
+	return func(response *http.Response) error {
+		a.info("Response status code:", response.StatusCode)
+		if response.StatusCode != statusCode {
+			responseString, _ := a.asString(response.Body, nil)
+			return fmt.Errorf("Unexpected response status code from server: [%d] %s", response.StatusCode, responseString)
+		}
+		return nil
+	}
+}
+
+func (a *API) storeTidepoolSession(isServer bool) responseFunc {
+	return func(response *http.Response) error {
+		token := response.Header.Get(TidepoolSessionToken)
+		if token == "" {
+			return errors.New("No session token included in response")
+		}
+
+		session := &Session{
+			Token:    token,
+			IsServer: isServer,
+		}
+
+		if !isServer {
+			bodyBytes, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				return err
+			}
+			response.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+
+			user, err := a.asUser(bytes.NewBuffer(bodyBytes), nil)
+			if err != nil {
+				return err
+			}
+			session.UserID = user.ID
+		}
+
+		if err := a.storeSession(session); err != nil {
+			return err
+		}
+
+		a.info("Session stored.")
+		return nil
+	}
+}
+
+func (a *API) updateTidepoolSession() responseFunc {
+	return func(response *http.Response) error {
+		token := response.Header.Get(TidepoolSessionToken)
+		if token == "" {
+			return errors.New("No session token included in response")
+		}
+
+		session, err := a.fetchSession()
+		if err != nil {
+			return err
+		}
+
+		session.Token = token
+
+		if err = a.storeSession(session); err != nil {
+			return err
+		}
+
+		a.info("Session updated.")
+		return nil
+	}
+}
+
+func (a *API) destroyTidepoolSession() responseFunc {
+	return func(response *http.Response) error {
+		if err := a.destroySession(); err != nil {
+			return err
+		}
+
+		a.info("Session destroyed.")
+		return nil
+	}
+}

--- a/tools/tapi/api/response.go
+++ b/tools/tapi/api/response.go
@@ -1,0 +1,192 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type ResponseObject struct {
+	Data   interface{} `json:"data,omitempty"`
+	Errors []*Error    `json:"errors,omitempty"`
+	Meta   *Meta       `json:"meta,omitempty"`
+}
+
+type ResponseArray struct {
+	Data   []interface{} `json:"data,omitempty"`
+	Errors []*Error      `json:"errors,omitempty"`
+	Meta   *Meta         `json:"meta,omitempty"`
+}
+
+type Error struct {
+	Code   string      `json:"code,omitempty"`
+	Title  string      `json:"title,omitempty"`
+	Detail string      `json:"detail,omitempty"`
+	Status int         `json:"status,string,omitempty"`
+	Source *Source     `json:"source,omitempty"`
+	Meta   interface{} `json:"meta,omitempty"`
+}
+
+type Source struct {
+	Parameter string `json:"parameter,omitempty"`
+	Pointer   string `json:"pointer,omitempty"`
+}
+
+type Meta struct {
+	Trace *Trace `json:"trace,omitempty"`
+}
+
+type Trace struct {
+	Request string `json:"request,omitempty"`
+	Session string `json:"session,omitempty"`
+}
+
+func (a *API) asEmpty(responseBody io.Reader, err error) error {
+	responseBuffer, err := a.asBuffer(responseBody, err)
+	if err != nil {
+		return err
+	}
+
+	if responseBuffer.Len() != 0 {
+		a.info("Ignoring non-empty response body.")
+	}
+
+	return nil
+}
+
+func (a *API) asBuffer(responseBody io.Reader, err error) (*bytes.Buffer, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	responseBuffer := &bytes.Buffer{}
+	if responseBody != nil {
+		if _, err = responseBuffer.ReadFrom(responseBody); err != nil {
+			return nil, fmt.Errorf("Error reading response body: %s", err.Error())
+		}
+	}
+
+	if length := responseBuffer.Len(); length != 0 {
+		a.info("Response body length:", length)
+	} else {
+		a.info("Response body empty.")
+	}
+
+	return responseBuffer, nil
+}
+
+func (a *API) asBytes(responseBody io.Reader, err error) ([]byte, error) {
+	responseBuffer, err := a.asBuffer(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBuffer.Bytes(), nil
+}
+
+func (a *API) asString(responseBody io.Reader, err error) (string, error) {
+	responseBuffer, err := a.asBuffer(responseBody, err)
+	if err != nil {
+		return "", err
+	}
+
+	responseString := responseBuffer.String()
+	if len(responseString) > 0 {
+		a.info("Response body:", responseString)
+	}
+
+	return responseString, nil
+}
+
+func (a *API) asObject(responseBody io.Reader, err error) (interface{}, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseObject interface{}
+	if len(responseString) > 0 {
+		if err = json.Unmarshal([]byte(responseString), &responseObject); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON object from response body: %s", err.Error())
+		}
+	}
+
+	return responseObject, nil
+}
+
+func (a *API) asStringMap(responseBody io.Reader, err error) (map[string]interface{}, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	responseStringMap := map[string]interface{}{}
+	if len(responseString) > 0 {
+		if err = json.Unmarshal([]byte(responseString), &responseStringMap); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON string map from response body: %s", err.Error())
+		}
+	}
+
+	return responseStringMap, nil
+}
+
+func (a *API) asArray(responseBody io.Reader, err error) ([]interface{}, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	responseArray := []interface{}{}
+	if len(responseString) > 0 {
+		if err = json.Unmarshal([]byte(responseString), &responseArray); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON array from response body: %s", err.Error())
+		}
+	}
+
+	return responseArray, nil
+}
+
+func (a *API) asResponseObject(responseBody io.Reader, err error) (*ResponseObject, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseObject *ResponseObject
+	if len(responseString) > 0 {
+		responseObject = &ResponseObject{}
+		if err = json.Unmarshal([]byte(responseString), responseObject); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON response array from response body: %s", err.Error())
+		}
+	}
+
+	return responseObject, nil
+}
+
+func (a *API) asResponseArray(responseBody io.Reader, err error) (*ResponseArray, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseArray *ResponseArray
+	if len(responseString) > 0 {
+		responseArray = &ResponseArray{}
+		if err = json.Unmarshal([]byte(responseString), responseArray); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON response array from response body: %s", err.Error())
+		}
+	}
+
+	return responseArray, nil
+}

--- a/tools/tapi/api/user.go
+++ b/tools/tapi/api/user.go
@@ -1,0 +1,46 @@
+package api
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type (
+	User struct {
+		ID             string   `json:"userid,omitempty"`
+		Username       string   `json:"username,omitempty"`
+		Emails         []string `json:"emails,omitempty"`
+		Roles          []string `json:"roles,omitempty"`
+		TermsAccepted  string   `json:"termsAccepted,omitempty"`
+		EmailVerified  bool     `json:"emailVerified,omitempty"`
+		PasswordExists bool     `json:"passwordExists,omitempty"`
+	}
+)
+
+func (a *API) asUser(responseBody io.Reader, err error) (*User, error) {
+	responseString, err := a.asString(responseBody, err)
+	if err != nil {
+		return nil, err
+	}
+
+	var responseUser *User
+	if len(responseString) > 0 {
+		responseUser = &User{}
+		if err = json.Unmarshal([]byte(responseString), responseUser); err != nil {
+			return nil, fmt.Errorf("Error decoding JSON User from response body: %s", err.Error())
+		}
+	}
+
+	return responseUser, nil
+}

--- a/tools/tapi/cmd/auth.go
+++ b/tools/tapi/cmd/auth.go
@@ -1,0 +1,130 @@
+package cmd
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import "github.com/urfave/cli"
+
+const (
+	TokenFlag = "token"
+)
+
+func AuthCommands() cli.Commands {
+	return cli.Commands{
+		{
+			Name:   "server-login",
+			Usage:  "authenticate and remember the new server session",
+			Flags:  CommandFlags(),
+			Before: ensureNoArgs,
+			Action: authServerLogin,
+		},
+		{
+			Name:  "login",
+			Usage: "authenticate and remember the new user session",
+			Flags: CommandFlags(
+				cli.StringFlag{
+					Name:  EmailFlag,
+					Usage: "`EMAIL` for authentication",
+				},
+				cli.StringFlag{
+					Name:  PasswordFlag,
+					Usage: "`PASSWORD` for authentication",
+				},
+			),
+			Before: ensureNoArgs,
+			Action: authLogin,
+		},
+		{
+			Name:   "logout",
+			Usage:  "logout and forget the current session",
+			Flags:  CommandFlags(),
+			Before: ensureNoArgs,
+			Action: authLogout,
+		},
+		{
+			Name:   "whoami",
+			Usage:  "display the current session",
+			Flags:  CommandFlags(),
+			Before: ensureNoArgs,
+			Action: authWhoami,
+		},
+		{
+			Name:  "check-session",
+			Usage: "check a session for validity",
+			Flags: CommandFlags(
+				cli.StringFlag{
+					Name:  TokenFlag,
+					Usage: "`TOKEN` to check",
+				},
+			),
+			Before: ensureNoArgs,
+			Action: authCheckSession,
+		},
+	}
+}
+
+func authServerLogin(c *cli.Context) error {
+	if err := API(c).ServerLogin(); err != nil {
+		return err
+	}
+
+	return reportMessage(c, "Server session created.")
+}
+
+func authLogin(c *cli.Context) error {
+	email := c.String(EmailFlag)
+	if email == "" {
+		var err error
+		if email, err = readFromConsole("Email: "); err != nil {
+			return err
+		}
+	}
+
+	password := c.String(PasswordFlag)
+	if password == "" {
+		var err error
+		if password, err = readFromConsoleNoEcho("Password: "); err != nil {
+			return err
+		}
+	}
+
+	_, err := API(c).Login(email, password)
+	if err != nil {
+		return err
+	}
+
+	return reportMessage(c, "Logged in.")
+}
+
+func authLogout(c *cli.Context) error {
+	if err := API(c).Logout(); err != nil {
+		return err
+	}
+
+	return reportMessage(c, "Logged out.")
+}
+
+func authWhoami(c *cli.Context) error {
+	token, err := API(c).RefreshToken()
+	if err != nil {
+		return err
+	}
+
+	return reportMessageWithJSON(c, token)
+}
+
+func authCheckSession(c *cli.Context) error {
+	checked, err := API(c).CheckToken(c.String(TokenFlag))
+	if err != nil {
+		return err
+	}
+
+	return reportMessageWithJSON(c, checked)
+}

--- a/tools/tapi/cmd/cmd.go
+++ b/tools/tapi/cmd/cmd.go
@@ -1,0 +1,89 @@
+package cmd
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli"
+
+	"github.com/tidepool-org/platform/tools/tapi/api"
+	"github.com/tidepool-org/platform/version"
+)
+
+var EnvironmentEndpointMap = map[string]string{
+	"prd":   "https://api.tidepool.org",
+	"int":   "https://int-api.tidepool.org",
+	"stg":   "https://stg-api.tidepool.org",
+	"dev":   "https://dev-api.tidepool.org",
+	"local": "http://localhost:8009",
+}
+
+var _API *api.API
+
+func InitializeApplication() (*cli.App, error) {
+	versionReporter, err := version.NewDefaultReporter()
+	if err != nil {
+		return nil, err
+	}
+
+	application := cli.NewApp()
+	application.Usage = "Command-line interface to interact with the Tidepool API"
+	application.Version = versionReporter.Long()
+	application.Authors = []cli.Author{{"Darin Krauss", "darin@tidepool.org"}}
+	application.Copyright = "Copyright \u00A9 2016, Tidepool Project"
+	application.HideVersion = true
+	application.Commands = wrapCommands(mergeCommands(
+		AuthCommands(),
+		DatasetCommands(),
+		VersionCommands(versionReporter),
+	))
+	return application, nil
+}
+
+func initializeAPI(c *cli.Context) (*api.API, error) {
+	name := fmt.Sprintf("%s-%s", c.App.Name, c.App.Version)
+	endpoint := c.String(EndpointFlag)
+	if endpoint == "" {
+		environment := c.String(EnvFlag)
+		if environment == "" {
+			return nil, errors.New("Endpoint or environment must be specified")
+		}
+
+		var ok bool
+		if endpoint, ok = EnvironmentEndpointMap[strings.ToLower(environment)]; !ok {
+			return nil, fmt.Errorf("Unknown environment: %s", environment)
+		}
+	}
+	proxy := c.String(ProxyFlag)
+
+	API, err := api.NewAPI(name, endpoint, proxy)
+	if err != nil {
+		return nil, err
+	}
+	API.Verbose = c.Bool(VerboseFlag)
+	API.Writer = c.App.Writer
+
+	return API, nil
+}
+
+func API(c *cli.Context) *api.API {
+	if _API == nil {
+		API, err := initializeAPI(c)
+		if err != nil {
+			reportErrorAndDie(c, err)
+		}
+		_API = API
+	}
+	return _API
+}

--- a/tools/tapi/cmd/common.go
+++ b/tools/tapi/cmd/common.go
@@ -1,0 +1,155 @@
+package cmd
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+const (
+	EndpointFlag = "endpoint"
+	EnvFlag      = "env"
+	PrettyFlag   = "pretty"
+	ProxyFlag    = "proxy"
+	VerboseFlag  = "verbose"
+)
+
+func CommandFlags(flags ...cli.Flag) []cli.Flag {
+	return append(flags,
+		cli.StringFlag{
+			Name:   EndpointFlag,
+			Usage:  "Tidepool API `ENDPOINT` (eg. 'https://api.tidepool.org')",
+			EnvVar: "TIDEPOOL_ENDPOINT",
+		},
+		cli.StringFlag{
+			Name:   EnvFlag,
+			Usage:  "Tidepool `ENVIRONMENT` (ie. 'prd', 'int', 'stg', 'dev', 'local')",
+			EnvVar: "TIDEPOOL_ENV",
+		},
+		cli.StringFlag{
+			Name:   ProxyFlag,
+			Value:  "",
+			Usage:  "proxy `URL`",
+			EnvVar: "HTTP_PROXY",
+		},
+		cli.BoolFlag{
+			Name:  fmt.Sprintf("%s,%s", PrettyFlag, "p"),
+			Usage: "pretty print JSON",
+		},
+		cli.BoolFlag{
+			Name:  fmt.Sprintf("%s,%s", VerboseFlag, "v"),
+			Usage: "include info output",
+		},
+	)
+}
+
+func mergeCommands(left cli.Commands, rights ...cli.Commands) cli.Commands {
+	merged := cli.Commands{}
+	merged = append(merged, left...)
+	for _, right := range rights {
+		merged = append(merged, right...)
+	}
+	return merged
+}
+
+func wrapCommands(commands cli.Commands) cli.Commands {
+	wrapped := cli.Commands{}
+	for _, command := range commands {
+		wrapped = append(wrapped, wrapCommand(command))
+	}
+	return wrapped
+}
+
+func wrapCommand(command cli.Command) cli.Command {
+	command.Before = wrapCommandFunc(command.Before)
+	command.After = wrapCommandFunc(command.After)
+	if actionFunc, actionOK := command.Action.(cli.ActionFunc); actionOK {
+		command.Action = wrapCommandFunc(actionFunc)
+	} else if commandFunc, commandOK := command.Action.(func(*cli.Context) error); commandOK {
+		command.Action = wrapCommandFunc(commandFunc)
+	}
+	command.Subcommands = wrapCommands(command.Subcommands)
+	return command
+}
+
+func wrapCommandFunc(commandFunc func(c *cli.Context) error) func(c *cli.Context) error {
+	if commandFunc == nil {
+		return nil
+	}
+	return func(c *cli.Context) error {
+		if err := commandFunc(c); err != nil {
+			reportErrorAndDie(c, err)
+		}
+		return nil
+	}
+}
+
+func reportErrorAndDie(c *cli.Context, err error) {
+	fmt.Fprintf(c.App.Writer, "ERROR: %s\n", err.Error())
+	os.Exit(1)
+}
+
+func reportMessage(c *cli.Context, messages ...interface{}) error {
+	fmt.Fprintln(c.App.Writer, messages...)
+	return nil
+}
+
+func reportMessageWithJSON(c *cli.Context, data interface{}) error {
+	var messageBytes []byte
+	var err error
+
+	if c.Bool(PrettyFlag) {
+		messageBytes, err = json.MarshalIndent(data, "", "    ")
+	} else {
+		messageBytes, err = json.Marshal(data)
+	}
+	if err != nil {
+		return err
+	}
+
+	return reportMessage(c, string(messageBytes))
+}
+
+func ensureNoArgs(c *cli.Context) error {
+	if c.Args().Present() {
+		return fmt.Errorf("Unexpected arguments: %s", strings.Join(c.Args(), " "))
+	}
+	return nil
+}
+
+func readFromConsole(prompt string) (string, error) {
+	fmt.Print(prompt)
+	result, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		fmt.Println()
+		return "", err
+	}
+	return strings.TrimRight(result, "\r\n"), nil
+}
+
+func readFromConsoleNoEcho(prompt string) (string, error) {
+	fmt.Print(prompt)
+	bytes, err := terminal.ReadPassword(int(syscall.Stdin))
+	fmt.Println()
+	if err != nil {
+		return "", err
+	}
+	result := string(bytes)
+	return result, nil
+}

--- a/tools/tapi/cmd/dataset.go
+++ b/tools/tapi/cmd/dataset.go
@@ -1,0 +1,119 @@
+package cmd
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"github.com/urfave/cli"
+
+	"github.com/tidepool-org/platform/tools/tapi/api"
+)
+
+const (
+	DatasetIDFlag = "dataset-id"
+	DeletedFlag   = "deleted"
+	PageFlag      = "page"
+	SizeFlag      = "size"
+)
+
+func DatasetCommands() cli.Commands {
+	return cli.Commands{
+		{
+			Name:  "dataset",
+			Usage: "dataset management",
+			Subcommands: []cli.Command{
+				{
+					Name:  "list",
+					Usage: "list datasets",
+					Flags: CommandFlags(
+						cli.StringFlag{
+							Name:  UserIDFlag,
+							Usage: "`USERID` of the user to list datasets",
+						},
+						cli.BoolFlag{
+							Name:  DeletedFlag,
+							Usage: "include deleted datasets in the list",
+						},
+						cli.IntFlag{
+							Name:  PageFlag,
+							Usage: "pagination `PAGE`",
+						},
+						cli.IntFlag{
+							Name:  SizeFlag,
+							Usage: "pagination `SIZE`",
+						},
+					),
+					Before: ensureNoArgs,
+					Action: datasetList,
+				},
+				{
+					Name:  "delete",
+					Usage: "delete dataset",
+					Flags: CommandFlags(
+						cli.StringFlag{
+							Name:  DatasetIDFlag,
+							Usage: "`DATASETID` of the dataset to delete",
+						},
+					),
+					Before: ensureNoArgs,
+					Action: datasetDelete,
+				},
+			},
+		},
+	}
+}
+
+func datasetList(c *cli.Context) error {
+	var filter *api.Filter
+	var pagination *api.Pagination
+
+	if c.IsSet(DeletedFlag) {
+		if filter == nil {
+			filter = &api.Filter{}
+		}
+		deleted := c.Bool(DeletedFlag)
+		filter.Deleted = &deleted
+	}
+	if c.IsSet(PageFlag) {
+		if pagination == nil {
+			pagination = &api.Pagination{}
+		}
+		page := c.Int(PageFlag)
+		pagination.Page = &page
+	}
+	if c.IsSet(SizeFlag) {
+		if pagination == nil {
+			pagination = &api.Pagination{}
+		}
+		size := c.Int(SizeFlag)
+		pagination.Size = &size
+	}
+
+	responseArray, err := API(c).ListDatasets(c.String(UserIDFlag), filter, pagination)
+	if err != nil {
+		return err
+	}
+
+	for _, dataset := range responseArray.Data {
+		if err = reportMessageWithJSON(c, dataset); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func datasetDelete(c *cli.Context) error {
+	if err := API(c).DeleteDataset(c.String(DatasetIDFlag)); err != nil {
+		return err
+	}
+
+	return reportMessage(c, "Dataset deleted.")
+}

--- a/tools/tapi/cmd/user.go
+++ b/tools/tapi/cmd/user.go
@@ -1,0 +1,17 @@
+package cmd
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+const (
+	UserIDFlag   = "user-id"
+	EmailFlag    = "email"
+	PasswordFlag = "password"
+)

--- a/tools/tapi/cmd/version.go
+++ b/tools/tapi/cmd/version.go
@@ -1,0 +1,89 @@
+package cmd
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"github.com/urfave/cli"
+
+	"github.com/tidepool-org/platform/version"
+)
+
+func VersionCommands(versionReporter version.Reporter) cli.Commands {
+	return cli.Commands{
+		{
+			Name:   "version",
+			Usage:  "print the version",
+			Action: versionLong(versionReporter),
+			Subcommands: []cli.Command{
+				{
+					Name:   "base",
+					Usage:  "print the base version",
+					Before: ensureNoArgs,
+					Action: versionBase(versionReporter),
+				},
+				{
+					Name:   "short-commit",
+					Usage:  "print the short git commit",
+					Before: ensureNoArgs,
+					Action: versionShortCommit(versionReporter),
+				},
+				{
+					Name:   "full-commit",
+					Usage:  "print the full git commit",
+					Before: ensureNoArgs,
+					Action: versionFullCommit(versionReporter),
+				},
+				{
+					Name:   "short",
+					Usage:  "print the short version, including the short git commit",
+					Before: ensureNoArgs,
+					Action: versionShort(versionReporter),
+				},
+				{
+					Name:   "long",
+					Usage:  "print the long version, including the full git commit",
+					Before: ensureNoArgs,
+					Action: versionLong(versionReporter),
+				},
+			},
+		},
+	}
+}
+
+func versionBase(versionReporter version.Reporter) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		return reportMessage(c, versionReporter.Base())
+	}
+}
+
+func versionShortCommit(versionReporter version.Reporter) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		return reportMessage(c, versionReporter.ShortCommit())
+	}
+}
+
+func versionFullCommit(versionReporter version.Reporter) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		return reportMessage(c, versionReporter.FullCommit())
+	}
+}
+
+func versionShort(versionReporter version.Reporter) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		return reportMessage(c, versionReporter.Short())
+	}
+}
+
+func versionLong(versionReporter version.Reporter) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		return reportMessage(c, versionReporter.Long())
+	}
+}

--- a/tools/tapi/tapi.go
+++ b/tools/tapi/tapi.go
@@ -1,0 +1,31 @@
+package main
+
+/* CHECKLIST
+ * [ ] Uses interfaces as appropriate
+ * [ ] Private package variables use underscore prefix
+ * [ ] All parameters validated
+ * [ ] All errors handled
+ * [ ] Reviewed for concurrency safety
+ * [ ] Code complete
+ * [ ] Full test coverage
+ */
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tidepool-org/platform/tools/tapi/cmd"
+)
+
+func main() {
+	application, err := cmd.InitializeApplication()
+	if err != nil {
+		fmt.Println("ERROR:", err)
+		os.Exit(1)
+	}
+
+	if err = application.Run(os.Args); err != nil {
+		fmt.Println("ERROR:", err)
+		os.Exit(1)
+	}
+}

--- a/vendor/github.com/mitchellh/go-homedir/LICENSE
+++ b/vendor/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-homedir/README.md
+++ b/vendor/github.com/mitchellh/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/vendor/github.com/mitchellh/go-homedir/homedir.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,137 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try getent
+	var stdout bytes.Buffer
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		// If "getent" is missing, ignore it
+		if err == exec.ErrNotFound {
+			return "", err
+		}
+	} else {
+		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := strings.SplitN(passwd, ":", 7)
+			if len(passwdParts) > 5 {
+				return passwdParts[5], nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/vendor/golang.org/x/crypto/LICENSE
+++ b/vendor/golang.org/x/crypto/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/crypto/PATENTS
+++ b/vendor/golang.org/x/crypto/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/crypto/ssh/terminal/terminal.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/terminal.go
@@ -1,0 +1,892 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"unicode/utf8"
+)
+
+// EscapeCodes contains escape sequences that can be written to the terminal in
+// order to achieve different styles of text.
+type EscapeCodes struct {
+	// Foreground colors
+	Black, Red, Green, Yellow, Blue, Magenta, Cyan, White []byte
+
+	// Reset all attributes
+	Reset []byte
+}
+
+var vt100EscapeCodes = EscapeCodes{
+	Black:   []byte{keyEscape, '[', '3', '0', 'm'},
+	Red:     []byte{keyEscape, '[', '3', '1', 'm'},
+	Green:   []byte{keyEscape, '[', '3', '2', 'm'},
+	Yellow:  []byte{keyEscape, '[', '3', '3', 'm'},
+	Blue:    []byte{keyEscape, '[', '3', '4', 'm'},
+	Magenta: []byte{keyEscape, '[', '3', '5', 'm'},
+	Cyan:    []byte{keyEscape, '[', '3', '6', 'm'},
+	White:   []byte{keyEscape, '[', '3', '7', 'm'},
+
+	Reset: []byte{keyEscape, '[', '0', 'm'},
+}
+
+// Terminal contains the state for running a VT100 terminal that is capable of
+// reading lines of input.
+type Terminal struct {
+	// AutoCompleteCallback, if non-null, is called for each keypress with
+	// the full input line and the current position of the cursor (in
+	// bytes, as an index into |line|). If it returns ok=false, the key
+	// press is processed normally. Otherwise it returns a replacement line
+	// and the new cursor position.
+	AutoCompleteCallback func(line string, pos int, key rune) (newLine string, newPos int, ok bool)
+
+	// Escape contains a pointer to the escape codes for this terminal.
+	// It's always a valid pointer, although the escape codes themselves
+	// may be empty if the terminal doesn't support them.
+	Escape *EscapeCodes
+
+	// lock protects the terminal and the state in this object from
+	// concurrent processing of a key press and a Write() call.
+	lock sync.Mutex
+
+	c      io.ReadWriter
+	prompt []rune
+
+	// line is the current line being entered.
+	line []rune
+	// pos is the logical position of the cursor in line
+	pos int
+	// echo is true if local echo is enabled
+	echo bool
+	// pasteActive is true iff there is a bracketed paste operation in
+	// progress.
+	pasteActive bool
+
+	// cursorX contains the current X value of the cursor where the left
+	// edge is 0. cursorY contains the row number where the first row of
+	// the current line is 0.
+	cursorX, cursorY int
+	// maxLine is the greatest value of cursorY so far.
+	maxLine int
+
+	termWidth, termHeight int
+
+	// outBuf contains the terminal data to be sent.
+	outBuf []byte
+	// remainder contains the remainder of any partial key sequences after
+	// a read. It aliases into inBuf.
+	remainder []byte
+	inBuf     [256]byte
+
+	// history contains previously entered commands so that they can be
+	// accessed with the up and down keys.
+	history stRingBuffer
+	// historyIndex stores the currently accessed history entry, where zero
+	// means the immediately previous entry.
+	historyIndex int
+	// When navigating up and down the history it's possible to return to
+	// the incomplete, initial line. That value is stored in
+	// historyPending.
+	historyPending string
+}
+
+// NewTerminal runs a VT100 terminal on the given ReadWriter. If the ReadWriter is
+// a local terminal, that terminal must first have been put into raw mode.
+// prompt is a string that is written at the start of each input line (i.e.
+// "> ").
+func NewTerminal(c io.ReadWriter, prompt string) *Terminal {
+	return &Terminal{
+		Escape:       &vt100EscapeCodes,
+		c:            c,
+		prompt:       []rune(prompt),
+		termWidth:    80,
+		termHeight:   24,
+		echo:         true,
+		historyIndex: -1,
+	}
+}
+
+const (
+	keyCtrlD     = 4
+	keyCtrlU     = 21
+	keyEnter     = '\r'
+	keyEscape    = 27
+	keyBackspace = 127
+	keyUnknown   = 0xd800 /* UTF-16 surrogate area */ + iota
+	keyUp
+	keyDown
+	keyLeft
+	keyRight
+	keyAltLeft
+	keyAltRight
+	keyHome
+	keyEnd
+	keyDeleteWord
+	keyDeleteLine
+	keyClearScreen
+	keyPasteStart
+	keyPasteEnd
+)
+
+var pasteStart = []byte{keyEscape, '[', '2', '0', '0', '~'}
+var pasteEnd = []byte{keyEscape, '[', '2', '0', '1', '~'}
+
+// bytesToKey tries to parse a key sequence from b. If successful, it returns
+// the key and the remainder of the input. Otherwise it returns utf8.RuneError.
+func bytesToKey(b []byte, pasteActive bool) (rune, []byte) {
+	if len(b) == 0 {
+		return utf8.RuneError, nil
+	}
+
+	if !pasteActive {
+		switch b[0] {
+		case 1: // ^A
+			return keyHome, b[1:]
+		case 5: // ^E
+			return keyEnd, b[1:]
+		case 8: // ^H
+			return keyBackspace, b[1:]
+		case 11: // ^K
+			return keyDeleteLine, b[1:]
+		case 12: // ^L
+			return keyClearScreen, b[1:]
+		case 23: // ^W
+			return keyDeleteWord, b[1:]
+		}
+	}
+
+	if b[0] != keyEscape {
+		if !utf8.FullRune(b) {
+			return utf8.RuneError, b
+		}
+		r, l := utf8.DecodeRune(b)
+		return r, b[l:]
+	}
+
+	if !pasteActive && len(b) >= 3 && b[0] == keyEscape && b[1] == '[' {
+		switch b[2] {
+		case 'A':
+			return keyUp, b[3:]
+		case 'B':
+			return keyDown, b[3:]
+		case 'C':
+			return keyRight, b[3:]
+		case 'D':
+			return keyLeft, b[3:]
+		case 'H':
+			return keyHome, b[3:]
+		case 'F':
+			return keyEnd, b[3:]
+		}
+	}
+
+	if !pasteActive && len(b) >= 6 && b[0] == keyEscape && b[1] == '[' && b[2] == '1' && b[3] == ';' && b[4] == '3' {
+		switch b[5] {
+		case 'C':
+			return keyAltRight, b[6:]
+		case 'D':
+			return keyAltLeft, b[6:]
+		}
+	}
+
+	if !pasteActive && len(b) >= 6 && bytes.Equal(b[:6], pasteStart) {
+		return keyPasteStart, b[6:]
+	}
+
+	if pasteActive && len(b) >= 6 && bytes.Equal(b[:6], pasteEnd) {
+		return keyPasteEnd, b[6:]
+	}
+
+	// If we get here then we have a key that we don't recognise, or a
+	// partial sequence. It's not clear how one should find the end of a
+	// sequence without knowing them all, but it seems that [a-zA-Z~] only
+	// appears at the end of a sequence.
+	for i, c := range b[0:] {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '~' {
+			return keyUnknown, b[i+1:]
+		}
+	}
+
+	return utf8.RuneError, b
+}
+
+// queue appends data to the end of t.outBuf
+func (t *Terminal) queue(data []rune) {
+	t.outBuf = append(t.outBuf, []byte(string(data))...)
+}
+
+var eraseUnderCursor = []rune{' ', keyEscape, '[', 'D'}
+var space = []rune{' '}
+
+func isPrintable(key rune) bool {
+	isInSurrogateArea := key >= 0xd800 && key <= 0xdbff
+	return key >= 32 && !isInSurrogateArea
+}
+
+// moveCursorToPos appends data to t.outBuf which will move the cursor to the
+// given, logical position in the text.
+func (t *Terminal) moveCursorToPos(pos int) {
+	if !t.echo {
+		return
+	}
+
+	x := visualLength(t.prompt) + pos
+	y := x / t.termWidth
+	x = x % t.termWidth
+
+	up := 0
+	if y < t.cursorY {
+		up = t.cursorY - y
+	}
+
+	down := 0
+	if y > t.cursorY {
+		down = y - t.cursorY
+	}
+
+	left := 0
+	if x < t.cursorX {
+		left = t.cursorX - x
+	}
+
+	right := 0
+	if x > t.cursorX {
+		right = x - t.cursorX
+	}
+
+	t.cursorX = x
+	t.cursorY = y
+	t.move(up, down, left, right)
+}
+
+func (t *Terminal) move(up, down, left, right int) {
+	movement := make([]rune, 3*(up+down+left+right))
+	m := movement
+	for i := 0; i < up; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'A'
+		m = m[3:]
+	}
+	for i := 0; i < down; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'B'
+		m = m[3:]
+	}
+	for i := 0; i < left; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'D'
+		m = m[3:]
+	}
+	for i := 0; i < right; i++ {
+		m[0] = keyEscape
+		m[1] = '['
+		m[2] = 'C'
+		m = m[3:]
+	}
+
+	t.queue(movement)
+}
+
+func (t *Terminal) clearLineToRight() {
+	op := []rune{keyEscape, '[', 'K'}
+	t.queue(op)
+}
+
+const maxLineLength = 4096
+
+func (t *Terminal) setLine(newLine []rune, newPos int) {
+	if t.echo {
+		t.moveCursorToPos(0)
+		t.writeLine(newLine)
+		for i := len(newLine); i < len(t.line); i++ {
+			t.writeLine(space)
+		}
+		t.moveCursorToPos(newPos)
+	}
+	t.line = newLine
+	t.pos = newPos
+}
+
+func (t *Terminal) advanceCursor(places int) {
+	t.cursorX += places
+	t.cursorY += t.cursorX / t.termWidth
+	if t.cursorY > t.maxLine {
+		t.maxLine = t.cursorY
+	}
+	t.cursorX = t.cursorX % t.termWidth
+
+	if places > 0 && t.cursorX == 0 {
+		// Normally terminals will advance the current position
+		// when writing a character. But that doesn't happen
+		// for the last character in a line. However, when
+		// writing a character (except a new line) that causes
+		// a line wrap, the position will be advanced two
+		// places.
+		//
+		// So, if we are stopping at the end of a line, we
+		// need to write a newline so that our cursor can be
+		// advanced to the next line.
+		t.outBuf = append(t.outBuf, '\n')
+	}
+}
+
+func (t *Terminal) eraseNPreviousChars(n int) {
+	if n == 0 {
+		return
+	}
+
+	if t.pos < n {
+		n = t.pos
+	}
+	t.pos -= n
+	t.moveCursorToPos(t.pos)
+
+	copy(t.line[t.pos:], t.line[n+t.pos:])
+	t.line = t.line[:len(t.line)-n]
+	if t.echo {
+		t.writeLine(t.line[t.pos:])
+		for i := 0; i < n; i++ {
+			t.queue(space)
+		}
+		t.advanceCursor(n)
+		t.moveCursorToPos(t.pos)
+	}
+}
+
+// countToLeftWord returns then number of characters from the cursor to the
+// start of the previous word.
+func (t *Terminal) countToLeftWord() int {
+	if t.pos == 0 {
+		return 0
+	}
+
+	pos := t.pos - 1
+	for pos > 0 {
+		if t.line[pos] != ' ' {
+			break
+		}
+		pos--
+	}
+	for pos > 0 {
+		if t.line[pos] == ' ' {
+			pos++
+			break
+		}
+		pos--
+	}
+
+	return t.pos - pos
+}
+
+// countToRightWord returns then number of characters from the cursor to the
+// start of the next word.
+func (t *Terminal) countToRightWord() int {
+	pos := t.pos
+	for pos < len(t.line) {
+		if t.line[pos] == ' ' {
+			break
+		}
+		pos++
+	}
+	for pos < len(t.line) {
+		if t.line[pos] != ' ' {
+			break
+		}
+		pos++
+	}
+	return pos - t.pos
+}
+
+// visualLength returns the number of visible glyphs in s.
+func visualLength(runes []rune) int {
+	inEscapeSeq := false
+	length := 0
+
+	for _, r := range runes {
+		switch {
+		case inEscapeSeq:
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscapeSeq = false
+			}
+		case r == '\x1b':
+			inEscapeSeq = true
+		default:
+			length++
+		}
+	}
+
+	return length
+}
+
+// handleKey processes the given key and, optionally, returns a line of text
+// that the user has entered.
+func (t *Terminal) handleKey(key rune) (line string, ok bool) {
+	if t.pasteActive && key != keyEnter {
+		t.addKeyToLine(key)
+		return
+	}
+
+	switch key {
+	case keyBackspace:
+		if t.pos == 0 {
+			return
+		}
+		t.eraseNPreviousChars(1)
+	case keyAltLeft:
+		// move left by a word.
+		t.pos -= t.countToLeftWord()
+		t.moveCursorToPos(t.pos)
+	case keyAltRight:
+		// move right by a word.
+		t.pos += t.countToRightWord()
+		t.moveCursorToPos(t.pos)
+	case keyLeft:
+		if t.pos == 0 {
+			return
+		}
+		t.pos--
+		t.moveCursorToPos(t.pos)
+	case keyRight:
+		if t.pos == len(t.line) {
+			return
+		}
+		t.pos++
+		t.moveCursorToPos(t.pos)
+	case keyHome:
+		if t.pos == 0 {
+			return
+		}
+		t.pos = 0
+		t.moveCursorToPos(t.pos)
+	case keyEnd:
+		if t.pos == len(t.line) {
+			return
+		}
+		t.pos = len(t.line)
+		t.moveCursorToPos(t.pos)
+	case keyUp:
+		entry, ok := t.history.NthPreviousEntry(t.historyIndex + 1)
+		if !ok {
+			return "", false
+		}
+		if t.historyIndex == -1 {
+			t.historyPending = string(t.line)
+		}
+		t.historyIndex++
+		runes := []rune(entry)
+		t.setLine(runes, len(runes))
+	case keyDown:
+		switch t.historyIndex {
+		case -1:
+			return
+		case 0:
+			runes := []rune(t.historyPending)
+			t.setLine(runes, len(runes))
+			t.historyIndex--
+		default:
+			entry, ok := t.history.NthPreviousEntry(t.historyIndex - 1)
+			if ok {
+				t.historyIndex--
+				runes := []rune(entry)
+				t.setLine(runes, len(runes))
+			}
+		}
+	case keyEnter:
+		t.moveCursorToPos(len(t.line))
+		t.queue([]rune("\r\n"))
+		line = string(t.line)
+		ok = true
+		t.line = t.line[:0]
+		t.pos = 0
+		t.cursorX = 0
+		t.cursorY = 0
+		t.maxLine = 0
+	case keyDeleteWord:
+		// Delete zero or more spaces and then one or more characters.
+		t.eraseNPreviousChars(t.countToLeftWord())
+	case keyDeleteLine:
+		// Delete everything from the current cursor position to the
+		// end of line.
+		for i := t.pos; i < len(t.line); i++ {
+			t.queue(space)
+			t.advanceCursor(1)
+		}
+		t.line = t.line[:t.pos]
+		t.moveCursorToPos(t.pos)
+	case keyCtrlD:
+		// Erase the character under the current position.
+		// The EOF case when the line is empty is handled in
+		// readLine().
+		if t.pos < len(t.line) {
+			t.pos++
+			t.eraseNPreviousChars(1)
+		}
+	case keyCtrlU:
+		t.eraseNPreviousChars(t.pos)
+	case keyClearScreen:
+		// Erases the screen and moves the cursor to the home position.
+		t.queue([]rune("\x1b[2J\x1b[H"))
+		t.queue(t.prompt)
+		t.cursorX, t.cursorY = 0, 0
+		t.advanceCursor(visualLength(t.prompt))
+		t.setLine(t.line, t.pos)
+	default:
+		if t.AutoCompleteCallback != nil {
+			prefix := string(t.line[:t.pos])
+			suffix := string(t.line[t.pos:])
+
+			t.lock.Unlock()
+			newLine, newPos, completeOk := t.AutoCompleteCallback(prefix+suffix, len(prefix), key)
+			t.lock.Lock()
+
+			if completeOk {
+				t.setLine([]rune(newLine), utf8.RuneCount([]byte(newLine)[:newPos]))
+				return
+			}
+		}
+		if !isPrintable(key) {
+			return
+		}
+		if len(t.line) == maxLineLength {
+			return
+		}
+		t.addKeyToLine(key)
+	}
+	return
+}
+
+// addKeyToLine inserts the given key at the current position in the current
+// line.
+func (t *Terminal) addKeyToLine(key rune) {
+	if len(t.line) == cap(t.line) {
+		newLine := make([]rune, len(t.line), 2*(1+len(t.line)))
+		copy(newLine, t.line)
+		t.line = newLine
+	}
+	t.line = t.line[:len(t.line)+1]
+	copy(t.line[t.pos+1:], t.line[t.pos:])
+	t.line[t.pos] = key
+	if t.echo {
+		t.writeLine(t.line[t.pos:])
+	}
+	t.pos++
+	t.moveCursorToPos(t.pos)
+}
+
+func (t *Terminal) writeLine(line []rune) {
+	for len(line) != 0 {
+		remainingOnLine := t.termWidth - t.cursorX
+		todo := len(line)
+		if todo > remainingOnLine {
+			todo = remainingOnLine
+		}
+		t.queue(line[:todo])
+		t.advanceCursor(visualLength(line[:todo]))
+		line = line[todo:]
+	}
+}
+
+func (t *Terminal) Write(buf []byte) (n int, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.cursorX == 0 && t.cursorY == 0 {
+		// This is the easy case: there's nothing on the screen that we
+		// have to move out of the way.
+		return t.c.Write(buf)
+	}
+
+	// We have a prompt and possibly user input on the screen. We
+	// have to clear it first.
+	t.move(0 /* up */, 0 /* down */, t.cursorX /* left */, 0 /* right */)
+	t.cursorX = 0
+	t.clearLineToRight()
+
+	for t.cursorY > 0 {
+		t.move(1 /* up */, 0, 0, 0)
+		t.cursorY--
+		t.clearLineToRight()
+	}
+
+	if _, err = t.c.Write(t.outBuf); err != nil {
+		return
+	}
+	t.outBuf = t.outBuf[:0]
+
+	if n, err = t.c.Write(buf); err != nil {
+		return
+	}
+
+	t.writeLine(t.prompt)
+	if t.echo {
+		t.writeLine(t.line)
+	}
+
+	t.moveCursorToPos(t.pos)
+
+	if _, err = t.c.Write(t.outBuf); err != nil {
+		return
+	}
+	t.outBuf = t.outBuf[:0]
+	return
+}
+
+// ReadPassword temporarily changes the prompt and reads a password, without
+// echo, from the terminal.
+func (t *Terminal) ReadPassword(prompt string) (line string, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	oldPrompt := t.prompt
+	t.prompt = []rune(prompt)
+	t.echo = false
+
+	line, err = t.readLine()
+
+	t.prompt = oldPrompt
+	t.echo = true
+
+	return
+}
+
+// ReadLine returns a line of input from the terminal.
+func (t *Terminal) ReadLine() (line string, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.readLine()
+}
+
+func (t *Terminal) readLine() (line string, err error) {
+	// t.lock must be held at this point
+
+	if t.cursorX == 0 && t.cursorY == 0 {
+		t.writeLine(t.prompt)
+		t.c.Write(t.outBuf)
+		t.outBuf = t.outBuf[:0]
+	}
+
+	lineIsPasted := t.pasteActive
+
+	for {
+		rest := t.remainder
+		lineOk := false
+		for !lineOk {
+			var key rune
+			key, rest = bytesToKey(rest, t.pasteActive)
+			if key == utf8.RuneError {
+				break
+			}
+			if !t.pasteActive {
+				if key == keyCtrlD {
+					if len(t.line) == 0 {
+						return "", io.EOF
+					}
+				}
+				if key == keyPasteStart {
+					t.pasteActive = true
+					if len(t.line) == 0 {
+						lineIsPasted = true
+					}
+					continue
+				}
+			} else if key == keyPasteEnd {
+				t.pasteActive = false
+				continue
+			}
+			if !t.pasteActive {
+				lineIsPasted = false
+			}
+			line, lineOk = t.handleKey(key)
+		}
+		if len(rest) > 0 {
+			n := copy(t.inBuf[:], rest)
+			t.remainder = t.inBuf[:n]
+		} else {
+			t.remainder = nil
+		}
+		t.c.Write(t.outBuf)
+		t.outBuf = t.outBuf[:0]
+		if lineOk {
+			if t.echo {
+				t.historyIndex = -1
+				t.history.Add(line)
+			}
+			if lineIsPasted {
+				err = ErrPasteIndicator
+			}
+			return
+		}
+
+		// t.remainder is a slice at the beginning of t.inBuf
+		// containing a partial key sequence
+		readBuf := t.inBuf[len(t.remainder):]
+		var n int
+
+		t.lock.Unlock()
+		n, err = t.c.Read(readBuf)
+		t.lock.Lock()
+
+		if err != nil {
+			return
+		}
+
+		t.remainder = t.inBuf[:n+len(t.remainder)]
+	}
+
+	panic("unreachable") // for Go 1.0.
+}
+
+// SetPrompt sets the prompt to be used when reading subsequent lines.
+func (t *Terminal) SetPrompt(prompt string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.prompt = []rune(prompt)
+}
+
+func (t *Terminal) clearAndRepaintLinePlusNPrevious(numPrevLines int) {
+	// Move cursor to column zero at the start of the line.
+	t.move(t.cursorY, 0, t.cursorX, 0)
+	t.cursorX, t.cursorY = 0, 0
+	t.clearLineToRight()
+	for t.cursorY < numPrevLines {
+		// Move down a line
+		t.move(0, 1, 0, 0)
+		t.cursorY++
+		t.clearLineToRight()
+	}
+	// Move back to beginning.
+	t.move(t.cursorY, 0, 0, 0)
+	t.cursorX, t.cursorY = 0, 0
+
+	t.queue(t.prompt)
+	t.advanceCursor(visualLength(t.prompt))
+	t.writeLine(t.line)
+	t.moveCursorToPos(t.pos)
+}
+
+func (t *Terminal) SetSize(width, height int) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if width == 0 {
+		width = 1
+	}
+
+	oldWidth := t.termWidth
+	t.termWidth, t.termHeight = width, height
+
+	switch {
+	case width == oldWidth:
+		// If the width didn't change then nothing else needs to be
+		// done.
+		return nil
+	case len(t.line) == 0 && t.cursorX == 0 && t.cursorY == 0:
+		// If there is nothing on current line and no prompt printed,
+		// just do nothing
+		return nil
+	case width < oldWidth:
+		// Some terminals (e.g. xterm) will truncate lines that were
+		// too long when shinking. Others, (e.g. gnome-terminal) will
+		// attempt to wrap them. For the former, repainting t.maxLine
+		// works great, but that behaviour goes badly wrong in the case
+		// of the latter because they have doubled every full line.
+
+		// We assume that we are working on a terminal that wraps lines
+		// and adjust the cursor position based on every previous line
+		// wrapping and turning into two. This causes the prompt on
+		// xterms to move upwards, which isn't great, but it avoids a
+		// huge mess with gnome-terminal.
+		if t.cursorX >= t.termWidth {
+			t.cursorX = t.termWidth - 1
+		}
+		t.cursorY *= 2
+		t.clearAndRepaintLinePlusNPrevious(t.maxLine * 2)
+	case width > oldWidth:
+		// If the terminal expands then our position calculations will
+		// be wrong in the future because we think the cursor is
+		// |t.pos| chars into the string, but there will be a gap at
+		// the end of any wrapped line.
+		//
+		// But the position will actually be correct until we move, so
+		// we can move back to the beginning and repaint everything.
+		t.clearAndRepaintLinePlusNPrevious(t.maxLine)
+	}
+
+	_, err := t.c.Write(t.outBuf)
+	t.outBuf = t.outBuf[:0]
+	return err
+}
+
+type pasteIndicatorError struct{}
+
+func (pasteIndicatorError) Error() string {
+	return "terminal: ErrPasteIndicator not correctly handled"
+}
+
+// ErrPasteIndicator may be returned from ReadLine as the error, in addition
+// to valid line data. It indicates that bracketed paste mode is enabled and
+// that the returned line consists only of pasted data. Programs may wish to
+// interpret pasted data more literally than typed data.
+var ErrPasteIndicator = pasteIndicatorError{}
+
+// SetBracketedPasteMode requests that the terminal bracket paste operations
+// with markers. Not all terminals support this but, if it is supported, then
+// enabling this mode will stop any autocomplete callback from running due to
+// pastes. Additionally, any lines that are completely pasted will be returned
+// from ReadLine with the error set to ErrPasteIndicator.
+func (t *Terminal) SetBracketedPasteMode(on bool) {
+	if on {
+		io.WriteString(t.c, "\x1b[?2004h")
+	} else {
+		io.WriteString(t.c, "\x1b[?2004l")
+	}
+}
+
+// stRingBuffer is a ring buffer of strings.
+type stRingBuffer struct {
+	// entries contains max elements.
+	entries []string
+	max     int
+	// head contains the index of the element most recently added to the ring.
+	head int
+	// size contains the number of elements in the ring.
+	size int
+}
+
+func (s *stRingBuffer) Add(a string) {
+	if s.entries == nil {
+		const defaultNumEntries = 100
+		s.entries = make([]string, defaultNumEntries)
+		s.max = defaultNumEntries
+	}
+
+	s.head = (s.head + 1) % s.max
+	s.entries[s.head] = a
+	if s.size < s.max {
+		s.size++
+	}
+}
+
+// NthPreviousEntry returns the value passed to the nth previous call to Add.
+// If n is zero then the immediately prior value is returned, if one, then the
+// next most recent, and so on. If such an element doesn't exist then ok is
+// false.
+func (s *stRingBuffer) NthPreviousEntry(n int) (value string, ok bool) {
+	if n >= s.size {
+		return "", false
+	}
+	index := s.head - n
+	if index < 0 {
+		index += s.max
+	}
+	return s.entries[index], true
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util.go
@@ -1,0 +1,133 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"io"
+	"syscall"
+	"unsafe"
+)
+
+// State contains the state of a terminal.
+type State struct {
+	termios syscall.Termios
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&oldState.termios)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState.termios
+	// This attempts to replicate the behaviour documented for cfmakeraw in
+	// the termios(3) manpage.
+	newState.Iflag &^= syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IXON
+	newState.Oflag &^= syscall.OPOST
+	newState.Lflag &^= syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
+	newState.Cflag &^= syscall.CSIZE | syscall.PARENB
+	newState.Cflag |= syscall.CS8
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	var oldState State
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&oldState.termios)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&state.termios)), 0, 0, 0)
+	return err
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	var dimensions [4]uint16
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&dimensions)), 0, 0, 0); err != 0 {
+		return -1, -1, err
+	}
+	return int(dimensions[1]), int(dimensions[0]), nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	var oldState syscall.Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	newState := oldState
+	newState.Lflag &^= syscall.ECHO
+	newState.Lflag |= syscall.ICANON | syscall.ISIG
+	newState.Iflag |= syscall.ICRNL
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	defer func() {
+		syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlWriteTermios, uintptr(unsafe.Pointer(&oldState)), 0, 0, 0)
+	}()
+
+	var buf [16]byte
+	var ret []byte
+	for {
+		n, err := syscall.Read(fd, buf[:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			if len(ret) == 0 {
+				return nil, io.EOF
+			}
+			break
+		}
+		if buf[n-1] == '\n' {
+			n--
+		}
+		ret = append(ret, buf[:n]...)
+		if n < len(buf) {
+			break
+		}
+	}
+
+	return ret, nil
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_bsd.go
@@ -1,0 +1,12 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package terminal
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_linux.go
@@ -1,0 +1,11 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+// These constants are declared here, rather than importing
+// them from the syscall package as some syscall packages, even
+// on linux, for example gccgo, do not declare them.
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_plan9.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_plan9.go
@@ -1,0 +1,58 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type State struct{}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	return false
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	return nil, fmt.Errorf("terminal: MakeRaw not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	return nil, fmt.Errorf("terminal: GetState not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	return fmt.Errorf("terminal: Restore not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	return 0, 0, fmt.Errorf("terminal: GetSize not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	return nil, fmt.Errorf("terminal: ReadPassword not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}

--- a/vendor/golang.org/x/crypto/ssh/terminal/util_windows.go
+++ b/vendor/golang.org/x/crypto/ssh/terminal/util_windows.go
@@ -1,0 +1,174 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+// Package terminal provides support functions for dealing with terminals, as
+// commonly found on UNIX systems.
+//
+// Putting a terminal into raw mode is the most common requirement:
+//
+// 	oldState, err := terminal.MakeRaw(0)
+// 	if err != nil {
+// 	        panic(err)
+// 	}
+// 	defer terminal.Restore(0, oldState)
+package terminal
+
+import (
+	"io"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	enableLineInput       = 2
+	enableEchoInput       = 4
+	enableProcessedInput  = 1
+	enableWindowInput     = 8
+	enableMouseInput      = 16
+	enableInsertMode      = 32
+	enableQuickEditMode   = 64
+	enableExtendedFlags   = 128
+	enableAutoPosition    = 256
+	enableProcessedOutput = 1
+	enableWrapAtEolOutput = 2
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode             = kernel32.NewProc("GetConsoleMode")
+	procSetConsoleMode             = kernel32.NewProc("SetConsoleMode")
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+)
+
+type (
+	short int16
+	word  uint16
+
+	coord struct {
+		x short
+		y short
+	}
+	smallRect struct {
+		left   short
+		top    short
+		right  short
+		bottom short
+	}
+	consoleScreenBufferInfo struct {
+		size              coord
+		cursorPosition    coord
+		attributes        word
+		window            smallRect
+		maximumWindowSize coord
+	}
+)
+
+type State struct {
+	mode uint32
+}
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}
+
+// MakeRaw put the terminal connected to the given file descriptor into raw
+// mode and returns the previous state of the terminal so that it can be
+// restored.
+func MakeRaw(fd int) (*State, error) {
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	raw := st &^ (enableEchoInput | enableProcessedInput | enableLineInput | enableProcessedOutput)
+	_, _, e = syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(raw), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	return &State{st}, nil
+}
+
+// GetState returns the current state of a terminal which may be useful to
+// restore the terminal after a signal.
+func GetState(fd int) (*State, error) {
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	return &State{st}, nil
+}
+
+// Restore restores the terminal connected to the given file descriptor to a
+// previous state.
+func Restore(fd int, state *State) error {
+	_, _, err := syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(state.mode), 0)
+	return err
+}
+
+// GetSize returns the dimensions of the given terminal.
+func GetSize(fd int) (width, height int, err error) {
+	var info consoleScreenBufferInfo
+	_, _, e := syscall.Syscall(procGetConsoleScreenBufferInfo.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&info)), 0)
+	if e != 0 {
+		return 0, 0, error(e)
+	}
+	return int(info.size.x), int(info.size.y), nil
+}
+
+// ReadPassword reads a line of input from a terminal without local echo.  This
+// is commonly used for inputting passwords and other sensitive data. The slice
+// returned does not include the \n.
+func ReadPassword(fd int) ([]byte, error) {
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	old := st
+
+	st &^= (enableEchoInput)
+	st |= (enableProcessedInput | enableLineInput | enableProcessedOutput)
+	_, _, e = syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(st), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+
+	defer func() {
+		syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(fd), uintptr(old), 0)
+	}()
+
+	var buf [16]byte
+	var ret []byte
+	for {
+		n, err := syscall.Read(syscall.Handle(fd), buf[:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			if len(ret) == 0 {
+				return nil, io.EOF
+			}
+			break
+		}
+		if buf[n-1] == '\n' {
+			n--
+		}
+		if n > 0 && buf[n-1] == '\r' {
+			n--
+		}
+		ret = append(ret, buf[:n]...)
+		if n < len(buf) {
+			break
+		}
+	}
+
+	return ret, nil
+}


### PR DESCRIPTION
@jh-bate This is the beginning of a command-line tool I started a while back. I added the "dataset list" and "dataset delete" command so that Nick can use this to test the delete uploads feature (rather than Postman, which would be quite confusing/onerous to test delete uploads with).

This is just a tool that invokes the API so there aren't any tests.

(I didn't commit a bunch of the other commands in with this tool as they aren't fully tested.)
