### PR TITLE
Destroy tasks with data; use ByID suffix for consistency/clarity

### DIFF
--- a/data/deduplicator/delegate/delegate_test.go
+++ b/data/deduplicator/delegate/delegate_test.go
@@ -80,12 +80,12 @@ func (t *TestDataStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) GetDatasetsForUser(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
-	panic("Unexpected invocation of GetDatasetsForUser on TestDataStoreSession")
+func (t *TestDataStoreSession) GetDatasetsForUserByID(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
+	panic("Unexpected invocation of GetDatasetsForUserByID on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) GetDataset(datasetID string) (*upload.Upload, error) {
-	panic("Unexpected invocation of GetDataset on TestDataStoreSession")
+func (t *TestDataStoreSession) GetDatasetByID(datasetID string) (*upload.Upload, error) {
+	panic("Unexpected invocation of GetDatasetByID on TestDataStoreSession")
 }
 
 func (t *TestDataStoreSession) CreateDataset(dataset *upload.Upload) error {
@@ -112,8 +112,8 @@ func (t *TestDataStoreSession) DeleteOtherDatasetData(dataset *upload.Upload) er
 	panic("Unexpected invocation of DeleteOtherDatasetData on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) DeleteDataForUser(userID string) error {
-	panic("Unexpected invocation of DeleteDataForUser on TestDataStoreSession")
+func (t *TestDataStoreSession) DestroyDataForUserByID(userID string) error {
+	panic("Unexpected invocation of DestroyDataForUserByID on TestDataStoreSession")
 }
 
 var _ = Describe("Delegate", func() {

--- a/data/deduplicator/truncate/truncate_test.go
+++ b/data/deduplicator/truncate/truncate_test.go
@@ -44,12 +44,12 @@ func (t *TestDataStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) GetDatasetsForUser(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
-	panic("Unexpected invocation of GetDatasetsForUser on TestDataStoreSession")
+func (t *TestDataStoreSession) GetDatasetsForUserByID(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
+	panic("Unexpected invocation of GetDatasetsForUserByID on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) GetDataset(datasetID string) (*upload.Upload, error) {
-	panic("Unexpected invocation of GetDataset on TestDataStoreSession")
+func (t *TestDataStoreSession) GetDatasetByID(datasetID string) (*upload.Upload, error) {
+	panic("Unexpected invocation of GetDatasetByID on TestDataStoreSession")
 }
 
 func (t *TestDataStoreSession) CreateDataset(dataset *upload.Upload) error {
@@ -88,8 +88,8 @@ func (t *TestDataStoreSession) DeleteOtherDatasetData(dataset *upload.Upload) er
 	return output
 }
 
-func (t *TestDataStoreSession) DeleteDataForUser(userID string) error {
-	panic("Unexpected invocation of DeleteDataForUser on TestDataStoreSession")
+func (t *TestDataStoreSession) DestroyDataForUserByID(userID string) error {
+	panic("Unexpected invocation of DestroyDataForUserByID on TestDataStoreSession")
 }
 
 var _ = Describe("Truncate", func() {

--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -54,7 +54,7 @@ type Session struct {
 	*mongo.Session
 }
 
-func (s *Session) GetDatasetsForUser(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
+func (s *Session) GetDatasetsForUserByID(userID string, filter *store.Filter, pagination *store.Pagination) ([]*upload.Upload, error) {
 	if userID == "" {
 		return nil, app.Error("mongo", "user id is missing")
 	}
@@ -86,10 +86,10 @@ func (s *Session) GetDatasetsForUser(userID string, filter *store.Filter, pagina
 	err := s.C().Find(selector).Sort("-createdTime").Skip(pagination.Page * pagination.Size).Limit(pagination.Size).All(&datasets)
 
 	loggerFields := log.Fields{"userID": userID, "datasets-count": len(datasets), "duration": time.Since(startTime) / time.Microsecond}
-	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetDatasetsForUser")
+	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetDatasetsForUserByID")
 
 	if err != nil {
-		return nil, app.ExtError(err, "mongo", "unable to get datasets for user")
+		return nil, app.ExtError(err, "mongo", "unable to get datasets for user by id")
 	}
 
 	if datasets == nil {
@@ -98,7 +98,7 @@ func (s *Session) GetDatasetsForUser(userID string, filter *store.Filter, pagina
 	return datasets, nil
 }
 
-func (s *Session) GetDataset(datasetID string) (*upload.Upload, error) {
+func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	if datasetID == "" {
 		return nil, app.Error("mongo", "dataset id is missing")
 	}
@@ -117,10 +117,10 @@ func (s *Session) GetDataset(datasetID string) (*upload.Upload, error) {
 	err := s.C().Find(selector).One(&dataset)
 
 	loggerFields := log.Fields{"datasetID": datasetID, "dataset": dataset, "duration": time.Since(startTime) / time.Microsecond}
-	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetDataset")
+	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetDatasetByID")
 
 	if err != nil {
-		return nil, app.ExtError(err, "mongo", "unable to get dataset")
+		return nil, app.ExtError(err, "mongo", "unable to get dataset by id")
 	}
 	return &dataset, nil
 }
@@ -456,7 +456,7 @@ func (s *Session) DeleteOtherDatasetData(dataset *upload.Upload) error {
 	return nil
 }
 
-func (s *Session) DeleteDataForUser(userID string) error {
+func (s *Session) DestroyDataForUserByID(userID string) error {
 	if userID == "" {
 		return app.Error("mongo", "user id is missing")
 	}
@@ -473,10 +473,10 @@ func (s *Session) DeleteDataForUser(userID string) error {
 	removeInfo, err := s.C().RemoveAll(selector)
 
 	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
-	s.Logger().WithFields(loggerFields).WithError(err).Debug("DeleteDataForUser")
+	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyDataForUserByID")
 
 	if err != nil {
-		return app.ExtError(err, "mongo", "unable to delete data for user")
+		return app.ExtError(err, "mongo", "unable to destroy data for user by id")
 	}
 
 	return nil

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Mongo", func() {
 					}
 				})
 
-				Context("GetDatasetsForUser", func() {
+				Context("GetDatasetsForUserByID", func() {
 					var filter *store.Filter
 					var pagination *store.Pagination
 
@@ -201,65 +201,65 @@ var _ = Describe("Mongo", func() {
 					})
 
 					It("succeeds if it successfully finds the user datasets", func() {
-						Expect(mongoSession.GetDatasetsForUser(userID, filter, pagination)).To(Equal([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
+						Expect(mongoSession.GetDatasetsForUserByID(userID, filter, pagination)).To(Equal([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
 					})
 
 					It("succeeds if the filter is not specified", func() {
-						Expect(mongoSession.GetDatasetsForUser(userID, nil, pagination)).To(Equal([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
+						Expect(mongoSession.GetDatasetsForUserByID(userID, nil, pagination)).To(Equal([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
 					})
 
 					It("succeeds if the pagination is not specified", func() {
-						Expect(mongoSession.GetDatasetsForUser(userID, filter, nil)).To(Equal([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
+						Expect(mongoSession.GetDatasetsForUserByID(userID, filter, nil)).To(Equal([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
 					})
 
 					It("succeeds if the pagination size is not default", func() {
 						pagination.Size = 2
-						Expect(mongoSession.GetDatasetsForUser(userID, filter, pagination)).To(Equal([]*upload.Upload{datasetExistingOne, dataset}))
+						Expect(mongoSession.GetDatasetsForUserByID(userID, filter, pagination)).To(Equal([]*upload.Upload{datasetExistingOne, dataset}))
 					})
 
 					It("succeeds if the pagination page and size is not default", func() {
 						pagination.Page = 1
 						pagination.Size = 2
-						Expect(mongoSession.GetDatasetsForUser(userID, filter, pagination)).To(Equal([]*upload.Upload{datasetExistingTwo}))
+						Expect(mongoSession.GetDatasetsForUserByID(userID, filter, pagination)).To(Equal([]*upload.Upload{datasetExistingTwo}))
 					})
 
 					It("succeeds if it successfully does not find another user datasets", func() {
-						resultDatasets, err := mongoSession.GetDatasetsForUser(app.NewID(), filter, pagination)
+						resultDatasets, err := mongoSession.GetDatasetsForUserByID(app.NewID(), filter, pagination)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(resultDatasets).ToNot(BeNil())
 						Expect(resultDatasets).To(BeEmpty())
 					})
 
 					It("returns an error if the user id is missing", func() {
-						resultDatasets, err := mongoSession.GetDatasetsForUser("", filter, pagination)
+						resultDatasets, err := mongoSession.GetDatasetsForUserByID("", filter, pagination)
 						Expect(err).To(MatchError("mongo: user id is missing"))
 						Expect(resultDatasets).To(BeNil())
 					})
 
 					It("returns an error if the pagination page is less than minimum", func() {
 						pagination.Page = -1
-						resultDatasets, err := mongoSession.GetDatasetsForUser(userID, filter, pagination)
+						resultDatasets, err := mongoSession.GetDatasetsForUserByID(userID, filter, pagination)
 						Expect(err).To(MatchError("mongo: pagination is invalid; store: page is invalid"))
 						Expect(resultDatasets).To(BeNil())
 					})
 
 					It("returns an error if the pagination size is less than minimum", func() {
 						pagination.Size = 0
-						resultDatasets, err := mongoSession.GetDatasetsForUser(userID, filter, pagination)
+						resultDatasets, err := mongoSession.GetDatasetsForUserByID(userID, filter, pagination)
 						Expect(err).To(MatchError("mongo: pagination is invalid; store: size is invalid"))
 						Expect(resultDatasets).To(BeNil())
 					})
 
 					It("returns an error if the pagination size is greater than maximum", func() {
 						pagination.Size = 101
-						resultDatasets, err := mongoSession.GetDatasetsForUser(userID, filter, pagination)
+						resultDatasets, err := mongoSession.GetDatasetsForUserByID(userID, filter, pagination)
 						Expect(err).To(MatchError("mongo: pagination is invalid; store: size is invalid"))
 						Expect(resultDatasets).To(BeNil())
 					})
 
 					It("returns an error if the session is closed", func() {
 						mongoSession.Close()
-						resultDatasets, err := mongoSession.GetDatasetsForUser(userID, filter, pagination)
+						resultDatasets, err := mongoSession.GetDatasetsForUserByID(userID, filter, pagination)
 						Expect(err).To(MatchError("mongo: session closed"))
 						Expect(resultDatasets).To(BeNil())
 					})
@@ -271,42 +271,42 @@ var _ = Describe("Mongo", func() {
 						})
 
 						It("succeeds if it successfully finds the non-deleted user datasets", func() {
-							Expect(mongoSession.GetDatasetsForUser(userID, filter, pagination)).To(ConsistOf([]*upload.Upload{datasetExistingOne, datasetExistingTwo}))
+							Expect(mongoSession.GetDatasetsForUserByID(userID, filter, pagination)).To(ConsistOf([]*upload.Upload{datasetExistingOne, datasetExistingTwo}))
 						})
 
 						It("succeeds if it successfully finds all the user datasets", func() {
 							filter.Deleted = true
-							Expect(mongoSession.GetDatasetsForUser(userID, filter, pagination)).To(ConsistOf([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
+							Expect(mongoSession.GetDatasetsForUserByID(userID, filter, pagination)).To(ConsistOf([]*upload.Upload{datasetExistingOne, dataset, datasetExistingTwo}))
 						})
 					})
 				})
 
-				Context("GetDataset", func() {
+				Context("GetDatasetByID", func() {
 					BeforeEach(func() {
 						dataset.CreatedTime = "2016-09-01T11:00:00Z"
 						Expect(testMongoCollection.Insert(dataset)).To(Succeed())
 					})
 
 					It("succeeds if it successfully finds the dataset", func() {
-						Expect(mongoSession.GetDataset(dataset.UploadID)).To(Equal(dataset))
+						Expect(mongoSession.GetDatasetByID(dataset.UploadID)).To(Equal(dataset))
 					})
 
 					It("returns an error if the dataset id is missing", func() {
-						resultDataset, err := mongoSession.GetDataset("")
+						resultDataset, err := mongoSession.GetDatasetByID("")
 						Expect(err).To(MatchError("mongo: dataset id is missing"))
 						Expect(resultDataset).To(BeNil())
 					})
 
 					It("returns an error if the session is closed", func() {
 						mongoSession.Close()
-						resultDataset, err := mongoSession.GetDataset(dataset.UploadID)
+						resultDataset, err := mongoSession.GetDatasetByID(dataset.UploadID)
 						Expect(err).To(MatchError("mongo: session closed"))
 						Expect(resultDataset).To(BeNil())
 					})
 
 					It("returns an error if the dataset cannot be found", func() {
-						resultDataset, err := mongoSession.GetDataset("not-found")
-						Expect(err).To(MatchError("mongo: unable to get dataset; not found"))
+						resultDataset, err := mongoSession.GetDatasetByID("not-found")
+						Expect(err).To(MatchError("mongo: unable to get dataset by id; not found"))
 						Expect(resultDataset).To(BeNil())
 					})
 				})
@@ -834,7 +834,7 @@ var _ = Describe("Mongo", func() {
 						})
 					})
 
-					Context("DeleteDataForUser", func() {
+					Context("DestroyDataForUserByID", func() {
 						var deleteUserID string
 						var deleteGroupID string
 						var deleteDataset *upload.Upload
@@ -852,21 +852,21 @@ var _ = Describe("Mongo", func() {
 						})
 
 						It("succeeds if it successfully removes all other dataset data", func() {
-							Expect(mongoSession.DeleteDataForUser(deleteUserID)).To(Succeed())
+							Expect(mongoSession.DestroyDataForUserByID(deleteUserID)).To(Succeed())
 						})
 
 						It("returns an error if the user id is missing", func() {
-							Expect(mongoSession.DeleteDataForUser("")).To(MatchError("mongo: user id is missing"))
+							Expect(mongoSession.DestroyDataForUserByID("")).To(MatchError("mongo: user id is missing"))
 						})
 
 						It("returns an error if the session is closed", func() {
 							mongoSession.Close()
-							Expect(mongoSession.DeleteDataForUser(deleteUserID)).To(MatchError("mongo: session closed"))
+							Expect(mongoSession.DestroyDataForUserByID(deleteUserID)).To(MatchError("mongo: session closed"))
 						})
 
 						It("has the correct stored dataset", func() {
 							ValidateDataset(testMongoCollection, bson.M{}, dataset, datasetExistingOne, datasetExistingTwo, deleteDataset)
-							Expect(mongoSession.DeleteDataForUser(deleteUserID)).To(Succeed())
+							Expect(mongoSession.DestroyDataForUserByID(deleteUserID)).To(Succeed())
 							ValidateDataset(testMongoCollection, bson.M{}, dataset, datasetExistingOne, datasetExistingTwo)
 						})
 
@@ -874,7 +874,7 @@ var _ = Describe("Mongo", func() {
 							datasetAfterRemoveData := append(append(append(datasetData, dataset, datasetExistingOne, datasetExistingTwo), datasetExistingOneData...), datasetExistingTwoData...)
 							datasetBeforeRemoveData := append(append(datasetAfterRemoveData, deleteDataset), deleteDatasetData...)
 							ValidateDatasetData(testMongoCollection, bson.M{}, datasetBeforeRemoveData)
-							Expect(mongoSession.DeleteDataForUser(deleteUserID)).To(Succeed())
+							Expect(mongoSession.DestroyDataForUserByID(deleteUserID)).To(Succeed())
 							ValidateDatasetData(testMongoCollection, bson.M{}, datasetAfterRemoveData)
 						})
 					})

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -27,15 +27,15 @@ type Store interface {
 type Session interface {
 	store.Session
 
-	GetDatasetsForUser(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
-	GetDataset(datasetID string) (*upload.Upload, error)
+	GetDatasetsForUserByID(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
+	GetDatasetByID(datasetID string) (*upload.Upload, error)
 	CreateDataset(dataset *upload.Upload) error
 	UpdateDataset(dataset *upload.Upload) error
 	DeleteDataset(dataset *upload.Upload) error
 	CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error
 	ActivateDatasetData(dataset *upload.Upload) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
-	DeleteDataForUser(userID string) error
+	DestroyDataForUserByID(userID string) error
 }
 
 type Filter struct {

--- a/dataservices/client/client.go
+++ b/dataservices/client/client.go
@@ -24,5 +24,5 @@ type Context interface {
 }
 
 type Client interface {
-	DeleteDataForUser(context Context, userID string) error
+	DestroyDataForUserByID(context Context, userID string) error
 }

--- a/dataservices/client/standard.go
+++ b/dataservices/client/standard.go
@@ -47,7 +47,7 @@ func NewStandard(config *Config) (*Standard, error) {
 	}, nil
 }
 
-func (s *Standard) DeleteDataForUser(context Context, userID string) error {
+func (s *Standard) DestroyDataForUserByID(context Context, userID string) error {
 	if context == nil {
 		return app.Error("client", "context is missing")
 	}

--- a/dataservices/client/standard_test.go
+++ b/dataservices/client/standard_test.go
@@ -141,17 +141,17 @@ var _ = Describe("Standard", func() {
 			}
 		})
 
-		Context("DeleteDataForUser", func() {
+		Context("DestroyDataForUserByID", func() {
 			It("returns error if context is missing", func() {
 				context.TestUserServicesClient.ServerTokenOutputs = nil
-				Expect(standard.DeleteDataForUser(nil, "test-user-id")).To(MatchError("client: context is missing"))
+				Expect(standard.DestroyDataForUserByID(nil, "test-user-id")).To(MatchError("client: context is missing"))
 				Expect(server.ReceivedRequests()).To(BeEmpty())
 				Expect(context.ValidateTest()).To(BeTrue())
 			})
 
 			It("returns error if user id is missing", func() {
 				context.TestUserServicesClient.ServerTokenOutputs = nil
-				Expect(standard.DeleteDataForUser(context, "")).To(MatchError("client: user id is missing"))
+				Expect(standard.DestroyDataForUserByID(context, "")).To(MatchError("client: user id is missing"))
 				Expect(server.ReceivedRequests()).To(BeEmpty())
 				Expect(context.ValidateTest()).To(BeTrue())
 			})
@@ -159,7 +159,7 @@ var _ = Describe("Standard", func() {
 			It("returns error if the context request is missing", func() {
 				context.TestRequest = nil
 				context.TestUserServicesClient.ServerTokenOutputs = nil
-				Expect(standard.DeleteDataForUser(context, "test-user-id")).To(MatchError("client: unable to copy request trace; service: source request is missing"))
+				Expect(standard.DestroyDataForUserByID(context, "test-user-id")).To(MatchError("client: unable to copy request trace; service: source request is missing"))
 				Expect(server.ReceivedRequests()).To(BeEmpty())
 				Expect(context.ValidateTest()).To(BeTrue())
 			})
@@ -167,7 +167,7 @@ var _ = Describe("Standard", func() {
 			It("returns error if the user services client server token returns an error", func() {
 				err := errors.New("test-error")
 				context.TestUserServicesClient.ServerTokenOutputs = []ServerTokenOutput{{"", err}}
-				Expect(standard.DeleteDataForUser(context, "test-user-id")).To(Equal(err))
+				Expect(standard.DestroyDataForUserByID(context, "test-user-id")).To(Equal(err))
 				Expect(server.ReceivedRequests()).To(BeEmpty())
 				Expect(context.ValidateTest()).To(BeTrue())
 			})
@@ -175,7 +175,7 @@ var _ = Describe("Standard", func() {
 			It("returns error if the server is not reachable", func() {
 				server.Close()
 				server = nil
-				err := standard.DeleteDataForUser(context, "test-user-id")
+				err := standard.DestroyDataForUserByID(context, "test-user-id")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(HavePrefix("client: unable to perform request DELETE "))
 				Expect(context.ValidateTest()).To(BeTrue())
@@ -193,7 +193,7 @@ var _ = Describe("Standard", func() {
 				})
 
 				It("returns an error", func() {
-					err := standard.DeleteDataForUser(context, "test-user-id")
+					err := standard.DestroyDataForUserByID(context, "test-user-id")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(HavePrefix("client: unexpected response status code 400 from DELETE "))
 					Expect(server.ReceivedRequests()).To(HaveLen(1))
@@ -213,7 +213,7 @@ var _ = Describe("Standard", func() {
 				})
 
 				It("returns an error", func() {
-					err := standard.DeleteDataForUser(context, "test-user-id")
+					err := standard.DestroyDataForUserByID(context, "test-user-id")
 					Expect(err).To(MatchError("client: unauthorized"))
 					Expect(server.ReceivedRequests()).To(HaveLen(1))
 					Expect(context.ValidateTest()).To(BeTrue())
@@ -232,7 +232,7 @@ var _ = Describe("Standard", func() {
 				})
 
 				It("returns success", func() {
-					Expect(standard.DeleteDataForUser(context, "test-user-id")).To(Succeed())
+					Expect(standard.DestroyDataForUserByID(context, "test-user-id")).To(Succeed())
 					Expect(server.ReceivedRequests()).To(HaveLen(1))
 					Expect(context.ValidateTest()).To(BeTrue())
 				})

--- a/dataservices/service/api/v1/datasets_data_create.go
+++ b/dataservices/service/api/v1/datasets_data_create.go
@@ -31,7 +31,7 @@ func DatasetsDataCreate(serviceContext service.Context) {
 		return
 	}
 
-	dataset, err := serviceContext.DataStoreSession().GetDataset(datasetID)
+	dataset, err := serviceContext.DataStoreSession().GetDatasetByID(datasetID)
 	if err != nil {
 		serviceContext.RespondWithError(ErrorDatasetIDNotFound(datasetID))
 		return

--- a/dataservices/service/api/v1/datasets_delete.go
+++ b/dataservices/service/api/v1/datasets_delete.go
@@ -25,7 +25,7 @@ func DatasetsDelete(serviceContext service.Context) {
 		return
 	}
 
-	dataset, err := serviceContext.DataStoreSession().GetDataset(datasetID)
+	dataset, err := serviceContext.DataStoreSession().GetDatasetByID(datasetID)
 	if err != nil {
 		serviceContext.RespondWithError(ErrorDatasetIDNotFound(datasetID))
 		return

--- a/dataservices/service/api/v1/datasets_delete_test.go
+++ b/dataservices/service/api/v1/datasets_delete_test.go
@@ -30,7 +30,7 @@ var _ = Describe("DatasetsDelete", func() {
 			targetUpload.ByUser = app.NewID()
 			context = NewTestContext()
 			context.RequestImpl.PathParams["datasetid"] = targetUpload.UploadID
-			context.DataStoreSessionImpl.GetDatasetOutputs = []GetDatasetOutput{{targetUpload, nil}}
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{{targetUpload, nil}}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{false}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{authenticatedUserID}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"root": client.Permission{}}, nil}}
@@ -40,7 +40,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("succeeds if authenticated as owner", func() {
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
@@ -51,7 +51,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("succeeds if authenticated as custodian", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"custodian": client.Permission{}}, nil}}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
@@ -63,7 +63,7 @@ var _ = Describe("DatasetsDelete", func() {
 			targetUpload.ByUser = authenticatedUserID
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"upload": client.Permission{}}, nil}}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
@@ -76,7 +76,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -84,7 +84,7 @@ var _ = Describe("DatasetsDelete", func() {
 		})
 
 		It("panics if context is missing", func() {
-			context.DataStoreSessionImpl.GetDatasetOutputs = []GetDatasetOutput{}
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
@@ -96,7 +96,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("panics if request is missing", func() {
 			context.RequestImpl = nil
-			context.DataStoreSessionImpl.GetDatasetOutputs = []GetDatasetOutput{}
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
@@ -108,7 +108,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if dataset id not provided as a parameter", func() {
 			delete(context.RequestImpl.PathParams, "datasetid")
-			context.DataStoreSessionImpl.GetDatasetOutputs = []GetDatasetOutput{}
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
@@ -130,14 +130,14 @@ var _ = Describe("DatasetsDelete", func() {
 		})
 
 		It("responds with error if data store session get dataset returns error", func() {
-			context.DataStoreSessionImpl.GetDatasetOutputs = []GetDatasetOutput{{nil, errors.New("other")}}
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{{nil, errors.New("other")}}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{v1.ErrorDatasetIDNotFound(targetUpload.UploadID)}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -150,7 +150,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to get user id from dataset", nil}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -161,7 +161,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
 
@@ -170,7 +170,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
 
@@ -179,7 +179,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{service.ErrorUnauthorized()}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -191,7 +191,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to get user permissions", []interface{}{err}}}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -202,7 +202,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{service.ErrorUnauthorized()}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -213,7 +213,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{service.ErrorUnauthorized()}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -224,7 +224,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{err}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to delete dataset", []interface{}{err}}}))
@@ -234,7 +234,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("panics if metric services client is missing", func() {
 			context.MetricServicesClientImpl = nil
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -243,7 +243,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("logs and ignores if metric services record metric returns an error", func() {
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{errors.New("other")}
 			v1.DatasetsDelete(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))

--- a/dataservices/service/api/v1/datasets_update.go
+++ b/dataservices/service/api/v1/datasets_update.go
@@ -25,7 +25,7 @@ func DatasetsUpdate(serviceContext service.Context) {
 		return
 	}
 
-	dataset, err := serviceContext.DataStoreSession().GetDataset(datasetID)
+	dataset, err := serviceContext.DataStoreSession().GetDatasetByID(datasetID)
 	if err != nil {
 		serviceContext.RespondWithError(ErrorDatasetIDNotFound(datasetID))
 		return

--- a/dataservices/service/api/v1/users_data_delete.go
+++ b/dataservices/service/api/v1/users_data_delete.go
@@ -29,8 +29,15 @@ func UsersDataDelete(serviceContext service.Context) {
 		return
 	}
 
-	if err := serviceContext.DataStoreSession().DeleteDataForUser(targetUserID); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to delete data for user", err)
+	if err := serviceContext.DataStoreSession().DestroyDataForUserByID(targetUserID); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to delete data for user by id", err)
+		return
+	}
+
+	// TODO: This should probably be in its own API, but then again, these are very specific tasks and
+	// the whole syncTask thing needs to be reworked, so we'll leave it be for the time being.
+	if err := serviceContext.TaskStoreSession().DestroyTasksForUserByID(targetUserID); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to delete tasks for user by id", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/users_datasets_get.go
+++ b/dataservices/service/api/v1/users_datasets_get.go
@@ -88,7 +88,7 @@ func UsersDatasetsGet(serviceContext service.Context) {
 		return
 	}
 
-	datasets, err := serviceContext.DataStoreSession().GetDatasetsForUser(targetUserID, filter, pagination)
+	datasets, err := serviceContext.DataStoreSession().GetDatasetsForUserByID(targetUserID, filter, pagination)
 	if err != nil {
 		serviceContext.RespondWithInternalServerFailure("Unable to get datasets for user", err)
 		return

--- a/dataservices/service/api/v1/users_datasets_get_test.go
+++ b/dataservices/service/api/v1/users_datasets_get_test.go
@@ -33,7 +33,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 			context = NewTestContext()
 			context.RequestImpl.PathParams["userid"] = targetUserID
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{client.ViewPermission: client.Permission{}}, nil}}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{{uploads, nil}}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{{uploads, nil}}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{false}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{authenticatedUserID}
 			filter = store.NewFilter()
@@ -42,7 +42,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 
 		It("succeeds if authenticated as user, not server", func() {
 			v1.UsersDatasetsGet(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, uploads}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -52,7 +52,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{true}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			v1.UsersDatasetsGet(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, uploads}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -61,7 +61,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 			filter.Deleted = true
 			context.RequestImpl.Request.URL.RawQuery = "deleted=true"
 			v1.UsersDatasetsGet(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, uploads}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -70,7 +70,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 			pagination.Page = 1
 			context.RequestImpl.Request.URL.RawQuery = "page=1"
 			v1.UsersDatasetsGet(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, uploads}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -79,7 +79,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 			pagination.Size = 10
 			context.RequestImpl.Request.URL.RawQuery = "size=10"
 			v1.UsersDatasetsGet(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, uploads}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -90,14 +90,14 @@ var _ = Describe("UsersDatasetsGet", func() {
 			pagination.Size = 20
 			context.RequestImpl.Request.URL.RawQuery = "size=20&deleted=true&page=3"
 			v1.UsersDatasetsGet(context)
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, uploads}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
 
 		It("panics if context is missing", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			Expect(func() { v1.UsersDatasetsGet(nil) }).To(Panic())
@@ -107,7 +107,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		It("panics if request is missing", func() {
 			context.RequestImpl = nil
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			Expect(func() { v1.UsersDatasetsGet(context) }).To(Panic())
@@ -116,7 +116,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 
 		It("responds with error if user id not provided as a parameter", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			delete(context.RequestImpl.PathParams, "userid")
@@ -127,14 +127,14 @@ var _ = Describe("UsersDatasetsGet", func() {
 
 		It("panics if authentication details is missing", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.AuthenticationDetailsImpl = nil
 			Expect(func() { v1.UsersDatasetsGet(context) }).To(Panic())
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
 
 		It("panics if user services client is missing", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl = nil
@@ -144,7 +144,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 
 		It("responds with error if user services client get user permissions returns unauthorized error", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{nil, client.NewUnauthorizedError()}}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			v1.UsersDatasetsGet(context)
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{service.ErrorUnauthorized()}))
@@ -154,7 +154,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		It("responds with error if user services client get user permissions returns any other error", func() {
 			err := errors.New("other")
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{nil, err}}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			v1.UsersDatasetsGet(context)
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to get user permissions", []interface{}{err}}}))
@@ -163,7 +163,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 
 		It("responds with error if user services client get user permissions does not return needed permissions", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{client.UploadPermission: client.Permission{}}, nil}}
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			v1.UsersDatasetsGet(context)
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
 			Expect(context.RespondWithErrorInputs).To(Equal([]*service.Error{service.ErrorUnauthorized()}))
@@ -171,7 +171,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		})
 
 		It("responds with error if deleted query parameter not a boolean", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.RequestImpl.Request.URL.RawQuery = "deleted=abc"
 			v1.UsersDatasetsGet(context)
 			Expect(context.RespondWithStatusAndErrorsInputs).To(Equal([]RespondWithStatusAndErrorsInput{{http.StatusBadRequest, []*service.Error{service.ErrorTypeNotBoolean("").WithSourceParameter("deleted")}}}))
@@ -179,7 +179,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		})
 
 		It("responds with error if page query parameter not an integer", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.RequestImpl.Request.URL.RawQuery = "page=abc"
 			v1.UsersDatasetsGet(context)
 			Expect(context.RespondWithStatusAndErrorsInputs).To(Equal([]RespondWithStatusAndErrorsInput{{http.StatusBadRequest, []*service.Error{service.ErrorTypeNotInteger("").WithSourceParameter("page")}}}))
@@ -187,7 +187,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		})
 
 		It("responds with error if page query parameter is less than minimum", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.RequestImpl.Request.URL.RawQuery = "page=-1"
 			v1.UsersDatasetsGet(context)
 			Expect(context.RespondWithStatusAndErrorsInputs).To(Equal([]RespondWithStatusAndErrorsInput{{http.StatusBadRequest, []*service.Error{service.ErrorValueNotGreaterThanOrEqualTo(-1, 0).WithSourceParameter("page")}}}))
@@ -195,7 +195,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		})
 
 		It("responds with error if size query parameter not an integer", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.RequestImpl.Request.URL.RawQuery = "size=abc"
 			v1.UsersDatasetsGet(context)
 			Expect(context.RespondWithStatusAndErrorsInputs).To(Equal([]RespondWithStatusAndErrorsInput{{http.StatusBadRequest, []*service.Error{service.ErrorTypeNotInteger("").WithSourceParameter("size")}}}))
@@ -203,7 +203,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		})
 
 		It("responds with error if size query parameter is less than minimum", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.RequestImpl.Request.URL.RawQuery = "size=0"
 			v1.UsersDatasetsGet(context)
 			Expect(context.RespondWithStatusAndErrorsInputs).To(Equal([]RespondWithStatusAndErrorsInput{{http.StatusBadRequest, []*service.Error{service.ErrorValueNotInRange(0, 1, 100).WithSourceParameter("size")}}}))
@@ -211,7 +211,7 @@ var _ = Describe("UsersDatasetsGet", func() {
 		})
 
 		It("responds with error if size query parameter is greater than maximum", func() {
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{}
 			context.RequestImpl.Request.URL.RawQuery = "size=101"
 			v1.UsersDatasetsGet(context)
 			Expect(context.RespondWithStatusAndErrorsInputs).To(Equal([]RespondWithStatusAndErrorsInput{{http.StatusBadRequest, []*service.Error{service.ErrorValueNotInRange(101, 1, 100).WithSourceParameter("size")}}}))
@@ -227,10 +227,10 @@ var _ = Describe("UsersDatasetsGet", func() {
 
 		It("responds with error if data store session get datasets for user returns an error", func() {
 			err := errors.New("other")
-			context.DataStoreSessionImpl.GetDatasetsForUserOutputs = []GetDatasetsForUserOutput{{nil, err}}
+			context.DataStoreSessionImpl.GetDatasetsForUserByIDOutputs = []GetDatasetsForUserByIDOutput{{nil, err}}
 			v1.UsersDatasetsGet(context)
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
-			Expect(context.DataStoreSessionImpl.GetDatasetsForUserInputs).To(Equal([]GetDatasetsForUserInput{{targetUserID, filter, pagination}}))
+			Expect(context.DataStoreSessionImpl.GetDatasetsForUserByIDInputs).To(Equal([]GetDatasetsForUserByIDInput{{targetUserID, filter, pagination}}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to get datasets for user", []interface{}{err}}}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -111,31 +111,31 @@ type RespondWithStatusAndDataInput struct {
 	data       interface{}
 }
 
-type GetDatasetsForUserInput struct {
+type GetDatasetsForUserByIDInput struct {
 	userID     string
 	filter     *dataStore.Filter
 	pagination *dataStore.Pagination
 }
 
-type GetDatasetsForUserOutput struct {
+type GetDatasetsForUserByIDOutput struct {
 	datasets []*upload.Upload
 	err      error
 }
 
-type GetDatasetOutput struct {
+type GetDatasetByIDOutput struct {
 	dataset *upload.Upload
 	err     error
 }
 
 type TestDataStoreSession struct {
-	GetDatasetsForUserInputs  []GetDatasetsForUserInput
-	GetDatasetsForUserOutputs []GetDatasetsForUserOutput
-	GetDatasetInputs          []string
-	GetDatasetOutputs         []GetDatasetOutput
-	DeleteDatasetInputs       []*upload.Upload
-	DeleteDatasetOutputs      []error
-	DeleteDataForUserInputs   []string
-	DeleteDataForUserOutputs  []error
+	GetDatasetsForUserByIDInputs  []GetDatasetsForUserByIDInput
+	GetDatasetsForUserByIDOutputs []GetDatasetsForUserByIDOutput
+	GetDatasetByIDInputs          []string
+	GetDatasetByIDOutputs         []GetDatasetByIDOutput
+	DeleteDatasetInputs           []*upload.Upload
+	DeleteDatasetOutputs          []error
+	DestroyDataForUserByIDInputs  []string
+	DestroyDataForUserByIDOutputs []error
 }
 
 func (t *TestDataStoreSession) IsClosed() bool {
@@ -150,17 +150,17 @@ func (t *TestDataStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) GetDatasetsForUser(userID string, filter *dataStore.Filter, pagination *dataStore.Pagination) ([]*upload.Upload, error) {
-	t.GetDatasetsForUserInputs = append(t.GetDatasetsForUserInputs, GetDatasetsForUserInput{userID, filter, pagination})
-	output := t.GetDatasetsForUserOutputs[0]
-	t.GetDatasetsForUserOutputs = t.GetDatasetsForUserOutputs[1:]
+func (t *TestDataStoreSession) GetDatasetsForUserByID(userID string, filter *dataStore.Filter, pagination *dataStore.Pagination) ([]*upload.Upload, error) {
+	t.GetDatasetsForUserByIDInputs = append(t.GetDatasetsForUserByIDInputs, GetDatasetsForUserByIDInput{userID, filter, pagination})
+	output := t.GetDatasetsForUserByIDOutputs[0]
+	t.GetDatasetsForUserByIDOutputs = t.GetDatasetsForUserByIDOutputs[1:]
 	return output.datasets, output.err
 }
 
-func (t *TestDataStoreSession) GetDataset(datasetID string) (*upload.Upload, error) {
-	t.GetDatasetInputs = append(t.GetDatasetInputs, datasetID)
-	output := t.GetDatasetOutputs[0]
-	t.GetDatasetOutputs = t.GetDatasetOutputs[1:]
+func (t *TestDataStoreSession) GetDatasetByID(datasetID string) (*upload.Upload, error) {
+	t.GetDatasetByIDInputs = append(t.GetDatasetByIDInputs, datasetID)
+	output := t.GetDatasetByIDOutputs[0]
+	t.GetDatasetByIDOutputs = t.GetDatasetByIDOutputs[1:]
 	return output.dataset, output.err
 }
 
@@ -191,20 +191,22 @@ func (t *TestDataStoreSession) DeleteOtherDatasetData(dataset *upload.Upload) er
 	panic("Unexpected invocation of DeleteOtherDatasetData on TestDataStoreSession")
 }
 
-func (t *TestDataStoreSession) DeleteDataForUser(userID string) error {
-	t.DeleteDataForUserInputs = append(t.DeleteDataForUserInputs, userID)
-	output := t.DeleteDataForUserOutputs[0]
-	t.DeleteDataForUserOutputs = t.DeleteDataForUserOutputs[1:]
+func (t *TestDataStoreSession) DestroyDataForUserByID(userID string) error {
+	t.DestroyDataForUserByIDInputs = append(t.DestroyDataForUserByIDInputs, userID)
+	output := t.DestroyDataForUserByIDOutputs[0]
+	t.DestroyDataForUserByIDOutputs = t.DestroyDataForUserByIDOutputs[1:]
 	return output
 }
 
 func (t *TestDataStoreSession) ValidateTest() bool {
-	return len(t.GetDatasetsForUserOutputs) == 0 &&
-		len(t.GetDatasetOutputs) == 0 &&
+	return len(t.GetDatasetsForUserByIDOutputs) == 0 &&
+		len(t.GetDatasetByIDOutputs) == 0 &&
 		len(t.DeleteDatasetOutputs) == 0
 }
 
 type TestTaskStoreSession struct {
+	DestroyTasksForUserByIDInputs  []string
+	DestroyTasksForUserByIDOutputs []error
 }
 
 func (t *TestTaskStoreSession) IsClosed() bool {
@@ -219,8 +221,15 @@ func (t *TestTaskStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestTaskStoreSession")
 }
 
+func (t *TestTaskStoreSession) DestroyTasksForUserByID(userID string) error {
+	t.DestroyTasksForUserByIDInputs = append(t.DestroyTasksForUserByIDInputs, userID)
+	output := t.DestroyTasksForUserByIDOutputs[0]
+	t.DestroyTasksForUserByIDOutputs = t.DestroyTasksForUserByIDOutputs[1:]
+	return output
+}
+
 func (t *TestTaskStoreSession) ValidateTest() bool {
-	return true
+	return len(t.DestroyTasksForUserByIDOutputs) == 0
 }
 
 type TestAuthenticationDetails struct {

--- a/dataservices/service/service/standard.go
+++ b/dataservices/service/service/standard.go
@@ -218,7 +218,7 @@ func (s *Standard) initializeTaskStore() error {
 	if err := s.ConfigLoader().Load("task_store", taskStoreConfig); err != nil {
 		return app.ExtError(err, "service", "unable to load task store config")
 	}
-	taskStoreConfig.Collection = "deviceData"
+	taskStoreConfig.Collection = "syncTasks"
 
 	s.Logger().Debug("Creating task store")
 

--- a/task/store/mongo/mongo.go
+++ b/task/store/mongo/mongo.go
@@ -11,6 +11,11 @@ package mongo
  */
 
 import (
+	"time"
+
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/store/mongo"
 	"github.com/tidepool-org/platform/task/store"
@@ -44,4 +49,30 @@ func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
 
 type Session struct {
 	*mongo.Session
+}
+
+func (s *Session) DestroyTasksForUserByID(userID string) error {
+	if userID == "" {
+		return app.Error("mongo", "user id is missing")
+	}
+
+	if s.IsClosed() {
+		return app.Error("mongo", "session closed")
+	}
+
+	startTime := time.Now()
+
+	selector := bson.M{
+		"_userId": userID,
+	}
+	removeInfo, err := s.C().RemoveAll(selector)
+
+	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyTasksForUserByID")
+
+	if err != nil {
+		return app.ExtError(err, "mongo", "unable to destroy tasks for user by id")
+	}
+
+	return nil
 }

--- a/task/store/mongo/mongo_test.go
+++ b/task/store/mongo/mongo_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/log"
@@ -15,6 +16,33 @@ import (
 	"github.com/tidepool-org/platform/task/store/mongo"
 	testMongo "github.com/tidepool-org/platform/test/mongo"
 )
+
+func NewTasksForUserByID(userID string) []interface{} {
+	tasks := []interface{}{}
+	for count := 0; count < 3; count++ {
+		task := map[string]interface{}{
+			"_createdTime":  time.Now().UTC().Format(time.RFC3339),
+			"_modifiedTime": time.Now().UTC().Format(time.RFC3339),
+			"_storage": map[string]interface{}{
+				"bucket":     "shovel",
+				"encryption": "none",
+				"key":        "1234567890",
+				"region":     "world",
+				"type":       "aws/s3",
+			},
+			"_userId": userID,
+			"status":  "success",
+		}
+		tasks = append(tasks, task)
+	}
+	return tasks
+}
+
+func ValidateTasks(testMongoCollection *mgo.Collection, selector bson.M, expectedTasks []interface{}) {
+	var actualTasks []interface{}
+	Expect(testMongoCollection.Find(selector).All(&actualTasks)).To(Succeed())
+	Expect(actualTasks).To(HaveLen(len(expectedTasks)))
+}
 
 var _ = Describe("Mongo", func() {
 	var mongoConfig *baseMongo.Config
@@ -100,6 +128,39 @@ var _ = Describe("Mongo", func() {
 					if testMongoSession != nil {
 						testMongoSession.Close()
 					}
+				})
+
+				Context("DestroyTasksForUserByID", func() {
+					var deleteUserID string
+					var deleteTasks []interface{}
+					var otherTasks []interface{}
+
+					BeforeEach(func() {
+						deleteUserID = app.NewID()
+						deleteTasks = NewTasksForUserByID(deleteUserID)
+						Expect(testMongoCollection.Insert(deleteTasks...)).To(Succeed())
+						otherTasks = NewTasksForUserByID(app.NewID())
+						Expect(testMongoCollection.Insert(otherTasks...)).To(Succeed())
+					})
+
+					It("succeeds if it successfully removes tasks", func() {
+						Expect(mongoSession.DestroyTasksForUserByID(deleteUserID)).To(Succeed())
+					})
+
+					It("returns an error if the user id is missing", func() {
+						Expect(mongoSession.DestroyTasksForUserByID("")).To(MatchError("mongo: user id is missing"))
+					})
+
+					It("returns an error if the session is closed", func() {
+						mongoSession.Close()
+						Expect(mongoSession.DestroyTasksForUserByID(deleteUserID)).To(MatchError("mongo: session closed"))
+					})
+
+					It("has the correct stored tasks", func() {
+						ValidateTasks(testMongoCollection, bson.M{}, append(otherTasks, deleteTasks...))
+						Expect(mongoSession.DestroyTasksForUserByID(deleteUserID)).To(Succeed())
+						ValidateTasks(testMongoCollection, bson.M{}, otherTasks)
+					})
 				})
 			})
 		})

--- a/task/store/store.go
+++ b/task/store/store.go
@@ -23,4 +23,6 @@ type Store interface {
 
 type Session interface {
 	store.Session
+
+	DestroyTasksForUserByID(userID string) error
 }


### PR DESCRIPTION
@jh-bate Rather than creating a separate endpoint for destroying tasks, I just piggy-backed it on to destroying data. Tasks (or data syncTasks) need to be generalized into either a "background job" mechanism or a message/event based system.

Also, for all store functions that operate on an object id, I changed the function name to have the "ByID" suffix so it is clear and consistent what the function does.