### PR TITLE
Upload data type improvements

### DIFF
--- a/data/datum.go
+++ b/data/datum.go
@@ -29,4 +29,7 @@ type Datum interface {
 	SetModifiedUserID(modifiedUserID string)
 	SetDeletedTime(deletedTime string)
 	SetDeletedUserID(deletedUserID string)
+
+	DeduplicatorDescriptor() *DeduplicatorDescriptor
+	SetDeduplicatorDescriptor(deduplicatorDescriptor *DeduplicatorDescriptor)
 }

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -1,0 +1,22 @@
+package data
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+type Deduplicator interface {
+	InitializeDataset() error
+	AddDataToDataset(datasetData []Datum) error
+	FinalizeDataset() error
+}
+
+type DeduplicatorDescriptor struct {
+	Name string `bson:"name,omitempty"`
+	Hash string `bson:"hash,omitempty"`
+}

--- a/data/deduplicator/delegate.go
+++ b/data/deduplicator/delegate.go
@@ -12,6 +12,7 @@ package deduplicator
 
 import (
 	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/base/upload"
 	"github.com/tidepool-org/platform/log"
@@ -46,7 +47,7 @@ func (d *DelegateFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, e
 	return false, nil
 }
 
-func (d *DelegateFactory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (Deduplicator, error) {
+func (d *DelegateFactory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
 	if logger == nil {
 		return nil, app.Error("deduplicator", "logger is missing")
 	}

--- a/data/deduplicator/factory.go
+++ b/data/deduplicator/factory.go
@@ -17,13 +17,7 @@ import (
 	"github.com/tidepool-org/platform/log"
 )
 
-type Deduplicator interface {
-	InitializeDataset() error
-	AddDataToDataset(datasetData []data.Datum) error
-	FinalizeDataset() error
-}
-
 type Factory interface {
 	CanDeduplicateDataset(dataset *upload.Upload) (bool, error)
-	NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (Deduplicator, error)
+	NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
 }

--- a/data/deduplicator/test/factory.go
+++ b/data/deduplicator/test/factory.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/deduplicator"
+	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/base/upload"
 	"github.com/tidepool-org/platform/log"
@@ -19,7 +19,7 @@ type NewDeduplicatorInput struct {
 }
 
 type NewDeduplicatorOutput struct {
-	Deduplicator deduplicator.Deduplicator
+	Deduplicator data.Deduplicator
 	Error        error
 }
 
@@ -46,7 +46,7 @@ func (f *Factory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
 	return output.Can, output.Error
 }
 
-func (f *Factory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (deduplicator.Deduplicator, error) {
+func (f *Factory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
 	f.NewDeduplicatoInvocations++
 
 	f.NewDeduplicatorInputs = append(f.NewDeduplicatorInputs, NewDeduplicatorInput{logger, dataStoreSession, dataset})

--- a/data/deduplicator/truncate.go
+++ b/data/deduplicator/truncate.go
@@ -20,8 +20,7 @@ import (
 	"github.com/tidepool-org/platform/log"
 )
 
-type TruncateFactory struct {
-}
+type TruncateFactory struct{}
 
 type TruncateDeduplicator struct {
 	logger           log.Logger
@@ -59,7 +58,7 @@ func (t *TruncateFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, e
 	return true, nil
 }
 
-func (t *TruncateFactory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (Deduplicator, error) {
+func (t *TruncateFactory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
 	if logger == nil {
 		return nil, app.Error("deduplicator", "logger is missing")
 	}
@@ -99,7 +98,7 @@ func (t *TruncateFactory) NewDeduplicator(logger log.Logger, dataStoreSession st
 }
 
 func (t *TruncateDeduplicator) InitializeDataset() error {
-	t.dataset.Deduplicator = &upload.Deduplicator{Name: TruncateDeduplicatorName}
+	t.dataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: TruncateDeduplicatorName})
 
 	if err := t.dataStoreSession.UpdateDataset(t.dataset); err != nil {
 		return app.ExtError(err, "deduplicator", "unable to initialize dataset")

--- a/data/deduplicator/truncate_test.go
+++ b/data/deduplicator/truncate_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Truncate", func() {
 
 			Context("with deduplicator", func() {
 				BeforeEach(func() {
-					testDataset.Deduplicator = &upload.Deduplicator{}
+					testDataset.Deduplicator = &data.DeduplicatorDescriptor{}
 				})
 
 				It("returns false if the deduplicator name is missing", func() {
@@ -202,7 +202,7 @@ var _ = Describe("Truncate", func() {
 
 		Context("with a new deduplicator", func() {
 			var testDataStoreSession *testDataStore.Session
-			var testTruncateDeduplicator deduplicator.Deduplicator
+			var testTruncateDeduplicator data.Deduplicator
 
 			BeforeEach(func() {
 				var err error
@@ -233,7 +233,7 @@ var _ = Describe("Truncate", func() {
 				It("sets the dataset deduplicator if there is no error", func() {
 					testDataStoreSession.UpdateDatasetOutputs = []error{nil}
 					Expect(testTruncateDeduplicator.InitializeDataset()).To(Succeed())
-					Expect(testDataset.Deduplicator).To(Equal(&upload.Deduplicator{Name: "truncate"}))
+					Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: "truncate"}))
 					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
 				})
 			})

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -393,9 +393,9 @@ var _ = Describe("Mongo", func() {
 						Expect(testMongoCollection.Insert(dataset)).To(Succeed())
 					})
 
-					Context("with data state closed", func() {
+					Context("with state closed", func() {
 						BeforeEach(func() {
-							dataset.DataState = "closed"
+							dataset.State = "closed"
 						})
 
 						It("succeeds if it successfully updates the dataset", func() {
@@ -433,7 +433,7 @@ var _ = Describe("Mongo", func() {
 					})
 
 					It("sets the modified time", func() {
-						dataset.DataState = "closed"
+						dataset.State = "closed"
 						Expect(mongoSession.UpdateDataset(dataset)).To(Succeed())
 						Expect(dataset.ModifiedTime).ToNot(BeEmpty())
 						Expect(dataset.ModifiedUserID).To(BeEmpty())
@@ -442,7 +442,7 @@ var _ = Describe("Mongo", func() {
 					It("has the correct stored datasets", func() {
 						ValidateDataset(testMongoCollection, bson.M{}, datasetExistingOne, datasetExistingTwo, dataset)
 						ValidateDataset(testMongoCollection, bson.M{"modifiedTime": bson.M{"$exists": true}, "modifiedUserId": bson.M{"$exists": false}})
-						dataset.DataState = "closed"
+						dataset.State = "closed"
 						Expect(mongoSession.UpdateDataset(dataset)).To(Succeed())
 						ValidateDataset(testMongoCollection, bson.M{}, datasetExistingOne, datasetExistingTwo, dataset)
 						ValidateDataset(testMongoCollection, bson.M{"modifiedTime": bson.M{"$exists": true}, "modifiedUserId": bson.M{"$exists": false}}, dataset)
@@ -457,7 +457,7 @@ var _ = Describe("Mongo", func() {
 						})
 
 						It("sets the modified time and modified user id", func() {
-							dataset.DataState = "closed"
+							dataset.State = "closed"
 							Expect(mongoSession.UpdateDataset(dataset)).To(Succeed())
 							Expect(dataset.ModifiedTime).ToNot(BeEmpty())
 							Expect(dataset.ModifiedUserID).To(Equal(agentUserID))
@@ -466,7 +466,7 @@ var _ = Describe("Mongo", func() {
 						It("has the correct stored datasets", func() {
 							ValidateDataset(testMongoCollection, bson.M{}, datasetExistingOne, datasetExistingTwo, dataset)
 							ValidateDataset(testMongoCollection, bson.M{"modifiedTime": bson.M{"$exists": true}, "modifiedUserId": agentUserID})
-							dataset.DataState = "closed"
+							dataset.State = "closed"
 							Expect(mongoSession.UpdateDataset(dataset)).To(Succeed())
 							ValidateDataset(testMongoCollection, bson.M{}, datasetExistingOne, datasetExistingTwo, dataset)
 							ValidateDataset(testMongoCollection, bson.M{"modifiedTime": bson.M{"$exists": true}, "modifiedUserId": agentUserID}, dataset)

--- a/data/test/datum.go
+++ b/data/test/datum.go
@@ -8,38 +8,42 @@ type IdentityFieldsOutput struct {
 }
 
 type Datum struct {
-	InitInvocations              int
-	MetaInvocations              int
-	MetaOutputs                  []interface{}
-	ParseInvocations             int
-	ParseInputs                  []data.ObjectParser
-	ParseOutputs                 []error
-	ValidateInvocations          int
-	ValidateInputs               []data.Validator
-	ValidateOutputs              []error
-	NormalizeInvocations         int
-	NormalizeInputs              []data.Normalizer
-	NormalizeOutputs             []error
-	SetUserIDInvocations         int
-	SetUserIDInputs              []string
-	SetGroupIDInvocations        int
-	SetGroupIDInputs             []string
-	SetDatasetIDInvocations      int
-	SetDatasetIDInputs           []string
-	SetActiveInvocations         int
-	SetActiveInputs              []bool
-	SetCreatedTimeInvocations    int
-	SetCreatedTimeInputs         []string
-	SetCreatedUserIDInvocations  int
-	SetCreatedUserIDInputs       []string
-	SetModifiedTimeInvocations   int
-	SetModifiedTimeInputs        []string
-	SetModifiedUserIDInvocations int
-	SetModifiedUserIDInputs      []string
-	SetDeletedTimeInvocations    int
-	SetDeletedTimeInputs         []string
-	SetDeletedUserIDInvocations  int
-	SetDeletedUserIDInputs       []string
+	InitInvocations                      int
+	MetaInvocations                      int
+	MetaOutputs                          []interface{}
+	ParseInvocations                     int
+	ParseInputs                          []data.ObjectParser
+	ParseOutputs                         []error
+	ValidateInvocations                  int
+	ValidateInputs                       []data.Validator
+	ValidateOutputs                      []error
+	NormalizeInvocations                 int
+	NormalizeInputs                      []data.Normalizer
+	NormalizeOutputs                     []error
+	SetUserIDInvocations                 int
+	SetUserIDInputs                      []string
+	SetGroupIDInvocations                int
+	SetGroupIDInputs                     []string
+	SetDatasetIDInvocations              int
+	SetDatasetIDInputs                   []string
+	SetActiveInvocations                 int
+	SetActiveInputs                      []bool
+	SetCreatedTimeInvocations            int
+	SetCreatedTimeInputs                 []string
+	SetCreatedUserIDInvocations          int
+	SetCreatedUserIDInputs               []string
+	SetModifiedTimeInvocations           int
+	SetModifiedTimeInputs                []string
+	SetModifiedUserIDInvocations         int
+	SetModifiedUserIDInputs              []string
+	SetDeletedTimeInvocations            int
+	SetDeletedTimeInputs                 []string
+	SetDeletedUserIDInvocations          int
+	SetDeletedUserIDInputs               []string
+	DeduplicatorDescriptorInvocations    int
+	DeduplicatorDescriptorOutputs        []*data.DeduplicatorDescriptor
+	SetDeduplicatorDescriptorInvocations int
+	SetDeduplicatorDescriptorInputs      []*data.DeduplicatorDescriptor
 }
 
 func (d *Datum) Init() {
@@ -160,9 +164,28 @@ func (d *Datum) SetDeletedUserID(deletedUserID string) {
 	d.SetDeletedUserIDInputs = append(d.SetDeletedUserIDInputs, deletedUserID)
 }
 
+func (d *Datum) DeduplicatorDescriptor() *data.DeduplicatorDescriptor {
+	d.DeduplicatorDescriptorInvocations++
+
+	if len(d.DeduplicatorDescriptorOutputs) == 0 {
+		panic("Unexpected invocation of DeduplicatorDescriptor on Session")
+	}
+
+	output := d.DeduplicatorDescriptorOutputs[0]
+	d.DeduplicatorDescriptorOutputs = d.DeduplicatorDescriptorOutputs[1:]
+	return output
+}
+
+func (d *Datum) SetDeduplicatorDescriptor(deduplicatorDescriptor *data.DeduplicatorDescriptor) {
+	d.SetDeduplicatorDescriptorInvocations++
+
+	d.SetDeduplicatorDescriptorInputs = append(d.SetDeduplicatorDescriptorInputs, deduplicatorDescriptor)
+}
+
 func (d *Datum) UnusedOutputsCount() int {
 	return len(d.MetaOutputs) +
 		len(d.ParseOutputs) +
 		len(d.ValidateOutputs) +
-		len(d.NormalizeOutputs)
+		len(d.NormalizeOutputs) +
+		len(d.DeduplicatorDescriptorOutputs)
 }

--- a/data/types/base/base.go
+++ b/data/types/base/base.go
@@ -18,21 +18,22 @@ import (
 const SchemaVersionCurrent = 3
 
 type Base struct {
-	Active         bool   `json:"-" bson:"_active"`
-	CreatedTime    string `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
-	CreatedUserID  string `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
-	DeletedTime    string `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
-	DeletedUserID  string `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
-	GroupID        string `json:"-" bson:"_groupId,omitempty"`
-	GUID           string `json:"guid,omitempty" bson:"guid,omitempty"`
-	ID             string `json:"id,omitempty" bson:"id,omitempty"`
-	ModifiedTime   string `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
-	ModifiedUserID string `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
-	SchemaVersion  int    `json:"-" bson:"_schemaVersion,omitempty"`
-	Type           string `json:"type,omitempty" bson:"type,omitempty"`
-	UploadID       string `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
-	UserID         string `json:"-" bson:"_userId,omitempty"`
-	Version        int    `json:"-" bson:"_version,omitempty"`
+	Active         bool                         `json:"-" bson:"_active"`
+	CreatedTime    string                       `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
+	CreatedUserID  string                       `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
+	Deduplicator   *data.DeduplicatorDescriptor `json:"-" bson:"_deduplicator,omitempty"`
+	DeletedTime    string                       `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
+	DeletedUserID  string                       `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
+	GroupID        string                       `json:"-" bson:"_groupId,omitempty"`
+	GUID           string                       `json:"guid,omitempty" bson:"guid,omitempty"`
+	ID             string                       `json:"id,omitempty" bson:"id,omitempty"`
+	ModifiedTime   string                       `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	ModifiedUserID string                       `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
+	SchemaVersion  int                          `json:"-" bson:"_schemaVersion,omitempty"`
+	Type           string                       `json:"type,omitempty" bson:"type,omitempty"`
+	UploadID       string                       `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
+	UserID         string                       `json:"-" bson:"_userId,omitempty"`
+	Version        int                          `json:"-" bson:"_version,omitempty"`
 
 	Annotations      *[]interface{} `json:"annotations,omitempty" bson:"annotations,omitempty"`
 	ClockDriftOffset *int           `json:"clockDriftOffset,omitempty" bson:"clockDriftOffset,omitempty"`
@@ -157,4 +158,12 @@ func (b *Base) SetDeletedTime(deletedTime string) {
 
 func (b *Base) SetDeletedUserID(deletedUserID string) {
 	b.DeletedUserID = deletedUserID
+}
+
+func (b *Base) DeduplicatorDescriptor() *data.DeduplicatorDescriptor {
+	return b.Deduplicator
+}
+
+func (b *Base) SetDeduplicatorDescriptor(deduplicatorDescriptor *data.DeduplicatorDescriptor) {
+	b.Deduplicator = deduplicatorDescriptor
 }

--- a/data/types/base/base_test.go
+++ b/data/types/base/base_test.go
@@ -2,137 +2,44 @@ package base_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	// . "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/base"
 )
 
-// func NewRawObject() map[string]interface{} {
-// 	rawObject := testing.RawBaseObject()
-// 	rawObject["type"] = "sample"
-// 	rawObject["subType"] = "sub"
-// 	rawObject["boolean"] = true
-// 	rawObject["integer"] = 7
-// 	rawObject["float"] = 4.5
-// 	rawObject["string"] = "aaa"
-// 	rawObject["stringArray"] = []string{"bach", "blech"}
-// 	rawObject["object"] = map[string]interface{}{
-// 		"one": 1,
-// 		"two": "two",
-// 		"three": map[string]interface{}{
-// 			"a": "apple",
-// 		},
-// 	}
-// 	rawObject["objectArray"] = []map[string]interface{}{
-// 		{
-// 			"alpha": "a",
-// 		},
-// 		{
-// 			"bravo": "b",
-// 		},
-// 	}
-// 	rawObject["interface"] = "yes"
-// 	rawObject["interfaceArray"] = []interface{}{
-// 		"alpha", map[string]interface{}{"alpha": "a"},
-// 		map[string]interface{}{"bravo": "b"},
-// 		-999,
-// 	}
-// 	rawObject["timeString"] = "2013-05-04T03:58:44-08:00"
-// 	return rawObject
-// }
+// TODO: Finish tests
 
-// func NewMeta() interface{} {
-// 	return &base.Meta{
-// 		Type: "sample",
-// 	}
-// }
+var _ = Describe("Base", func() {
+	Context("with new base", func() {
+		var testBase *base.Base
 
-// TODO_DATA: Need to find another way to test base not using sample/sub
+		BeforeEach(func() {
+			testBase = &base.Base{}
+			testBase.Init()
+		})
 
-var _ = PDescribe("Base", func() {
-	// Context("_userId", func() {
-	// 	DescribeTable("invalid when", testing.ExpectFieldNotValid,
-	// 		Entry("is empty", NewRawObject(), "_userId", "",
-	// 			[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThanOrEqualTo(0, 10), "/userId", NewMeta())},
-	// 		),
-	// 		Entry("is less than 10 characters", NewRawObject(), "_userId", "123456789",
-	// 			[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThanOrEqualTo(9, 10), "/userId", NewMeta())},
-	// 		),
-	// 	)
+		Context("with deduplicator descriptor", func() {
+			var testDeduplicatorDescriptor *data.DeduplicatorDescriptor
 
-	// 	DescribeTable("valid when", testing.ExpectFieldIsValid,
-	// 		Entry("has id 10 characters in length", NewRawObject(), "_userId", "b676436f60"),
-	// 		Entry("has id more 10 characters in length", NewRawObject(), "_userId", "b676436f60-b676436f60"),
-	// 	)
-	// })
+			BeforeEach(func() {
+				testDeduplicatorDescriptor = &data.DeduplicatorDescriptor{Name: app.NewID(), Hash: app.NewID()}
+			})
 
-	// Context("uploadId", func() {
-	// 	DescribeTable("invalid when", testing.ExpectFieldNotValid,
-	// 		Entry("is empty", NewRawObject(), "uploadId", "",
-	// 			[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/uploadId", NewMeta())},
-	// 		),
-	// 	)
+			Context("DeduplicatorDescriptor", func() {
+				It("gets the deduplicator descriptor", func() {
+					testBase.Deduplicator = testDeduplicatorDescriptor
+					Expect(testBase.DeduplicatorDescriptor()).To(Equal(testDeduplicatorDescriptor))
+				})
+			})
 
-	// 	DescribeTable("valid when", testing.ExpectFieldIsValid,
-	// 		Entry("has string id", NewRawObject(), "uploadId", "upid_b856b0e6e519"),
-	// 		Entry("has string id 1 or more characters", NewRawObject(), "uploadId", "d"),
-	// 	)
-	// })
-
-	// Context("deviceId", func() {
-	// 	DescribeTable("invalid when", testing.ExpectFieldNotValid,
-	// 		Entry("is empty", NewRawObject(), "deviceId", "",
-	// 			[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/deviceId", NewMeta())},
-	// 		),
-	// 	)
-
-	// 	DescribeTable("valid when", testing.ExpectFieldIsValid,
-	// 		Entry("is given string id", NewRawObject(), "deviceId", "InsOmn-111111111"),
-	// 		Entry("has string id 1 or more characters", NewRawObject(), "deviceId", "d"),
-	// 	)
-	// })
-
-	// Context("timezoneOffset", func() {
-	// 	DescribeTable("timezoneOffset valid", testing.ExpectFieldIsValid,
-	// 		Entry("is greater than zero", NewRawObject(), "timezoneOffset", 480),
-	// 		Entry("is zero", NewRawObject(), "timezoneOffset", 0),
-	// 		Entry("is negative", NewRawObject(), "timezoneOffset", -100),
-	// 	)
-	// })
-
-	// Context("conversionOffset", func() {
-	// 	DescribeTable("invalid when", testing.ExpectFieldNotValid,
-	// 		Entry("is negative", NewRawObject(), "conversionOffset", -1,
-	// 			[]*service.Error{testing.ComposeError(service.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/conversionOffset", NewMeta())},
-	// 		),
-	// 	)
-
-	// 	DescribeTable("valid when", testing.ExpectFieldIsValid,
-	// 		Entry("is greater than zero", NewRawObject(), "conversionOffset", 45),
-	// 		Entry("is zero", NewRawObject(), "conversionOffset", 0),
-	// 	)
-	// })
-
-	// Context("clockDriftOffset", func() {
-	// 	DescribeTable("invalid when", testing.ExpectFieldNotValid,
-	// 		Entry("is negative", NewRawObject(), "clockDriftOffset", -1,
-	// 			[]*service.Error{testing.ComposeError(service.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/clockDriftOffset", NewMeta())},
-	// 		),
-	// 	)
-
-	// 	DescribeTable("valid when", testing.ExpectFieldIsValid,
-	// 		Entry("is greater than zero", NewRawObject(), "clockDriftOffset", 45),
-	// 		Entry("is zero", NewRawObject(), "clockDriftOffset", 0),
-	// 	)
-	// })
-
-	// Context("time", func() {
-	// 	DescribeTable("valid when", testing.ExpectFieldIsValid,
-	// 		Entry("is zulu time", NewRawObject(), "time", "2013-05-04T03:58:44.584Z"),
-	// 	)
-
-	// 	DescribeTable("invalid when", testing.ExpectFieldNotValid,
-	// 		Entry("is non zulu time", NewRawObject(), "time", "2013-05-04T03:58:44.584",
-	// 			[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("2013-05-04T03:58:44.584", "2006-01-02T15:04:05Z"), "/time", NewMeta())},
-	// 		),
-	// 	)
-	// })
+			Context("SetDeduplicatorDescriptor", func() {
+				It("sets the deduplicator descriptor", func() {
+					testBase.SetDeduplicatorDescriptor(testDeduplicatorDescriptor)
+					Expect(testBase.Deduplicator).To(Equal(testDeduplicatorDescriptor))
+				})
+			})
+		})
+	})
 })

--- a/data/types/base/upload/upload.go
+++ b/data/types/base/upload/upload.go
@@ -6,18 +6,12 @@ import (
 	"github.com/tidepool-org/platform/data/types/base"
 )
 
-type Deduplicator struct {
-	Name string                 `bson:"name,omitempty"`
-	Data map[string]interface{} `bson:"data,omitempty"`
-}
-
 type Upload struct {
 	base.Base `bson:",inline"`
 
-	State        string        `json:"-" bson:"_state,omitempty"`
-	DataState    string        `json:"-" bson:"_dataState,omitempty"` // TODO: Deprecated DataState (after data migration)
-	Deduplicator *Deduplicator `json:"-" bson:"_deduplicator,omitempty"`
-	ByUser       string        `json:"byUser,omitempty" bson:"byUser,omitempty"`
+	State     string `json:"-" bson:"_state,omitempty"`
+	DataState string `json:"-" bson:"_dataState,omitempty"` // TODO: Deprecated DataState (after data migration)
+	ByUser    string `json:"byUser,omitempty" bson:"byUser,omitempty"`
 
 	ComputerTime        *string   `json:"computerTime,omitempty" bson:"computerTime,omitempty"`
 	DeviceManufacturers *[]string `json:"deviceManufacturers,omitempty" bson:"deviceManufacturers,omitempty"`

--- a/data/types/base/upload/upload.go
+++ b/data/types/base/upload/upload.go
@@ -14,7 +14,8 @@ type Deduplicator struct {
 type Upload struct {
 	base.Base `bson:",inline"`
 
-	DataState    string        `json:"-" bson:"_dataState,omitempty"`
+	State        string        `json:"-" bson:"_state,omitempty"`
+	DataState    string        `json:"-" bson:"_dataState,omitempty"` // TODO: Deprecated DataState (after data migration)
 	Deduplicator *Deduplicator `json:"-" bson:"_deduplicator,omitempty"`
 	ByUser       string        `json:"byUser,omitempty" bson:"byUser,omitempty"`
 
@@ -51,7 +52,8 @@ func (u *Upload) Init() {
 	u.Base.Type = Type()
 	u.Base.UploadID = app.NewID()
 
-	u.DataState = "open"
+	u.State = "open"
+	u.DataState = "open" // TODO: Deprecated DataState (after data migration)
 	u.Deduplicator = nil
 	u.ByUser = ""
 

--- a/dataservices/service/api/v1/datasets_data_create.go
+++ b/dataservices/service/api/v1/datasets_data_create.go
@@ -58,7 +58,7 @@ func DatasetsDataCreate(serviceContext service.Context) {
 		}
 	}
 
-	if dataset.DataState != "open" {
+	if dataset.State == "closed" || dataset.DataState == "closed" { // TODO: Deprecated DataState (after data migration)
 		serviceContext.RespondWithError(ErrorDatasetClosed(datasetID))
 		return
 	}

--- a/dataservices/service/api/v1/datasets_update.go
+++ b/dataservices/service/api/v1/datasets_update.go
@@ -52,12 +52,12 @@ func DatasetsUpdate(serviceContext service.Context) {
 		}
 	}
 
-	if dataset.DataState != "open" {
+	if dataset.State == "closed" || dataset.DataState == "closed" { // TODO: Deprecated DataState (after data migration)
 		serviceContext.RespondWithError(ErrorDatasetClosed(datasetID))
 		return
 	}
 
-	dataset.DataState = "closed"
+	dataset.State = "closed"
 
 	if err = serviceContext.DataStoreSession().UpdateDataset(dataset); err != nil {
 		serviceContext.RespondWithInternalServerFailure("Unable to update dataset", err)


### PR DESCRIPTION
@jh-bate Rename `_dataState` to just `_state` (more accurate, plus no other field has `data` prefix though others are pertinent to data, as well.). Migration should be performed after deployment (though, not required). Move `deduplicator` descriptor as first class citizen of `data.Datum` (needed for upcoming de-duplicator work; was limited to `upload` data type).