### PR TITLE
Add Agent to global store session

### DIFF
--- a/data/deduplicator/delegate/delegate_test.go
+++ b/data/deduplicator/delegate/delegate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/base/upload"
 	"github.com/tidepool-org/platform/log"
+	commonStore "github.com/tidepool-org/platform/store"
 )
 
 type CanDeduplicateDatasetOutput struct {
@@ -75,7 +76,7 @@ func (t *TestDataStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) SetAgent(agent store.Agent) {
+func (t *TestDataStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestDataStoreSession")
 }
 

--- a/data/deduplicator/truncate/truncate_test.go
+++ b/data/deduplicator/truncate/truncate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/base/upload"
 	"github.com/tidepool-org/platform/log"
+	commonStore "github.com/tidepool-org/platform/store"
 )
 
 type CreateDatasetDataInput struct {
@@ -39,7 +40,7 @@ func (t *TestDataStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) SetAgent(agent store.Agent) {
+func (t *TestDataStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestDataStoreSession")
 }
 

--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -52,11 +52,6 @@ func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
 
 type Session struct {
 	*mongo.Session
-	agent store.Agent
-}
-
-func (s *Session) SetAgent(agent store.Agent) {
-	s.agent = agent
 }
 
 func (s *Session) GetDatasetsForUser(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
@@ -150,8 +145,8 @@ func (s *Session) CreateDataset(dataset *upload.Upload) error {
 
 	startTime := time.Now()
 
-	dataset.CreatedTime = newTimestamp()
-	dataset.CreatedUserID = s.agentUserID()
+	dataset.CreatedTime = s.Timestamp()
+	dataset.CreatedUserID = s.AgentUserID()
 
 	dataset.ByUser = dataset.CreatedUserID
 
@@ -201,8 +196,8 @@ func (s *Session) UpdateDataset(dataset *upload.Upload) error {
 
 	startTime := time.Now()
 
-	dataset.ModifiedTime = newTimestamp()
-	dataset.ModifiedUserID = s.agentUserID()
+	dataset.ModifiedTime = s.Timestamp()
+	dataset.ModifiedUserID = s.AgentUserID()
 
 	selector := bson.M{
 		"_userId":  dataset.UserID,
@@ -241,8 +236,8 @@ func (s *Session) DeleteDataset(dataset *upload.Upload) error {
 
 	startTime := time.Now()
 
-	deletedTimestamp := newTimestamp()
-	deletedUserID := s.agentUserID()
+	deletedTimestamp := s.Timestamp()
+	deletedUserID := s.AgentUserID()
 
 	var err error
 	var removeInfo *mgo.ChangeInfo
@@ -311,8 +306,8 @@ func (s *Session) CreateDatasetData(dataset *upload.Upload, datasetData []data.D
 
 	startTime := time.Now()
 
-	createdTimestamp := newTimestamp()
-	createdUserID := s.agentUserID()
+	createdTimestamp := s.Timestamp()
+	createdUserID := s.AgentUserID()
 
 	insertData := make([]interface{}, len(datasetData))
 	for index, datum := range datasetData {
@@ -359,8 +354,8 @@ func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 
 	startTime := time.Now()
 
-	modifiedTimestamp := newTimestamp()
-	modifiedUserID := s.agentUserID()
+	modifiedTimestamp := s.Timestamp()
+	modifiedUserID := s.AgentUserID()
 
 	selector := bson.M{
 		"_userId":  dataset.UserID,
@@ -415,8 +410,8 @@ func (s *Session) DeleteOtherDatasetData(dataset *upload.Upload) error {
 
 	startTime := time.Now()
 
-	deletedTimestamp := newTimestamp()
-	deletedUserID := s.agentUserID()
+	deletedTimestamp := s.Timestamp()
+	deletedUserID := s.AgentUserID()
 
 	var err error
 	var removeInfo *mgo.ChangeInfo
@@ -485,15 +480,4 @@ func (s *Session) DeleteDataForUser(userID string) error {
 	}
 
 	return nil
-}
-
-func (s *Session) agentUserID() string {
-	if s.agent == nil {
-		return ""
-	}
-	return s.agent.UserID()
-}
-
-func newTimestamp() string {
-	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -160,16 +160,6 @@ var _ = Describe("Mongo", func() {
 				Expect(mongoSession).ToNot(BeNil())
 			})
 
-			Context("SetAgent", func() {
-				It("successfully sets the agent", func() {
-					mongoSession.SetAgent(&TestAgent{app.NewID()})
-				})
-
-				It("successfully sets the agent if nil", func() {
-					mongoSession.SetAgent(nil)
-				})
-			})
-
 			Context("with persisted data", func() {
 				var testMongoSession *mgo.Session
 				var testMongoCollection *mgo.Collection

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -27,8 +27,6 @@ type Store interface {
 type Session interface {
 	store.Session
 
-	SetAgent(agent Agent)
-
 	GetDatasetsForUser(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
 	GetDataset(datasetID string) (*upload.Upload, error)
 	CreateDataset(dataset *upload.Upload) error
@@ -38,10 +36,6 @@ type Session interface {
 	ActivateDatasetData(dataset *upload.Upload) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
 	DeleteDataForUser(userID string) error
-}
-
-type Agent interface {
-	UserID() string
 }
 
 type Filter struct {

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tidepool-org/platform/log"
 	metricservicesClient "github.com/tidepool-org/platform/metricservices/client"
 	"github.com/tidepool-org/platform/service"
+	commonStore "github.com/tidepool-org/platform/store"
 	taskStore "github.com/tidepool-org/platform/task/store"
 	userservicesClient "github.com/tidepool-org/platform/userservices/client"
 )
@@ -145,7 +146,7 @@ func (t *TestDataStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) SetAgent(agent dataStore.Agent) {
+func (t *TestDataStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestDataStoreSession")
 }
 
@@ -212,6 +213,10 @@ func (t *TestTaskStoreSession) IsClosed() bool {
 
 func (t *TestTaskStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestTaskStoreSession")
+}
+
+func (t *TestTaskStoreSession) SetAgent(agent commonStore.Agent) {
+	panic("Unexpected invocation of SetAgent on TestTaskStoreSession")
 }
 
 func (t *TestTaskStoreSession) ValidateTest() bool {

--- a/dataservices/service/context/standard.go
+++ b/dataservices/service/context/standard.go
@@ -103,4 +103,5 @@ func (s *Standard) SetAuthenticationDetails(authenticationDetails userservicesCl
 	s.authenticationDetails = authenticationDetails
 
 	s.dataStoreSession.SetAgent(authenticationDetails)
+	s.taskStoreSession.SetAgent(authenticationDetails)
 }

--- a/store/mongo/mongo.go
+++ b/store/mongo/mongo.go
@@ -14,11 +14,13 @@ import (
 	"crypto/tls"
 	"net"
 	"strconv"
+	"time"
 
 	mgo "gopkg.in/mgo.v2"
 
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/store"
 )
 
 // TODO: Consider SetStats, GetStats
@@ -167,6 +169,7 @@ type Session struct {
 	config        *Config
 	sourceSession *mgo.Session
 	targetSession *mgo.Session
+	agent         store.Agent
 }
 
 func (s *Session) IsClosed() bool {
@@ -185,6 +188,10 @@ func (s *Session) Logger() log.Logger {
 	return s.logger
 }
 
+func (s *Session) SetAgent(agent store.Agent) {
+	s.agent = agent
+}
+
 func (s *Session) C() *mgo.Collection {
 	if s.IsClosed() {
 		return nil
@@ -195,4 +202,15 @@ func (s *Session) C() *mgo.Collection {
 	}
 
 	return s.targetSession.DB(s.config.Database).C(s.config.Collection)
+}
+
+func (s *Session) AgentUserID() string {
+	if s.agent == nil {
+		return ""
+	}
+	return s.agent.UserID()
+}
+
+func (s *Session) Timestamp() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -20,4 +20,10 @@ type Store interface {
 type Session interface {
 	IsClosed() bool
 	Close()
+
+	SetAgent(agent Agent)
+}
+
+type Agent interface {
+	UserID() string
 }

--- a/userservices/service/context/standard.go
+++ b/userservices/service/context/standard.go
@@ -150,4 +150,11 @@ func (s *Standard) AuthenticationDetails() userservicesClient.AuthenticationDeta
 
 func (s *Standard) SetAuthenticationDetails(authenticationDetails userservicesClient.AuthenticationDetails) {
 	s.authenticationDetails = authenticationDetails
+
+	s.messageStoreSession.SetAgent(authenticationDetails)
+	s.notificationStoreSession.SetAgent(authenticationDetails)
+	s.permissionStoreSession.SetAgent(authenticationDetails)
+	s.profileStoreSession.SetAgent(authenticationDetails)
+	s.sessionStoreSession.SetAgent(authenticationDetails)
+	s.userStoreSession.SetAgent(authenticationDetails)
 }


### PR DESCRIPTION
@jh-bate The agent is the user ID that is authenticated (or empty string if server) on the request. The agent is used for all `createdUserID`, `modifiedUserID`, and `deleteUserID` fields, as appropriate.