### PR TITLE
Clean log statements; use camelCase for keys; only report ids, not objects

### DIFF
--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -85,7 +85,7 @@ func (s *Session) GetDatasetsForUserByID(userID string, filter *store.Filter, pa
 	}
 	err := s.C().Find(selector).Sort("-createdTime").Skip(pagination.Page * pagination.Size).Limit(pagination.Size).All(&datasets)
 
-	loggerFields := log.Fields{"userID": userID, "datasets-count": len(datasets), "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "count": len(datasets), "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetDatasetsForUserByID")
 
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	}
 	err := s.C().Find(selector).Limit(2).All(&datasets)
 
-	loggerFields := log.Fields{"datasetID": datasetID, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"datasetId": datasetID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetDatasetByID")
 
 	if err != nil {
@@ -126,7 +126,7 @@ func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	if datasetsCount := len(datasets); datasetsCount == 0 {
 		return nil, nil
 	} else if datasetsCount > 1 {
-		s.Logger().WithField("datasetID", datasetID).Warn("Multiple datasets found for dataset id")
+		s.Logger().WithField("datasetId", datasetID).Warn("Multiple datasets found for dataset id")
 	}
 
 	return datasets[0], nil
@@ -174,7 +174,7 @@ func (s *Session) CreateDataset(dataset *upload.Upload) error {
 		}
 	}
 
-	loggerFields := log.Fields{"dataset": dataset, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": dataset.UserID, "datasetId": dataset.UploadID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("CreateDataset")
 
 	if err != nil {
@@ -214,7 +214,7 @@ func (s *Session) UpdateDataset(dataset *upload.Upload) error {
 	}
 	err := s.C().Update(selector, dataset)
 
-	loggerFields := log.Fields{"dataset": dataset, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"datasetId": dataset.UploadID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("UpdateDataset")
 
 	if err != nil {
@@ -278,7 +278,7 @@ func (s *Session) DeleteDataset(dataset *upload.Upload) error {
 		updateInfo, err = s.C().UpdateAll(selector, update)
 	}
 
-	loggerFields := log.Fields{"datasetID": dataset.UploadID, "remove-info": removeInfo, "update-info": updateInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"datasetId": dataset.UploadID, "removeInfo": removeInfo, "updateInfo": updateInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DeleteDataset")
 
 	if err != nil {
@@ -332,7 +332,7 @@ func (s *Session) CreateDatasetData(dataset *upload.Upload, datasetData []data.D
 
 	_, err := bulk.Run()
 
-	loggerFields := log.Fields{"dataset": dataset, "dataset-data-length": len(datasetData), "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"datasetId": dataset.UploadID, "count": len(datasetData), "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("CreateDatasetData")
 
 	if err != nil {
@@ -381,7 +381,7 @@ func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 	}
 	updateInfo, err := s.C().UpdateAll(selector, update)
 
-	loggerFields := log.Fields{"dataset": dataset, "update-info": updateInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"datasetId": dataset.UploadID, "updateInfo": updateInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("ActivateDatasetData")
 
 	if err != nil {
@@ -454,7 +454,7 @@ func (s *Session) DeleteOtherDatasetData(dataset *upload.Upload) error {
 		updateInfo, err = s.C().UpdateAll(selector, update)
 	}
 
-	loggerFields := log.Fields{"dataset": dataset, "remove-info": removeInfo, "update-info": updateInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"datasetId": dataset.UploadID, "removeInfo": removeInfo, "updateInfo": updateInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DeleteOtherDatasetData")
 
 	if err != nil {
@@ -479,7 +479,7 @@ func (s *Session) DestroyDataForUserByID(userID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyDataForUserByID")
 
 	if err != nil {

--- a/dataservices/client/standard.go
+++ b/dataservices/client/standard.go
@@ -55,7 +55,7 @@ func (s *Standard) DestroyDataForUserByID(context Context, userID string) error 
 		return app.Error("client", "user id is missing")
 	}
 
-	context.Logger().WithField("user-id", userID).Debug("Deleting data for user")
+	context.Logger().WithField("userId", userID).Debug("Deleting data for user")
 
 	return s.sendRequest(context, "DELETE", s.buildURL("dataservices", "v1", "users", userID, "data"))
 }

--- a/log/null_test.go
+++ b/log/null_test.go
@@ -49,19 +49,19 @@ var _ = Describe("Null", func() {
 
 			Context("WithError", func() {
 				It("returns a logger", func() {
-					Expect(logger.WithError(errors.New("test-error"))).ToNot(BeNil())
+					Expect(logger.WithError(errors.New("test error"))).ToNot(BeNil())
 				})
 			})
 
 			Context("WithField", func() {
 				It("returns a logger", func() {
-					Expect(logger.WithField("test-key", "test-value")).ToNot(BeNil())
+					Expect(logger.WithField("testKey", "test value")).ToNot(BeNil())
 				})
 			})
 
 			Context("WithFields", func() {
 				It("returns a logger", func() {
-					Expect(logger.WithFields(log.Fields{"test-key": "test-value"})).ToNot(BeNil())
+					Expect(logger.WithFields(log.Fields{"testKey": "test value"})).ToNot(BeNil())
 				})
 			})
 		})

--- a/message/store/mongo/mongo.go
+++ b/message/store/mongo/mongo.go
@@ -80,7 +80,7 @@ func (s *Session) DeleteMessagesFromUser(user *store.User) error {
 	}
 	changeInfo, err := s.C().UpdateAll(selector, update)
 
-	loggerFields := log.Fields{"userID": user.ID, "change-info": changeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": user.ID, "changeInfo": changeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DeleteMessagesFromUser")
 
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *Session) DestroyMessagesForUserByID(userID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyMessagesForUserByID")
 
 	if err != nil {

--- a/notification/store/mongo/mongo.go
+++ b/notification/store/mongo/mongo.go
@@ -70,7 +70,7 @@ func (s *Session) DestroyNotificationsForUserByID(userID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyNotificationsForUserByID")
 
 	if err != nil {

--- a/permission/store/mongo/mongo.go
+++ b/permission/store/mongo/mongo.go
@@ -89,7 +89,7 @@ func (s *Session) DestroyPermissionsForUserByID(userID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyPermissionsForUserByID")
 
 	if err != nil {

--- a/profile/store/mongo/mongo.go
+++ b/profile/store/mongo/mongo.go
@@ -70,7 +70,7 @@ func (s *Session) GetProfileByID(profileID string) (*profile.Profile, error) {
 	}
 	err := s.C().Find(selector).Limit(2).All(&profiles)
 
-	loggerFields := log.Fields{"profileID": profileID, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"profileId": profileID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetProfileByID")
 
 	if err != nil {
@@ -80,7 +80,7 @@ func (s *Session) GetProfileByID(profileID string) (*profile.Profile, error) {
 	if profilesCount := len(profiles); profilesCount == 0 {
 		return nil, nil
 	} else if profilesCount > 1 {
-		s.Logger().WithField("profileID", profileID).Warn("Multiple profiles found for profile id")
+		s.Logger().WithField("profileId", profileID).Warn("Multiple profiles found for profile id")
 	}
 
 	profile := profiles[0]
@@ -89,7 +89,7 @@ func (s *Session) GetProfileByID(profileID string) (*profile.Profile, error) {
 	if profile.Value != "" {
 		var value map[string]interface{}
 		if err = json.Unmarshal([]byte(profile.Value), &value); err != nil {
-			s.Logger().WithField("profileID", profileID).WithError(err).Warn("Unable to unmarshal profile value")
+			s.Logger().WithField("profileId", profileID).WithError(err).Warn("Unable to unmarshal profile value")
 		} else {
 			if profileMap, profileMapOk := value["profile"].(map[string]interface{}); profileMapOk {
 				if fullName, fullNameOk := profileMap["fullName"].(string); fullNameOk {
@@ -118,7 +118,7 @@ func (s *Session) DestroyProfileByID(profileID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"profileID": profileID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"profileId": profileID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyProfileByID")
 
 	if err != nil {

--- a/session/store/mongo/mongo.go
+++ b/session/store/mongo/mongo.go
@@ -67,7 +67,7 @@ func (s *Session) DestroySessionsForUserByID(userID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroySessionsForUserByID")
 
 	if err != nil {

--- a/task/store/mongo/mongo.go
+++ b/task/store/mongo/mongo.go
@@ -67,7 +67,7 @@ func (s *Session) DestroyTasksForUserByID(userID string) error {
 	}
 	removeInfo, err := s.C().RemoveAll(selector)
 
-	loggerFields := log.Fields{"userID": userID, "remove-info": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "removeInfo": removeInfo, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyTasksForUserByID")
 
 	if err != nil {

--- a/user/store/mongo/mongo.go
+++ b/user/store/mongo/mongo.go
@@ -84,7 +84,7 @@ func (s *Session) GetUserByID(userID string) (*user.User, error) {
 	}
 	err := s.C().Find(selector).Limit(2).All(&users)
 
-	loggerFields := log.Fields{"userID": userID, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("GetUserByID")
 
 	if err != nil {
@@ -94,7 +94,7 @@ func (s *Session) GetUserByID(userID string) (*user.User, error) {
 	if usersCount := len(users); usersCount == 0 {
 		return nil, nil
 	} else if usersCount > 1 {
-		s.Logger().WithField("userID", userID).Warn("Multiple users found for user id")
+		s.Logger().WithField("userId", userID).Warn("Multiple users found for user id")
 	}
 
 	user := users[0]
@@ -128,7 +128,7 @@ func (s *Session) DeleteUser(user *user.User) error {
 	}
 	err := s.C().Update(selector, user)
 
-	loggerFields := log.Fields{"userID": user.ID, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": user.ID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DeleteUser")
 
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *Session) DestroyUserByID(userID string) error {
 	}
 	err := s.C().Remove(selector)
 
-	loggerFields := log.Fields{"userID": userID, "duration": time.Since(startTime) / time.Microsecond}
+	loggerFields := log.Fields{"userId": userID, "duration": time.Since(startTime) / time.Microsecond}
 	s.Logger().WithFields(loggerFields).WithError(err).Debug("DestroyUserByID")
 
 	if err != nil {

--- a/userservices/client/standard.go
+++ b/userservices/client/standard.go
@@ -121,7 +121,7 @@ func (s *Standard) ValidateAuthenticationToken(context service.Context, authenti
 		return nil, app.Error("client", "client is closed")
 	}
 
-	context.Logger().WithField("authentication-token", authenticationToken).Debug("Validating authentication token")
+	context.Logger().WithField("authenticationToken", authenticationToken).Debug("Validating authentication token")
 
 	var authentication struct {
 		IsServer bool
@@ -158,7 +158,7 @@ func (s *Standard) GetUserPermissions(context service.Context, requestUserID str
 		return nil, app.Error("client", "client is closed")
 	}
 
-	context.Logger().WithFields(log.Fields{"request-user-id": requestUserID, "target-user-id": targetUserID}).Debug("Get user permissions")
+	context.Logger().WithFields(log.Fields{"requestUserId": requestUserID, "targetUserId": targetUserID}).Debug("Get user permissions")
 
 	permissions := Permissions{}
 	if err := s.sendRequest(context, "GET", s.buildURL("access", targetUserID, requestUserID), &permissions); err != nil {
@@ -195,7 +195,7 @@ func (s *Standard) GetUserGroupID(context service.Context, userID string) (strin
 		return "", app.Error("client", "client is closed")
 	}
 
-	context.Logger().WithField("user-id", userID).Debug("Getting user group id")
+	context.Logger().WithField("userId", userID).Debug("Getting user group id")
 
 	var uploadsPair struct {
 		ID    string


### PR DESCRIPTION
@jh-bate Quick cleanup of logs for consistency. I noticed this while adding new log statements.  Use camelCase for keys since this is our JSON standard. Do not write full objects to log as it may contain user data, only write object ids.