### PR TITLE
Keep 5 decimal places on converting mg/dL to mmol/L (to do otherwise implies greater accuracy than is available)

### DIFF
--- a/data/blood/glucose/glucose.go
+++ b/data/blood/glucose/glucose.go
@@ -30,6 +30,7 @@ const (
 	MgdLUpperLimit float64 = 1000.0
 
 	MmolLToMgdLConversionFactor float64 = 18.01559
+	MmolLToMgdLPrecisionFactor  float64 = 100000.0
 )
 
 func Units() []string {
@@ -62,7 +63,9 @@ func NormalizeValueForUnits(value *float64, units *string) *float64 {
 	if value != nil && units != nil {
 		switch *units {
 		case MgdL, Mgdl:
-			return app.FloatAsPointer(*value / MmolLToMgdLConversionFactor)
+			intValue := int(*value/MmolLToMgdLConversionFactor*MmolLToMgdLPrecisionFactor + 0.5)
+			floatValue := float64(intValue) / MmolLToMgdLPrecisionFactor
+			return &floatValue
 		}
 	}
 	return value

--- a/data/blood/glucose/glucose_test.go
+++ b/data/blood/glucose/glucose_test.go
@@ -101,7 +101,17 @@ var _ = Describe("Glucose", func() {
 		Entry("returns unchanged value for unknown units", app.FloatAsPointer(10.0), app.StringAsPointer("unknown"), app.FloatAsPointer(10.0)),
 		Entry("returns unchanged value for mmol/L units", app.FloatAsPointer(10.0), app.StringAsPointer("mmol/L"), app.FloatAsPointer(10.0)),
 		Entry("returns unchanged value for mmol/l units", app.FloatAsPointer(10.0), app.StringAsPointer("mmol/l"), app.FloatAsPointer(10.0)),
-		Entry("returns converted value for mg/dL units", app.FloatAsPointer(180.0), app.StringAsPointer("mg/dL"), app.FloatAsPointer(9.991346383881961)),
-		Entry("returns converted value for mg/dl units", app.FloatAsPointer(180.0), app.StringAsPointer("mg/dl"), app.FloatAsPointer(9.991346383881961)),
+		Entry("returns converted value for mg/dL units", app.FloatAsPointer(180.0), app.StringAsPointer("mg/dL"), app.FloatAsPointer(9.99135)),
+		Entry("returns converted value for mg/dl units", app.FloatAsPointer(180.0), app.StringAsPointer("mg/dl"), app.FloatAsPointer(9.99135)),
 	)
+
+	Context("NormalizeValueForUnits", func() {
+		It("properly normalizes all known mg/dL values", func() {
+			for value := int(glucose.MgdLLowerLimit); value <= int(glucose.MgdLUpperLimit); value++ {
+				normalizedValue := glucose.NormalizeValueForUnits(app.FloatAsPointer(float64(value)), app.StringAsPointer("mg/dL"))
+				Expect(normalizedValue).ToNot(BeNil())
+				Expect(int(*normalizedValue*18.01559 + 0.5)).To(Equal(value))
+			}
+		})
+	})
 })

--- a/data/blood/glucose/target_test.go
+++ b/data/blood/glucose/target_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Target", func() {
 			Entry("normalizes a target with units of unknown and values are nil", NewTestTarget(nil, nil, nil, nil), "unknown", NewTestTarget(nil, nil, nil, nil)),
 			Entry("normalizes a target with units of mmol/L", NewTestTarget(6.6, 1.0, 5.6, 7.6), "mmol/L", NewTestTarget(6.6, 1.0, 5.6, 7.6)),
 			Entry("normalizes a target with units of mmol/L and values are nil", NewTestTarget(nil, nil, nil, nil), "mmol/L", NewTestTarget(nil, nil, nil, nil)),
-			Entry("normalizes a target with units of mg/dL", NewTestTarget(120.0, 10.0, 110.0, 130.0), "mg/dL", NewTestTarget(6.66089758925464, 0.5550747991045534, 6.1058227901500866, 7.2159723883591935)),
+			Entry("normalizes a target with units of mg/dL", NewTestTarget(120.0, 10.0, 110.0, 130.0), "mg/dL", NewTestTarget(6.66090, 0.55507, 6.10582, 7.21597)),
 			Entry("normalizes a target with units of mg/dL and values are nil", NewTestTarget(nil, nil, nil, nil), "mg/dL", NewTestTarget(nil, nil, nil, nil)),
 		)
 	})

--- a/data/types/base/blood/glucose/glucose_test.go
+++ b/data/types/base/blood/glucose/glucose_test.go
@@ -211,11 +211,11 @@ var _ = Describe("Glucose", func() {
 				),
 				Entry("mg/dL units",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 180.0),
-					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 9.991346383881961),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 9.99135),
 				),
 				Entry("mg/dl units",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 180.0),
-					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 9.991346383881961),
+					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 9.99135),
 				),
 			)
 		})

--- a/data/types/base/bolus/calculator/calculator_test.go
+++ b/data/types/base/bolus/calculator/calculator_test.go
@@ -316,9 +316,9 @@ var _ = Describe("Calculator", func() {
 				Expect(*bolusCalculator.InsulinSensitivity).To(Equal(expected))
 				Expect(*bolusCalculator.BloodGlucoseTarget.Target).To(Equal(expected))
 			},
-				Entry("is expected lower bg value", 60.0, 3.33044879462732),
-				Entry("is below max", glucose.MgdLUpperLimit, 55.50747991045534),
-				Entry("is expected upper bg value", 400.0, 22.202991964182132),
+				Entry("is expected lower bg value", 60.0, 3.33045),
+				Entry("is below max", glucose.MgdLUpperLimit, 55.50748),
+				Entry("is expected upper bg value", 400.0, 22.20299),
 			)
 		})
 

--- a/data/types/base/device/calibration/calibration_test.go
+++ b/data/types/base/device/calibration/calibration_test.go
@@ -117,9 +117,9 @@ var _ = Describe("Calibration", func() {
 			Expect(*calibrationEvent.Units).To(Equal(glucose.MmolL))
 			Expect(*calibrationEvent.Value).To(Equal(expected))
 		},
-			Entry("is expected lower bg value", 60.0, 3.33044879462732),
-			Entry("is below max", glucose.MgdLUpperLimit, 55.50747991045534),
-			Entry("is expected upper bg value", 400.0, 22.202991964182132),
+			Entry("is expected lower bg value", 60.0, 3.33045),
+			Entry("is below max", glucose.MgdLUpperLimit, 55.50748),
+			Entry("is expected upper bg value", 400.0, 22.20299),
 		)
 	})
 })

--- a/data/types/base/settings/pump/pump_test.go
+++ b/data/types/base/settings/pump/pump_test.go
@@ -449,9 +449,9 @@ var _ = Describe("Settings", func() {
 				Expect(*bgTarget.Low).To(Equal(expected))
 			}
 		},
-			Entry("is very low", 60.1, 3.3359995426183655),
-			Entry("is very high", 800.0, 44.405983928364265),
-			Entry("is normal", 160.0, 8.881196785672854),
+			Entry("is very low", 60.1, 3.33600),
+			Entry("is very high", 800.0, 44.40598),
+			Entry("is normal", 160.0, 8.88120),
 		)
 
 		DescribeTable("normalization when high mg/dL", func(val, expected float64) {
@@ -480,9 +480,9 @@ var _ = Describe("Settings", func() {
 				Expect(*bgTarget.High).To(Equal(expected))
 			}
 		},
-			Entry("is very low", 100.0, 5.550747991045533),
-			Entry("is very high", 950.0, 52.73210591493257),
-			Entry("is normal", 200.0, 11.101495982091066),
+			Entry("is very low", 100.0, 5.55075),
+			Entry("is very high", 950.0, 52.73211),
+			Entry("is normal", 200.0, 11.10150),
 		)
 
 		DescribeTable("normalization when target mg/dL", func(val, expected float64) {
@@ -511,9 +511,9 @@ var _ = Describe("Settings", func() {
 				Expect(*bgTarget.Target.Target).To(Equal(expected))
 			}
 		},
-			Entry("is very low", 70.1, 3.8910743417229186),
-			Entry("is very high", 500.0, 27.75373995522767),
-			Entry("is normal", 180.1, 9.996897131873006),
+			Entry("is very low", 70.1, 3.89107),
+			Entry("is very high", 500.0, 27.75374),
+			Entry("is normal", 180.1, 9.99690),
 		)
 	})
 
@@ -573,9 +573,9 @@ var _ = Describe("Settings", func() {
 				Expect(*insulinSensitivity.Amount).To(Equal(expected))
 			}
 		},
-			Entry("is very low", 60.0, 3.33044879462732),
-			Entry("is very high", glucose.MgdLUpperLimit, 55.50747991045534),
-			Entry("is normal", 160.0, 8.881196785672854),
+			Entry("is very low", 60.0, 3.33045),
+			Entry("is very high", glucose.MgdLUpperLimit, 55.50748),
+			Entry("is normal", 160.0, 8.88120),
 		)
 	})
 })


### PR DESCRIPTION
@jh-bate What it says above.