### PR TITLE
Refactor out common blood glucose/ketone; tests

### DIFF
--- a/data/types/base/blood/blood.go
+++ b/data/types/base/blood/blood.go
@@ -1,0 +1,62 @@
+package blood
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/base"
+)
+
+type Blood struct {
+	base.Base `bson:",inline"`
+
+	Units *string  `json:"units,omitempty" bson:"units,omitempty"`
+	Value *float64 `json:"value,omitempty" bson:"value,omitempty"`
+}
+
+func (b *Blood) Init() {
+	b.Base.Init()
+
+	b.Units = nil
+	b.Value = nil
+}
+
+func (b *Blood) Parse(parser data.ObjectParser) error {
+	parser.SetMeta(b.Meta())
+
+	if err := b.Base.Parse(parser); err != nil {
+		return err
+	}
+
+	b.Units = parser.ParseString("units")
+	b.Value = parser.ParseFloat("value")
+
+	return nil
+}
+
+func (b *Blood) Validate(validator data.Validator) error {
+	validator.SetMeta(b.Meta())
+
+	if err := b.Base.Validate(validator); err != nil {
+		return err
+	}
+
+	validator.ValidateString("units", b.Units).Exists()
+	validator.ValidateFloat("value", b.Value).Exists()
+
+	return nil
+}
+
+func (b *Blood) Normalize(normalizer data.Normalizer) error {
+	normalizer.SetMeta(b.Meta())
+
+	return b.Base.Normalize(normalizer)
+}

--- a/data/types/base/blood/blood_suite_test.go
+++ b/data/types/base/blood/blood_suite_test.go
@@ -1,4 +1,4 @@
-package selfmonitored_test
+package blood_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood/glucose/selfmonitored")
+	RunSpecs(t, "data/types/base/blood")
 }

--- a/data/types/base/blood/blood_test.go
+++ b/data/types/base/blood/blood_test.go
@@ -1,0 +1,186 @@
+package blood_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data/context"
+	"github.com/tidepool-org/platform/data/factory"
+	"github.com/tidepool-org/platform/data/normalizer"
+	"github.com/tidepool-org/platform/data/parser"
+	"github.com/tidepool-org/platform/data/types/base"
+	"github.com/tidepool-org/platform/data/types/base/blood"
+	"github.com/tidepool-org/platform/data/types/base/testing"
+	"github.com/tidepool-org/platform/data/validator"
+	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/service"
+)
+
+func NewMeta() interface{} {
+	return &base.Meta{
+		Type: "testBlood",
+	}
+}
+
+func NewTestBlood(sourceTime interface{}, sourceUnits interface{}, sourceValue interface{}) *blood.Blood {
+	testBlood := &blood.Blood{}
+	testBlood.Init()
+	testBlood.Type = "testBlood"
+	testBlood.DeviceID = app.StringAsPointer(app.NewID())
+	if value, ok := sourceTime.(string); ok {
+		testBlood.Time = app.StringAsPointer(value)
+	}
+	if value, ok := sourceUnits.(string); ok {
+		testBlood.Units = app.StringAsPointer(value)
+	}
+	if value, ok := sourceValue.(float64); ok {
+		testBlood.Value = app.FloatAsPointer(value)
+	}
+	return testBlood
+}
+
+var _ = Describe("Blood", func() {
+	Context("with new blood", func() {
+		var testBlood *blood.Blood
+
+		BeforeEach(func() {
+			testBlood = &blood.Blood{}
+		})
+
+		Context("Init", func() {
+			It("initializes the blood", func() {
+				testBlood.Init()
+				Expect(testBlood.Units).To(BeNil())
+				Expect(testBlood.Value).To(BeNil())
+			})
+		})
+
+		Context("with initialized", func() {
+			BeforeEach(func() {
+				testBlood.Init()
+				testBlood.Type = "testBlood"
+			})
+
+			DescribeTable("Parse",
+				func(sourceObject *map[string]interface{}, expectedBlood *blood.Blood, expectedErrors []*service.Error) {
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testFactory, err := factory.NewStandard()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testFactory).ToNot(BeNil())
+					testParser, err := parser.NewStandardObject(testContext, testFactory, sourceObject, parser.AppendErrorNotParsed)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testParser).ToNot(BeNil())
+					Expect(testBlood.Parse(testParser)).To(Succeed())
+					Expect(testBlood.Time).To(Equal(expectedBlood.Time))
+					Expect(testBlood.Units).To(Equal(expectedBlood.Units))
+					Expect(testBlood.Value).To(Equal(expectedBlood.Value))
+					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
+				},
+				Entry("parses object that is nil",
+					nil,
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that is empty",
+					&map[string]interface{}{},
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that has valid time",
+					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00"},
+					NewTestBlood("2016-09-06T13:45:58-07:00", nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that has invalid time",
+					&map[string]interface{}{"time": 0},
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+					}),
+				Entry("parses object that has valid units",
+					&map[string]interface{}{"units": "mmol/L"},
+					NewTestBlood(nil, "mmol/L", nil),
+					[]*service.Error{}),
+				Entry("parses object that has invalid units",
+					&map[string]interface{}{"units": 0},
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+					}),
+				Entry("parses object that has valid value",
+					&map[string]interface{}{"value": 1.0},
+					NewTestBlood(nil, nil, 1.0),
+					[]*service.Error{}),
+				Entry("parses object that has invalid value",
+					&map[string]interface{}{"value": "invalid"},
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+					}),
+				Entry("parses object that has multiple valid fields",
+					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "units": "mmol/L", "value": 1.0},
+					NewTestBlood("2016-09-06T13:45:58-07:00", "mmol/L", 1.0),
+					[]*service.Error{}),
+				Entry("parses object that has multiple invalid fields",
+					&map[string]interface{}{"time": 0, "units": 0, "value": "invalid"},
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+					}),
+			)
+
+			DescribeTable("Validate",
+				func(sourceBlood *blood.Blood, expectedErrors []*service.Error) {
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testValidator, err := validator.NewStandard(testContext)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testValidator).ToNot(BeNil())
+					Expect(sourceBlood.Validate(testValidator)).To(Succeed())
+					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
+				},
+				Entry("all valid",
+					NewTestBlood("2016-09-06T13:45:58-07:00", "mmol/L", 1.0),
+					[]*service.Error{}),
+				Entry("missing time",
+					NewTestBlood(nil, "mmol/L", 1.0),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+					}),
+				Entry("missing units",
+					NewTestBlood("2016-09-06T13:45:58-07:00", nil, 1.0),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+					}),
+				Entry("missing value",
+					NewTestBlood("2016-09-06T13:45:58-07:00", "mmol/L", nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+					}),
+				Entry("multiple",
+					NewTestBlood(nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+					}),
+			)
+
+			Context("Normalize", func() {
+				It("succeeds", func() {
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testNormalizer, err := normalizer.NewStandard(testContext)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testNormalizer).ToNot(BeNil())
+					Expect(testBlood.Normalize(testNormalizer)).To(Succeed())
+				})
+			})
+		})
+	})
+})

--- a/data/types/base/blood/glucose/continuous/continuous.go
+++ b/data/types/base/blood/glucose/continuous/continuous.go
@@ -1,16 +1,22 @@
 package continuous
 
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
 import (
 	"github.com/tidepool-org/platform/data"
-	"github.com/tidepool-org/platform/data/blood/glucose"
-	"github.com/tidepool-org/platform/data/types/base"
+	"github.com/tidepool-org/platform/data/types/base/blood/glucose"
 )
 
 type Continuous struct {
-	base.Base `bson:",inline"`
-
-	Units *string  `json:"units,omitempty" bson:"units,omitempty"`
-	Value *float64 `json:"value,omitempty" bson:"value,omitempty"`
+	glucose.Glucose `bson:",inline"`
 }
 
 func Type() string {
@@ -32,48 +38,6 @@ func Init() *Continuous {
 }
 
 func (c *Continuous) Init() {
-	c.Base.Init()
-	c.Base.Type = Type()
-
-	c.Units = nil
-	c.Value = nil
-}
-
-func (c *Continuous) Parse(parser data.ObjectParser) error {
-	parser.SetMeta(c.Meta())
-
-	if err := c.Base.Parse(parser); err != nil {
-		return err
-	}
-
-	c.Units = parser.ParseString("units")
-	c.Value = parser.ParseFloat("value")
-
-	return nil
-}
-
-func (c *Continuous) Validate(validator data.Validator) error {
-	validator.SetMeta(c.Meta())
-
-	if err := c.Base.Validate(validator); err != nil {
-		return err
-	}
-
-	validator.ValidateString("units", c.Units).Exists().OneOf(glucose.Units())
-	validator.ValidateFloat("value", c.Value).Exists().InRange(glucose.ValueRangeForUnits(c.Units))
-
-	return nil
-}
-
-func (c *Continuous) Normalize(normalizer data.Normalizer) error {
-	normalizer.SetMeta(c.Meta())
-
-	if err := c.Base.Normalize(normalizer); err != nil {
-		return err
-	}
-
-	c.Value = glucose.NormalizeValueForUnits(c.Value, c.Units)
-	c.Units = glucose.NormalizeUnits(c.Units)
-
-	return nil
+	c.Glucose.Init()
+	c.Type = Type()
 }

--- a/data/types/base/blood/glucose/continuous/continuous_suite_test.go
+++ b/data/types/base/blood/glucose/continuous/continuous_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/continuous")
+	RunSpecs(t, "data/types/base/blood/glucose/continuous")
 }

--- a/data/types/base/blood/glucose/continuous/continuous_test.go
+++ b/data/types/base/blood/glucose/continuous/continuous_test.go
@@ -2,120 +2,51 @@ package continuous_test
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/data/blood/glucose"
-	"github.com/tidepool-org/platform/data/context"
-	"github.com/tidepool-org/platform/data/normalizer"
-	"github.com/tidepool-org/platform/data/types/base"
 	"github.com/tidepool-org/platform/data/types/base/blood/glucose/continuous"
-	"github.com/tidepool-org/platform/data/types/base/testing"
-	"github.com/tidepool-org/platform/log"
-	"github.com/tidepool-org/platform/service"
 )
 
-func NewRawObjectMmolL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
-	rawObject["type"] = "cbg"
-	rawObject["units"] = glucose.MmolL
-	rawObject["value"] = 5
-	return rawObject
-}
-
-func NewRawObjectMgdL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
-	rawObject["type"] = "cbg"
-	rawObject["units"] = glucose.MgdL
-	rawObject["value"] = 99
-	return rawObject
-}
-
-func NewMeta() interface{} {
-	return &base.Meta{
-		Type: "cbg",
-	}
-}
-
 var _ = Describe("Continuous", func() {
-	Context("units", func() {
-		DescribeTable("units when", testing.ExpectFieldNotValid,
-			Entry("is empty", NewRawObjectMmolL(), "units", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
-			),
-			Entry("is not one of the predefined values", NewRawObjectMmolL(), "units", "wrong",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
-			),
-		)
-
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
-			Entry("is mmol/l", NewRawObjectMmolL(), "units", "mmol/l"),
-			Entry("is mmol/L", NewRawObjectMmolL(), "units", "mmol/L"),
-			Entry("is mg/dl", NewRawObjectMgdL(), "units", "mg/dl"),
-			Entry("is mg/dL", NewRawObjectMgdL(), "units", "mg/dL"),
-		)
+	Context("Type", func() {
+		It("returns the expected type", func() {
+			Expect(continuous.Type()).To(Equal("cbg"))
+		})
 	})
 
-	Context("value", func() {
-		DescribeTable("value when", testing.ExpectFieldNotValid,
-			Entry("is less than 0", NewRawObjectMgdL(), "value", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
-			),
-			Entry("is greater than 1000", NewRawObjectMgdL(), "value", 1000.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
-			),
-		)
-
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
-			Entry("is above 0", NewRawObjectMgdL(), "value", 0.1),
-			Entry("is below max", NewRawObjectMgdL(), "value", glucose.MgdLUpperLimit),
-			Entry("is an integer", NewRawObjectMgdL(), "value", 380),
-		)
+	Context("NewDatum", func() {
+		It("returns the expected datum", func() {
+			Expect(continuous.NewDatum()).To(Equal(&continuous.Continuous{}))
+		})
 	})
 
-	Context("normalized when mmol/L", func() {
-		DescribeTable("normalization", func(val, expected float64) {
-			continuousBg := continuous.Init()
-			units := glucose.MmolL
-			continuousBg.Units = &units
-			continuousBg.Value = &val
-
-			testContext, err := context.NewStandard(log.NewNull())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(testContext).ToNot(BeNil())
-			standardNormalizer, err := normalizer.NewStandard(testContext)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(standardNormalizer).ToNot(BeNil())
-			continuousBg.Normalize(standardNormalizer)
-			Expect(*continuousBg.Units).To(Equal(glucose.MmolL))
-			Expect(*continuousBg.Value).To(Equal(expected))
-		},
-			Entry("is expected lower bg value", 3.7, 3.7),
-			Entry("is below max", 54.99, 54.99),
-			Entry("is expected upper bg value", 23.0, 23.0),
-		)
+	Context("New", func() {
+		It("returns the expected continuous", func() {
+			Expect(continuous.New()).To(Equal(&continuous.Continuous{}))
+		})
 	})
 
-	Context("normalized when mg/dL", func() {
-		DescribeTable("normalization", func(val, expected float64) {
-			continuousBg := continuous.Init()
-			units := glucose.MgdL
-			continuousBg.Units = &units
-			continuousBg.Value = &val
+	Context("Init", func() {
+		It("returns the expected continuous", func() {
+			testContinuous := continuous.Init()
+			Expect(testContinuous).ToNot(BeNil())
+			Expect(testContinuous.Type).To(Equal("cbg"))
+		})
+	})
 
-			testContext, err := context.NewStandard(log.NewNull())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(testContext).ToNot(BeNil())
-			standardNormalizer, err := normalizer.NewStandard(testContext)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(standardNormalizer).ToNot(BeNil())
-			continuousBg.Normalize(standardNormalizer)
-			Expect(*continuousBg.Units).To(Equal(glucose.MmolL))
-			Expect(*continuousBg.Value).To(Equal(expected))
-		},
-			Entry("is expected lower bg value", 60.0, 3.33044879462732),
-			Entry("is below max", glucose.MgdLUpperLimit, 55.50747991045534),
-			Entry("is expected upper bg value", 400.0, 22.202991964182132),
-		)
+	Context("with new continuous", func() {
+		var testContinuous *continuous.Continuous
+
+		BeforeEach(func() {
+			testContinuous = continuous.New()
+			Expect(testContinuous).ToNot(BeNil())
+		})
+
+		Context("Init", func() {
+			It("initializes the continuous", func() {
+				testContinuous.Init()
+				Expect(testContinuous.Type).To(Equal("cbg"))
+			})
+		})
 	})
 })

--- a/data/types/base/blood/glucose/glucose.go
+++ b/data/types/base/blood/glucose/glucose.go
@@ -1,0 +1,43 @@
+package glucose
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/blood/glucose"
+	"github.com/tidepool-org/platform/data/types/base/blood"
+)
+
+type Glucose struct {
+	blood.Blood `bson:",inline"`
+}
+
+func (g *Glucose) Validate(validator data.Validator) error {
+	if err := g.Blood.Validate(validator); err != nil {
+		return err
+	}
+
+	validator.ValidateString("units", g.Units).OneOf(glucose.Units())
+	validator.ValidateFloat("value", g.Value).InRange(glucose.ValueRangeForUnits(g.Units))
+
+	return nil
+}
+
+func (g *Glucose) Normalize(normalizer data.Normalizer) error {
+	if err := g.Blood.Normalize(normalizer); err != nil {
+		return err
+	}
+
+	g.Value = glucose.NormalizeValueForUnits(g.Value, g.Units)
+	g.Units = glucose.NormalizeUnits(g.Units)
+
+	return nil
+}

--- a/data/types/base/blood/glucose/glucose_suite_test.go
+++ b/data/types/base/blood/glucose/glucose_suite_test.go
@@ -1,4 +1,4 @@
-package selfmonitored_test
+package glucose_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood/glucose/selfmonitored")
+	RunSpecs(t, "data/types/base/blood/glucose")
 }

--- a/data/types/base/blood/glucose/glucose_test.go
+++ b/data/types/base/blood/glucose/glucose_test.go
@@ -1,0 +1,223 @@
+package glucose_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"math"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data/context"
+	"github.com/tidepool-org/platform/data/normalizer"
+	"github.com/tidepool-org/platform/data/types/base"
+	"github.com/tidepool-org/platform/data/types/base/blood/glucose"
+	"github.com/tidepool-org/platform/data/types/base/testing"
+	"github.com/tidepool-org/platform/data/validator"
+	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/service"
+)
+
+func NewMeta() interface{} {
+	return &base.Meta{
+		Type: "testGlucose",
+	}
+}
+
+func NewTestGlucose(sourceTime interface{}, sourceUnits interface{}, sourceValue interface{}) *glucose.Glucose {
+	testGlucose := &glucose.Glucose{}
+	testGlucose.Init()
+	testGlucose.Type = "testGlucose"
+	testGlucose.DeviceID = app.StringAsPointer(app.NewID())
+	if value, ok := sourceTime.(string); ok {
+		testGlucose.Time = app.StringAsPointer(value)
+	}
+	if value, ok := sourceUnits.(string); ok {
+		testGlucose.Units = app.StringAsPointer(value)
+	}
+	if value, ok := sourceValue.(float64); ok {
+		testGlucose.Value = app.FloatAsPointer(value)
+	}
+	return testGlucose
+}
+
+var _ = Describe("Glucose", func() {
+	Context("with new glucose", func() {
+		var testGlucose *glucose.Glucose
+
+		BeforeEach(func() {
+			testGlucose = &glucose.Glucose{}
+		})
+
+		Context("with initialized", func() {
+			BeforeEach(func() {
+				testGlucose.Init()
+			})
+
+			DescribeTable("Validate",
+				func(sourceGlucose *glucose.Glucose, expectedErrors []*service.Error) {
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testValidator, err := validator.NewStandard(testContext)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testValidator).ToNot(BeNil())
+					Expect(sourceGlucose.Validate(testValidator)).To(Succeed())
+					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
+				},
+				Entry("all valid",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 10.0),
+					[]*service.Error{}),
+				Entry("missing time",
+					NewTestGlucose(nil, "mmol/L", 10.0),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+					}),
+				Entry("missing units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", nil, 10.0),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+					}),
+				Entry("unknown units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", 10.0),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+					}),
+				Entry("mmol/L units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 10.0),
+					[]*service.Error{}),
+				Entry("mmol/l units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 10.0),
+					[]*service.Error{}),
+				Entry("mg/dL units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 180.0),
+					[]*service.Error{}),
+				Entry("mg/dl units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 180.0),
+					[]*service.Error{}),
+				Entry("missing value",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+					}),
+				Entry("unknown units; value in range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", -math.MaxFloat64),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+					}),
+				Entry("unknown units; value in range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", math.MaxFloat64),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+					}),
+				Entry("mmol/L units; value out of range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", -0.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mmol/L units; value in range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 0.0),
+					[]*service.Error{}),
+				Entry("mmol/L units; value in range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 55.0),
+					[]*service.Error{}),
+				Entry("mmol/L units; value out of range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 55.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mmol/l units; value out of range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", -0.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mmol/l units; value in range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 0.0),
+					[]*service.Error{}),
+				Entry("mmol/l units; value in range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 55.0),
+					[]*service.Error{}),
+				Entry("mmol/l units; value out of range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 55.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dL units; value out of range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", -0.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dL units; value in range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 0.0),
+					[]*service.Error{}),
+				Entry("mg/dL units; value in range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 1000.0),
+					[]*service.Error{}),
+				Entry("mg/dL units; value out of range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 1000.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dl units; value out of range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", -0.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dl units; value in range (lower)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 0.0),
+					[]*service.Error{}),
+				Entry("mg/dl units; value in range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 1000.0),
+					[]*service.Error{}),
+				Entry("mg/dl units; value out of range (upper)",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 1000.1),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("multiple",
+					NewTestGlucose(nil, "unknown", nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+					}),
+			)
+
+			DescribeTable("Normalize",
+				func(sourceGlucose *glucose.Glucose, expectedKetone *glucose.Glucose) {
+					sourceGlucose.GUID = expectedKetone.GUID
+					sourceGlucose.ID = expectedKetone.ID
+					sourceGlucose.DeviceID = expectedKetone.DeviceID
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testNormalizer, err := normalizer.NewStandard(testContext)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testNormalizer).ToNot(BeNil())
+					Expect(sourceGlucose.Normalize(testNormalizer)).To(Succeed())
+					Expect(sourceGlucose).To(Equal(expectedKetone))
+				},
+				Entry("unknown units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", 10.0),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", 10.0),
+				),
+				Entry("mmol/L units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 10.0),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 10.0),
+				),
+				Entry("mmol/l units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 10.0),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 10.0),
+				),
+				Entry("mg/dL units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 180.0),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 9.991346383881961),
+				),
+				Entry("mg/dl units",
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 180.0),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 9.991346383881961),
+				),
+			)
+		})
+	})
+})

--- a/data/types/base/blood/glucose/selfmonitored/selfmonitored_test.go
+++ b/data/types/base/blood/glucose/selfmonitored/selfmonitored_test.go
@@ -5,33 +5,19 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/data/blood/glucose"
+	"math"
+
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data/context"
-	"github.com/tidepool-org/platform/data/normalizer"
+	"github.com/tidepool-org/platform/data/factory"
+	"github.com/tidepool-org/platform/data/parser"
 	"github.com/tidepool-org/platform/data/types/base"
 	"github.com/tidepool-org/platform/data/types/base/blood/glucose/selfmonitored"
 	"github.com/tidepool-org/platform/data/types/base/testing"
+	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
 )
-
-func NewRawObjectMmolL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
-	rawObject["type"] = "smbg"
-	rawObject["units"] = glucose.MmolL
-	rawObject["subType"] = "manual"
-	rawObject["value"] = 5
-	return rawObject
-}
-
-func NewRawObjectMgdL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
-	rawObject["type"] = "smbg"
-	rawObject["units"] = glucose.MgdL
-	rawObject["subType"] = "manual"
-	rawObject["value"] = 120
-	return rawObject
-}
 
 func NewMeta() interface{} {
 	return &base.Meta{
@@ -39,98 +25,292 @@ func NewMeta() interface{} {
 	}
 }
 
+func NewTestSelfMonitored(sourceTime interface{}, sourceUnits interface{}, sourceValue interface{}, sourceSubType interface{}) *selfmonitored.SelfMonitored {
+	testSelfMonitored := selfmonitored.Init()
+	testSelfMonitored.DeviceID = app.StringAsPointer(app.NewID())
+	if value, ok := sourceTime.(string); ok {
+		testSelfMonitored.Time = app.StringAsPointer(value)
+	}
+	if value, ok := sourceUnits.(string); ok {
+		testSelfMonitored.Units = app.StringAsPointer(value)
+	}
+	if value, ok := sourceValue.(float64); ok {
+		testSelfMonitored.Value = app.FloatAsPointer(value)
+	}
+	if value, ok := sourceSubType.(string); ok {
+		testSelfMonitored.SubType = app.StringAsPointer(value)
+	}
+	return testSelfMonitored
+}
+
 var _ = Describe("SelfMonitored", func() {
-	Context("units", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
-			Entry("is empty", NewRawObjectMmolL(), "units", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
-			),
-			Entry("is not one of the predefined values", NewRawObjectMmolL(), "units", "wrong",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
-			),
-		)
-
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
-			Entry("is mmol/l", NewRawObjectMmolL(), "units", "mmol/l"),
-			Entry("is mmol/L", NewRawObjectMmolL(), "units", "mmol/L"),
-			Entry("is mg/dl", NewRawObjectMgdL(), "units", "mg/dl"),
-			Entry("is mg/dL", NewRawObjectMgdL(), "units", "mg/dL"),
-		)
+	Context("Type", func() {
+		It("returns the expected type", func() {
+			Expect(selfmonitored.Type()).To(Equal("smbg"))
+		})
 	})
 
-	Context("subType", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
-			Entry("is not one of the predefined values", NewRawObjectMmolL(), "subType", "wrong",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"manual", "linked"}), "/subType", NewMeta())},
-			),
-		)
-
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
-			Entry("is manual", NewRawObjectMmolL(), "subType", "manual"),
-			Entry("is linked", NewRawObjectMgdL(), "subType", "linked"),
-		)
+	Context("NewDatum", func() {
+		It("returns the expected datum", func() {
+			Expect(selfmonitored.NewDatum()).To(Equal(&selfmonitored.SelfMonitored{}))
+		})
 	})
 
-	Context("value", func() {
-		DescribeTable("value when", testing.ExpectFieldNotValid,
-			Entry("is less than 0", NewRawObjectMgdL(), "value", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
-			),
-			Entry("is greater than 1000", NewRawObjectMgdL(), "value", 1000.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
-			),
-		)
-
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
-			Entry("is above 0", NewRawObjectMgdL(), "value", 0.1),
-			Entry("is below 1000", NewRawObjectMgdL(), "value", glucose.MgdLUpperLimit),
-			Entry("is an integer", NewRawObjectMgdL(), "value", 12),
-		)
+	Context("New", func() {
+		It("returns the expected self monitored", func() {
+			Expect(selfmonitored.New()).To(Equal(&selfmonitored.SelfMonitored{}))
+		})
 	})
 
-	Context("normalized when mmol/L", func() {
-		DescribeTable("normalization", func(val, expected float64) {
-			selfMonitoredBg := selfmonitored.Init()
-			units := glucose.MmolL
-			selfMonitoredBg.Units = &units
-			selfMonitoredBg.Value = &val
-
-			testContext, err := context.NewStandard(log.NewNull())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(testContext).ToNot(BeNil())
-			standardNormalizer, err := normalizer.NewStandard(testContext)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(standardNormalizer).ToNot(BeNil())
-			selfMonitoredBg.Normalize(standardNormalizer)
-			Expect(*selfMonitoredBg.Units).To(Equal(glucose.MmolL))
-			Expect(*selfMonitoredBg.Value).To(Equal(expected))
-		},
-			Entry("is expected lower bg value", 3.7, 3.7),
-			Entry("is below max", 54.99, 54.99),
-			Entry("is expected upper bg value", 23.0, 23.0),
-		)
+	Context("Init", func() {
+		It("returns the expected self monitored", func() {
+			testSelfMonitored := selfmonitored.Init()
+			Expect(testSelfMonitored).ToNot(BeNil())
+			Expect(testSelfMonitored.Type).To(Equal("smbg"))
+		})
 	})
 
-	Context("normalized when mg/dL", func() {
-		DescribeTable("normalization", func(val, expected float64) {
-			selfMonitoredBg := selfmonitored.Init()
-			units := glucose.MgdL
-			selfMonitoredBg.Units = &units
-			selfMonitoredBg.Value = &val
+	Context("with new self monitored", func() {
+		var testSelfMonitored *selfmonitored.SelfMonitored
 
-			testContext, err := context.NewStandard(log.NewNull())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(testContext).ToNot(BeNil())
-			standardNormalizer, err := normalizer.NewStandard(testContext)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(standardNormalizer).ToNot(BeNil())
-			selfMonitoredBg.Normalize(standardNormalizer)
-			Expect(*selfMonitoredBg.Units).To(Equal(glucose.MmolL))
-			Expect(*selfMonitoredBg.Value).To(Equal(expected))
-		},
-			Entry("is expected lower bg value", 60.0, 3.33044879462732),
-			Entry("is below max", glucose.MgdLUpperLimit, 55.50747991045534),
-			Entry("is expected upper bg value", 400.0, 22.202991964182132),
-		)
+		BeforeEach(func() {
+			testSelfMonitored = selfmonitored.New()
+			Expect(testSelfMonitored).ToNot(BeNil())
+		})
+
+		Context("Init", func() {
+			It("initializes the self monitored", func() {
+				testSelfMonitored.Init()
+				Expect(testSelfMonitored.Type).To(Equal("smbg"))
+			})
+		})
+
+		Context("with initialized", func() {
+			BeforeEach(func() {
+				testSelfMonitored.Init()
+			})
+
+			DescribeTable("Parse",
+				func(sourceObject *map[string]interface{}, expectedSelfMonitored *selfmonitored.SelfMonitored, expectedErrors []*service.Error) {
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testFactory, err := factory.NewStandard()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testFactory).ToNot(BeNil())
+					testParser, err := parser.NewStandardObject(testContext, testFactory, sourceObject, parser.AppendErrorNotParsed)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testParser).ToNot(BeNil())
+					Expect(testSelfMonitored.Parse(testParser)).To(Succeed())
+					Expect(testSelfMonitored.Time).To(Equal(expectedSelfMonitored.Time))
+					Expect(testSelfMonitored.Units).To(Equal(expectedSelfMonitored.Units))
+					Expect(testSelfMonitored.Value).To(Equal(expectedSelfMonitored.Value))
+					Expect(testSelfMonitored.SubType).To(Equal(expectedSelfMonitored.SubType))
+					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
+				},
+				Entry("parses object that is nil",
+					nil,
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that is empty",
+					&map[string]interface{}{},
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that has valid time",
+					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00"},
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", nil, nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that has invalid time",
+					&map[string]interface{}{"time": 0},
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+					}),
+				Entry("parses object that has valid units",
+					&map[string]interface{}{"units": "mmol/L"},
+					NewTestSelfMonitored(nil, "mmol/L", nil, nil),
+					[]*service.Error{}),
+				Entry("parses object that has invalid units",
+					&map[string]interface{}{"units": 0},
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+					}),
+				Entry("parses object that has valid value",
+					&map[string]interface{}{"value": 10.0},
+					NewTestSelfMonitored(nil, nil, 10.0, nil),
+					[]*service.Error{}),
+				Entry("parses object that has invalid value",
+					&map[string]interface{}{"value": "invalid"},
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+					}),
+				Entry("parses object that has valid sub type",
+					&map[string]interface{}{"subType": "linked"},
+					NewTestSelfMonitored(nil, nil, nil, "linked"),
+					[]*service.Error{}),
+				Entry("parses object that has invalid sub type",
+					&map[string]interface{}{"subType": 0},
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/subType", NewMeta()),
+					}),
+				Entry("parses object that has multiple valid fields",
+					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "units": "mmol/L", "value": 10.0, "subType": "linked"},
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "linked"),
+					[]*service.Error{}),
+				Entry("parses object that has multiple invalid fields",
+					&map[string]interface{}{"time": 0, "units": 0, "value": "invalid", "subType": 0},
+					NewTestSelfMonitored(nil, nil, nil, nil),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+						testing.ComposeError(service.ErrorTypeNotString(0), "/subType", NewMeta()),
+					}),
+			)
+
+			DescribeTable("Validate",
+				func(sourceSelfMonitored *selfmonitored.SelfMonitored, expectedErrors []*service.Error) {
+					testContext, err := context.NewStandard(log.NewNull())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testContext).ToNot(BeNil())
+					testValidator, err := validator.NewStandard(testContext)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testValidator).ToNot(BeNil())
+					Expect(sourceSelfMonitored.Validate(testValidator)).To(Succeed())
+					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
+				},
+				Entry("all valid",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "linked"),
+					[]*service.Error{}),
+				Entry("missing time",
+					NewTestSelfMonitored(nil, "mmol/L", 10.0, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+					}),
+				Entry("missing units",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", nil, 10.0, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+					}),
+				Entry("unknown units",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "unknown", 10.0, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+					}),
+				Entry("mmol/L units",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "linked"),
+					[]*service.Error{}),
+				Entry("mmol/l units",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", 10.0, "linked"),
+					[]*service.Error{}),
+				Entry("mg/dL units",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", 180.0, "linked"),
+					[]*service.Error{}),
+				Entry("mg/dl units",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", 180.0, "linked"),
+					[]*service.Error{}),
+				Entry("missing value",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", nil, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+					}),
+				Entry("unknown units; value in range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "unknown", -math.MaxFloat64, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+					}),
+				Entry("unknown units; value in range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "unknown", math.MaxFloat64, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+					}),
+				Entry("mmol/L units; value out of range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", -0.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mmol/L units; value in range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 0.0, "linked"),
+					[]*service.Error{}),
+				Entry("mmol/L units; value in range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 55.0, "linked"),
+					[]*service.Error{}),
+				Entry("mmol/L units; value out of range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 55.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mmol/l units; value out of range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", -0.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mmol/l units; value in range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", 0.0, "linked"),
+					[]*service.Error{}),
+				Entry("mmol/l units; value in range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", 55.0, "linked"),
+					[]*service.Error{}),
+				Entry("mmol/l units; value out of range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", 55.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dL units; value out of range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", -0.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dL units; value in range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", 0.0, "linked"),
+					[]*service.Error{}),
+				Entry("mg/dL units; value in range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", 1000.0, "linked"),
+					[]*service.Error{}),
+				Entry("mg/dL units; value out of range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", 1000.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dl units; value out of range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", -0.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("mg/dl units; value in range (lower)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", 0.0, "linked"),
+					[]*service.Error{}),
+				Entry("mg/dl units; value in range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", 1000.0, "linked"),
+					[]*service.Error{}),
+				Entry("mg/dl units; value out of range (upper)",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", 1000.1, "linked"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+					}),
+				Entry("unknown sub type",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "unknown"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"linked", "manual"}), "/subType", NewMeta()),
+					}),
+				Entry("linked sub type",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "linked"),
+					[]*service.Error{}),
+				Entry("manual sub type",
+					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "manual"),
+					[]*service.Error{}),
+				Entry("multiple",
+					NewTestSelfMonitored(nil, "unknown", nil, "unknown"),
+					[]*service.Error{
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"linked", "manual"}), "/subType", NewMeta()),
+					}),
+			)
+		})
 	})
 })

--- a/data/types/base/blood/ketone/ketone.go
+++ b/data/types/base/blood/ketone/ketone.go
@@ -1,16 +1,23 @@
 package ketone
 
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
 import (
 	"github.com/tidepool-org/platform/data"
 	commonKetone "github.com/tidepool-org/platform/data/blood/ketone"
-	"github.com/tidepool-org/platform/data/types/base"
+	"github.com/tidepool-org/platform/data/types/base/blood"
 )
 
 type Ketone struct {
-	base.Base `bson:",inline"`
-
-	Value *float64 `json:"value,omitempty" bson:"value,omitempty"`
-	Units *string  `json:"units,omitempty" bson:"units,omitempty"`
+	blood.Blood `bson:",inline"`
 }
 
 func Type() string {
@@ -32,43 +39,23 @@ func Init() *Ketone {
 }
 
 func (k *Ketone) Init() {
-	k.Base.Init()
-	k.Base.Type = Type()
-
-	k.Value = nil
-	k.Units = nil
-}
-
-func (k *Ketone) Parse(parser data.ObjectParser) error {
-	parser.SetMeta(k.Meta())
-
-	if err := k.Base.Parse(parser); err != nil {
-		return err
-	}
-
-	k.Value = parser.ParseFloat("value")
-	k.Units = parser.ParseString("units")
-
-	return nil
+	k.Blood.Init()
+	k.Type = Type()
 }
 
 func (k *Ketone) Validate(validator data.Validator) error {
-	validator.SetMeta(k.Meta())
-
-	if err := k.Base.Validate(validator); err != nil {
+	if err := k.Blood.Validate(validator); err != nil {
 		return err
 	}
 
-	validator.ValidateString("units", k.Units).Exists().OneOf(commonKetone.Units())
-	validator.ValidateFloat("value", k.Value).Exists().InRange(commonKetone.ValueRangeForUnits(k.Units))
+	validator.ValidateString("units", k.Units).OneOf(commonKetone.Units())
+	validator.ValidateFloat("value", k.Value).InRange(commonKetone.ValueRangeForUnits(k.Units))
 
 	return nil
 }
 
 func (k *Ketone) Normalize(normalizer data.Normalizer) error {
-	normalizer.SetMeta(k.Meta())
-
-	if err := k.Base.Normalize(normalizer); err != nil {
+	if err := k.Blood.Normalize(normalizer); err != nil {
 		return err
 	}
 

--- a/data/types/base/blood/ketone/ketone_suite_test.go
+++ b/data/types/base/blood/ketone/ketone_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/ketone")
+	RunSpecs(t, "data/types/base/blood/ketone")
 }

--- a/data/types/base/settings/pump/pump.go
+++ b/data/types/base/settings/pump/pump.go
@@ -5,7 +5,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/base"
 )
 
-type Settings struct {
+type Pump struct {
 	base.Base `bson:",inline"`
 
 	*Units `json:"units,omitempty" bson:"units,omitempty"`
@@ -27,17 +27,17 @@ func NewDatum() data.Datum {
 	return New()
 }
 
-func New() *Settings {
-	return &Settings{}
+func New() *Pump {
+	return &Pump{}
 }
 
-func Init() *Settings {
-	settings := New()
-	settings.Init()
-	return settings
+func Init() *Pump {
+	pump := New()
+	pump.Init()
+	return pump
 }
 
-func (s *Settings) Init() {
+func (s *Pump) Init() {
 	s.Base.Init()
 	s.Type = Type()
 
@@ -52,7 +52,7 @@ func (s *Settings) Init() {
 	s.ActiveSchedule = nil
 }
 
-func (s *Settings) Parse(parser data.ObjectParser) error {
+func (s *Pump) Parse(parser data.ObjectParser) error {
 	parser.SetMeta(s.Meta())
 
 	if err := s.Base.Parse(parser); err != nil {
@@ -71,7 +71,7 @@ func (s *Settings) Parse(parser data.ObjectParser) error {
 	return nil
 }
 
-func (s *Settings) Validate(validator data.Validator) error {
+func (s *Pump) Validate(validator data.Validator) error {
 	validator.SetMeta(s.Meta())
 
 	if err := s.Base.Validate(validator); err != nil {
@@ -127,7 +127,7 @@ func (s *Settings) Validate(validator data.Validator) error {
 	return nil
 }
 
-func (s *Settings) Normalize(normalizer data.Normalizer) error {
+func (s *Pump) Normalize(normalizer data.Normalizer) error {
 	normalizer.SetMeta(s.Meta())
 
 	if err := s.Base.Normalize(normalizer); err != nil {

--- a/data/types/base/settings/pump/pump_suite_test.go
+++ b/data/types/base/settings/pump/pump_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/pump")
+	RunSpecs(t, "data/types/base/settings/pump")
 }


### PR DESCRIPTION
@jh-bate Main refactor that previous PRs lead to. Create data type hierarchy of `blood` -> `ketone` and `blood` -> `glucose` -> `continuous`/`selfmonitored` to allow sharing of common functionality and tests. Full tests for entire hierarchy. Also missed a type rename for pump settings.