### PR TITLE
Clinic accounts should not be able to be deleted

### DIFF
--- a/app/string.go
+++ b/app/string.go
@@ -41,3 +41,12 @@ func QuoteIfString(interfaceValue interface{}) interface{} {
 	}
 	return interfaceValue
 }
+
+func StringArrayContains(sourceStrings []string, searchString string) bool {
+	for _, sourceString := range sourceStrings {
+		if sourceString == searchString {
+			return true
+		}
+	}
+	return false
+}

--- a/app/string_test.go
+++ b/app/string_test.go
@@ -65,4 +65,18 @@ var _ = Describe("String", func() {
 			Entry("is a map", map[string]string{"a": "b"}, map[string]string{"a": "b"}),
 		)
 	})
+
+	DescribeTable("StringArrayContains",
+		func(sourceStrings []string, searchString string, expectedResult bool) {
+			Expect(app.StringArrayContains(sourceStrings, searchString)).To(Equal(expectedResult))
+		},
+		Entry("is an empty source array with empty search string", []string{}, "", false),
+		Entry("is an empty source array with valid search string", []string{}, "one", false),
+		Entry("is an single source array with empty search string", []string{"two"}, "", false),
+		Entry("is an single source array with non-matching search string", []string{"two"}, "one", false),
+		Entry("is an single source array with matching search string", []string{"two"}, "two", true),
+		Entry("is an multiple source array with empty search string", []string{"zero", "two", "four"}, "", false),
+		Entry("is an multiple source array with non-matching search string", []string{"zero", "two", "four"}, "one", false),
+		Entry("is an multiple source array with matching search string", []string{"zero", "two", "four"}, "two", true),
+	)
 })

--- a/tools/tapi/api/auth.go
+++ b/tools/tapi/api/auth.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/tidepool-org/platform/user"
 )
 
 type (
@@ -31,7 +33,7 @@ func (a *API) ServerLogin() error {
 		responseFuncs{a.expectStatusCode(http.StatusOK), a.storeTidepoolSession(true)}))
 }
 
-func (a *API) Login(email string, password string) (*User, error) {
+func (a *API) Login(email string, password string) (*user.User, error) {
 	if email == "" {
 		return nil, errors.New("Email is missing")
 	}

--- a/tools/tapi/cmd/user.go
+++ b/tools/tapi/cmd/user.go
@@ -16,6 +16,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/tidepool-org/platform/tools/tapi/api"
+	"github.com/tidepool-org/platform/user"
 )
 
 const (
@@ -113,7 +114,7 @@ func UserCommands() cli.Commands {
 }
 
 func userGet(c *cli.Context) error {
-	var user *api.User
+	var user *user.User
 	var err error
 
 	email := c.String(EmailFlag)
@@ -165,12 +166,12 @@ func userAddRoles(c *cli.Context) error {
 		return err
 	}
 
-	user, err := API(c).ApplyUpdatersToUserByID(c.String(UserIDFlag), []api.UserUpdater{updater})
+	updateUser, err := API(c).ApplyUpdatersToUserByID(c.String(UserIDFlag), []api.UserUpdater{updater})
 	if err != nil {
 		return err
 	}
 
-	return reportMessageWithJSON(c, user)
+	return reportMessageWithJSON(c, updateUser)
 }
 
 func userRemoveRoles(c *cli.Context) error {
@@ -179,12 +180,12 @@ func userRemoveRoles(c *cli.Context) error {
 		return err
 	}
 
-	user, err := API(c).ApplyUpdatersToUserByID(c.String(UserIDFlag), []api.UserUpdater{updater})
+	updateUser, err := API(c).ApplyUpdatersToUserByID(c.String(UserIDFlag), []api.UserUpdater{updater})
 	if err != nil {
 		return err
 	}
 
-	return reportMessageWithJSON(c, user)
+	return reportMessageWithJSON(c, updateUser)
 }
 
 func userDelete(c *cli.Context) error {

--- a/user/role.go
+++ b/user/role.go
@@ -1,0 +1,13 @@
+package user
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+const ClinicRole string = "clinic"

--- a/user/role_test.go
+++ b/user/role_test.go
@@ -1,0 +1,16 @@
+package user_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/user"
+)
+
+var _ = Describe("Role", func() {
+	Context("ClinicRole", func() {
+		It("exists", func() {
+			Expect(user.ClinicRole).To(Equal("clinic"))
+		})
+	})
+})

--- a/user/store/mongo/mongo_test.go
+++ b/user/store/mongo/mongo_test.go
@@ -39,7 +39,7 @@ func NewUser(userID string) *user.User {
 		ID:                userID,
 		Email:             email,
 		Emails:            []string{email},
-		Roles:             []string{"clinic"},
+		Roles:             []string{user.ClinicRole},
 		TermsAcceptedTime: time.Now().UTC().Format(time.RFC3339),
 		EmailVerified:     true,
 		PasswordHash:      "1234567890",

--- a/user/user.go
+++ b/user/user.go
@@ -10,6 +10,8 @@ package user
  * [ ] Full test coverage
  */
 
+import "github.com/tidepool-org/platform/app"
+
 type User struct {
 	ID                string             `json:"userid,omitempty" bson:"userid,omitempty"`
 	Email             string             `json:"username,omitempty" bson:"username,omitempty"`
@@ -33,4 +35,8 @@ type User struct {
 type IDHash struct {
 	ID   string `json:"id"`
 	Hash string `json:"hash"`
+}
+
+func (u *User) HasRole(userRole string) bool {
+	return app.StringArrayContains(u.Roles, userRole)
 }

--- a/user/user_suite_test.go
+++ b/user/user_suite_test.go
@@ -1,0 +1,13 @@
+package user_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "user")
+}

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -1,0 +1,30 @@
+package user_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/user"
+)
+
+var _ = Describe("User", func() {
+	DescribeTable("HasRole",
+		func(roles []string, role string, expectedResult bool) {
+			testUser := &user.User{
+				Roles: roles,
+			}
+			Expect(testUser.HasRole(role)).To(Equal(expectedResult))
+		},
+		Entry("roles is nil, role is empty", nil, "", false),
+		Entry("roles is nil, role is specified", nil, user.ClinicRole, false),
+		Entry("roles is empty, role is empty", []string{}, "", false),
+		Entry("roles is empty, role is specified", []string{}, user.ClinicRole, false),
+		Entry("roles has one, role is empty", []string{user.ClinicRole}, "", false),
+		Entry("roles has one, role is specified, not in roles", []string{user.ClinicRole}, "unknown", false),
+		Entry("roles has one, role is specified, in roles", []string{user.ClinicRole}, user.ClinicRole, true),
+		Entry("roles has many, role is empty", []string{"administrator", user.ClinicRole, "manager"}, "", false),
+		Entry("roles has many, role is specified, not in roles", []string{"administrator", user.ClinicRole, "manager"}, "unknown", false),
+		Entry("roles has many, role is specified, in roles", []string{"administrator", user.ClinicRole, "manager"}, user.ClinicRole, true),
+	)
+})

--- a/userservices/service/api/v1/users_delete.go
+++ b/userservices/service/api/v1/users_delete.go
@@ -16,6 +16,7 @@ import (
 	messageStore "github.com/tidepool-org/platform/message/store"
 	"github.com/tidepool-org/platform/profile"
 	commonService "github.com/tidepool-org/platform/service"
+	"github.com/tidepool-org/platform/user"
 	"github.com/tidepool-org/platform/userservices/client"
 	"github.com/tidepool-org/platform/userservices/service"
 )
@@ -65,6 +66,11 @@ func UsersDelete(serviceContext service.Context) {
 	}
 	if targetUser == nil {
 		serviceContext.RespondWithError(ErrorUserIDNotFound(targetUserID))
+		return
+	}
+
+	if targetUser.HasRole(user.ClinicRole) {
+		serviceContext.RespondWithError(commonService.ErrorUnauthorized())
 		return
 	}
 


### PR DESCRIPTION
@jh-bate Per discussion with Brandon and Howard, we don't want to accidentally delete a clinic account (as it would create a whole range of complicated issues). Therefore, I updated the code to prevent this. If a clinic account really needs to be deleted, then we'll have to delete all of the custodial accounts first, remove the clinic role, and then delete the account.