### PR TITLE
GetDatasetByID returns nil (rather than error) if dataset not found

### DIFF
--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -304,9 +304,9 @@ var _ = Describe("Mongo", func() {
 						Expect(resultDataset).To(BeNil())
 					})
 
-					It("returns an error if the dataset cannot be found", func() {
+					It("returns no dataset successfully if the dataset cannot be found", func() {
 						resultDataset, err := mongoSession.GetDatasetByID("not-found")
-						Expect(err).To(MatchError("mongo: unable to get dataset by id; not found"))
+						Expect(err).ToNot(HaveOccurred())
 						Expect(resultDataset).To(BeNil())
 					})
 				})
@@ -851,7 +851,7 @@ var _ = Describe("Mongo", func() {
 							Expect(mongoSession.CreateDatasetData(deleteDataset, deleteDatasetData)).To(Succeed())
 						})
 
-						It("succeeds if it successfully removes all other dataset data", func() {
+						It("succeeds if it successfully removes all data", func() {
 							Expect(mongoSession.DestroyDataForUserByID(deleteUserID)).To(Succeed())
 						})
 

--- a/dataservices/service/api/v1/datasets_data_create.go
+++ b/dataservices/service/api/v1/datasets_data_create.go
@@ -33,6 +33,10 @@ func DatasetsDataCreate(serviceContext service.Context) {
 
 	dataset, err := serviceContext.DataStoreSession().GetDatasetByID(datasetID)
 	if err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to get dataset by id", err)
+		return
+	}
+	if dataset == nil {
 		serviceContext.RespondWithError(ErrorDatasetIDNotFound(datasetID))
 		return
 	}

--- a/dataservices/service/api/v1/datasets_delete.go
+++ b/dataservices/service/api/v1/datasets_delete.go
@@ -27,6 +27,10 @@ func DatasetsDelete(serviceContext service.Context) {
 
 	dataset, err := serviceContext.DataStoreSession().GetDatasetByID(datasetID)
 	if err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to get dataset by id", err)
+		return
+	}
+	if dataset == nil {
 		serviceContext.RespondWithError(ErrorDatasetIDNotFound(datasetID))
 		return
 	}

--- a/dataservices/service/api/v1/datasets_delete_test.go
+++ b/dataservices/service/api/v1/datasets_delete_test.go
@@ -130,7 +130,21 @@ var _ = Describe("DatasetsDelete", func() {
 		})
 
 		It("responds with error if data store session get dataset returns error", func() {
-			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{{nil, errors.New("other")}}
+			err := errors.New("other")
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{{nil, err}}
+			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
+			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
+			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to get dataset by id", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if data store session get dataset returns no dataset", func() {
+			context.DataStoreSessionImpl.GetDatasetByIDOutputs = []GetDatasetByIDOutput{{nil, nil}}
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}

--- a/dataservices/service/api/v1/datasets_update.go
+++ b/dataservices/service/api/v1/datasets_update.go
@@ -27,6 +27,10 @@ func DatasetsUpdate(serviceContext service.Context) {
 
 	dataset, err := serviceContext.DataStoreSession().GetDatasetByID(datasetID)
 	if err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to get dataset by id", err)
+		return
+	}
+	if dataset == nil {
 		serviceContext.RespondWithError(ErrorDatasetIDNotFound(datasetID))
 		return
 	}

--- a/tools/tapi/cmd/common.go
+++ b/tools/tapi/cmd/common.go
@@ -79,9 +79,9 @@ func wrapCommands(commands cli.Commands) cli.Commands {
 func wrapCommand(command cli.Command) cli.Command {
 	command.Before = wrapCommandFunc(command.Before)
 	command.After = wrapCommandFunc(command.After)
-	if actionFunc, actionOK := command.Action.(cli.ActionFunc); actionOK {
+	if actionFunc, actionOk := command.Action.(cli.ActionFunc); actionOk {
 		command.Action = wrapCommandFunc(actionFunc)
-	} else if commandFunc, commandOK := command.Action.(func(*cli.Context) error); commandOK {
+	} else if commandFunc, commandOk := command.Action.(func(*cli.Context) error); commandOk {
 		command.Action = wrapCommandFunc(commandFunc)
 	}
 	command.Subcommands = wrapCommands(command.Subcommands)


### PR DESCRIPTION
@jh-bate Per our Slack conversation, all Get(Object)ByID store functions (that intend to return a single object) now return nil for the object (and no error) if the object doesn't exist.

Also, removed all usage of the `One` mgo function as it returns error if there is no object. Instead, use the `All` function with `Limit(2)` to handle 0, 1, or > 1 objects in existence. If 0, then returns nil; if 1, then returns the object; if > 1, then returns the object and warns about multiples for the same id. (In a perfect world, where we had a unique index on the object ids, this could never happen, but we aren't there yet. ;) )