### PR TITLE
Add data identity fields to be used by hash generation for de-duplication

### DIFF
--- a/data/datum.go
+++ b/data/datum.go
@@ -19,6 +19,8 @@ type Datum interface {
 	Validate(validator Validator) error
 	Normalize(normalizer Normalizer) error
 
+	IdentityFields() ([]string, error)
+
 	SetUserID(userID string)
 	SetGroupID(groupID string)
 	SetDatasetID(datasetID string)

--- a/data/test/datum.go
+++ b/data/test/datum.go
@@ -20,6 +20,8 @@ type Datum struct {
 	NormalizeInvocations                 int
 	NormalizeInputs                      []data.Normalizer
 	NormalizeOutputs                     []error
+	IdentityFieldsInvocations            int
+	IdentityFieldsOutputs                []IdentityFieldsOutput
 	SetUserIDInvocations                 int
 	SetUserIDInputs                      []string
 	SetGroupIDInvocations                int
@@ -102,6 +104,18 @@ func (d *Datum) Normalize(normalizer data.Normalizer) error {
 	output := d.NormalizeOutputs[0]
 	d.NormalizeOutputs = d.NormalizeOutputs[1:]
 	return output
+}
+
+func (d *Datum) IdentityFields() ([]string, error) {
+	d.IdentityFieldsInvocations++
+
+	if len(d.IdentityFieldsOutputs) == 0 {
+		panic("Unexpected invocation of IdentityFields on Session")
+	}
+
+	output := d.IdentityFieldsOutputs[0]
+	d.IdentityFieldsOutputs = d.IdentityFieldsOutputs[1:]
+	return output.IdentityFields, output.Error
 }
 
 func (d *Datum) SetUserID(userID string) {
@@ -187,5 +201,6 @@ func (d *Datum) UnusedOutputsCount() int {
 		len(d.ParseOutputs) +
 		len(d.ValidateOutputs) +
 		len(d.NormalizeOutputs) +
+		len(d.IdentityFieldsOutputs) +
 		len(d.DeduplicatorDescriptorOutputs)
 }

--- a/data/types/base/basal/basal.go
+++ b/data/types/base/basal/basal.go
@@ -11,6 +11,7 @@ package basal
  */
 
 import (
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/base"
 )
@@ -68,4 +69,17 @@ func (b *Basal) Normalize(normalizer data.Normalizer) error {
 	normalizer.SetMeta(b.Meta())
 
 	return b.Base.Normalize(normalizer)
+}
+
+func (b *Basal) IdentityFields() ([]string, error) {
+	identityFields, err := b.Base.IdentityFields()
+	if err != nil {
+		return nil, err
+	}
+
+	if b.DeliveryType == "" {
+		return nil, app.Error("basal", "delivery type is empty")
+	}
+
+	return append(identityFields, b.DeliveryType), nil
 }

--- a/data/types/base/base.go
+++ b/data/types/base/base.go
@@ -120,6 +120,29 @@ func (b *Base) Normalize(normalizer data.Normalizer) error {
 	return nil
 }
 
+func (b *Base) IdentityFields() ([]string, error) {
+	if b.UserID == "" {
+		return nil, app.Error("base", "user id is empty")
+	}
+	if b.DeviceID == nil {
+		return nil, app.Error("base", "device id is missing")
+	}
+	if *b.DeviceID == "" {
+		return nil, app.Error("base", "device id is empty")
+	}
+	if b.Time == nil {
+		return nil, app.Error("base", "time is missing")
+	}
+	if *b.Time == "" {
+		return nil, app.Error("base", "time is empty")
+	}
+	if b.Type == "" {
+		return nil, app.Error("base", "type is empty")
+	}
+
+	return []string{b.UserID, *b.DeviceID, *b.Time, b.Type}, nil
+}
+
 func (b *Base) SetUserID(userID string) {
 	b.UserID = userID
 }

--- a/data/types/base/base_test.go
+++ b/data/types/base/base_test.go
@@ -20,6 +20,68 @@ var _ = Describe("Base", func() {
 			testBase.Init()
 		})
 
+		Context("IdentityFields", func() {
+			var userID string
+			var deviceID string
+
+			BeforeEach(func() {
+				userID = app.NewID()
+				deviceID = app.NewID()
+				testBase.UserID = userID
+				testBase.DeviceID = &deviceID
+				testBase.Time = app.StringAsPointer("2016-09-06T13:45:58-07:00")
+				testBase.Type = "testBase"
+			})
+
+			It("returns error if user id is empty", func() {
+				testBase.UserID = ""
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).To(MatchError("base: user id is empty"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if device id is missing", func() {
+				testBase.DeviceID = nil
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).To(MatchError("base: device id is missing"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if device id is empty", func() {
+				testBase.DeviceID = app.StringAsPointer("")
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).To(MatchError("base: device id is empty"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if time is missing", func() {
+				testBase.Time = nil
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).To(MatchError("base: time is missing"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if time is empty", func() {
+				testBase.Time = app.StringAsPointer("")
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).To(MatchError("base: time is empty"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if type is empty", func() {
+				testBase.Type = ""
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).To(MatchError("base: type is empty"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns the expected identity fields", func() {
+				identityFields, err := testBase.IdentityFields()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(identityFields).To(Equal([]string{userID, deviceID, "2016-09-06T13:45:58-07:00", "testBase"}))
+			})
+		})
+
 		Context("with deduplicator descriptor", func() {
 			var testDeduplicatorDescriptor *data.DeduplicatorDescriptor
 

--- a/data/types/base/blood/blood.go
+++ b/data/types/base/blood/blood.go
@@ -11,6 +11,9 @@ package blood
  */
 
 import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/base"
 )
@@ -59,4 +62,20 @@ func (b *Blood) Normalize(normalizer data.Normalizer) error {
 	normalizer.SetMeta(b.Meta())
 
 	return b.Base.Normalize(normalizer)
+}
+
+func (b *Blood) IdentityFields() ([]string, error) {
+	identityFields, err := b.Base.IdentityFields()
+	if err != nil {
+		return nil, err
+	}
+
+	if b.Units == nil {
+		return nil, app.Error("blood", "units is missing")
+	}
+	if b.Value == nil {
+		return nil, app.Error("blood", "value is missing")
+	}
+
+	return append(identityFields, *b.Units, strconv.FormatFloat(*b.Value, 'f', -1, 64)), nil
 }

--- a/data/types/base/blood/blood_test.go
+++ b/data/types/base/blood/blood_test.go
@@ -181,6 +181,48 @@ var _ = Describe("Blood", func() {
 					Expect(testBlood.Normalize(testNormalizer)).To(Succeed())
 				})
 			})
+
+			Context("IdentityFields", func() {
+				var userID string
+				var deviceID string
+
+				BeforeEach(func() {
+					userID = app.NewID()
+					deviceID = app.NewID()
+					testBlood.UserID = userID
+					testBlood.DeviceID = &deviceID
+					testBlood.Time = app.StringAsPointer("2016-09-06T13:45:58-07:00")
+					testBlood.Units = app.StringAsPointer("mmol/L")
+					testBlood.Value = app.FloatAsPointer(1)
+				})
+
+				It("returns error if user id is empty", func() {
+					testBlood.UserID = ""
+					identityFields, err := testBlood.IdentityFields()
+					Expect(err).To(MatchError("base: user id is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if units is missing", func() {
+					testBlood.Units = nil
+					identityFields, err := testBlood.IdentityFields()
+					Expect(err).To(MatchError("blood: units is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if value is missing", func() {
+					testBlood.Value = nil
+					identityFields, err := testBlood.IdentityFields()
+					Expect(err).To(MatchError("blood: value is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns the expected identity fields", func() {
+					identityFields, err := testBlood.IdentityFields()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(identityFields).To(Equal([]string{userID, deviceID, "2016-09-06T13:45:58-07:00", "testBlood", "mmol/L", "1"}))
+				})
+			})
 		})
 	})
 })

--- a/data/types/base/bolus/bolus.go
+++ b/data/types/base/bolus/bolus.go
@@ -1,16 +1,17 @@
 package bolus
 
 /* CHECKLIST
- * [ ] Uses interfaces as appropriate
- * [ ] Private package variables use underscore prefix
- * [ ] All parameters validated
- * [ ] All errors handled
- * [ ] Reviewed for concurrency safety
- * [ ] Code complete
- * [ ] Full test coverage
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
  */
 
 import (
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/base"
 )
@@ -68,4 +69,17 @@ func (b *Bolus) Normalize(normalizer data.Normalizer) error {
 	normalizer.SetMeta(b.Meta())
 
 	return b.Base.Normalize(normalizer)
+}
+
+func (b *Bolus) IdentityFields() ([]string, error) {
+	identityFields, err := b.Base.IdentityFields()
+	if err != nil {
+		return nil, err
+	}
+
+	if b.SubType == "" {
+		return nil, app.Error("bolus", "sub type is empty")
+	}
+
+	return append(identityFields, b.SubType), nil
 }

--- a/data/types/base/bolus/bolus_test.go
+++ b/data/types/base/bolus/bolus_test.go
@@ -1,4 +1,4 @@
-package basal_test
+package bolus_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -10,76 +10,76 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
-	"github.com/tidepool-org/platform/data/types/base/basal"
+	"github.com/tidepool-org/platform/data/types/base/bolus"
 	"github.com/tidepool-org/platform/data/types/base/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
 )
 
-func NewMeta(deliveryType string) interface{} {
-	return &basal.Meta{
-		Type:         "basal",
-		DeliveryType: deliveryType,
+func NewMeta(subType string) interface{} {
+	return &bolus.Meta{
+		Type:    "bolus",
+		SubType: subType,
 	}
 }
 
-func NewTestBasal(sourceTime interface{}, sourceDeliveryType interface{}) *basal.Basal {
-	testBasal := &basal.Basal{}
-	testBasal.Init()
-	testBasal.DeviceID = app.StringAsPointer(app.NewID())
+func NewTestBolus(sourceTime interface{}, sourceSubType interface{}) *bolus.Bolus {
+	testBolus := &bolus.Bolus{}
+	testBolus.Init()
+	testBolus.DeviceID = app.StringAsPointer(app.NewID())
 	if value, ok := sourceTime.(string); ok {
-		testBasal.Time = app.StringAsPointer(value)
+		testBolus.Time = app.StringAsPointer(value)
 	}
-	if value, ok := sourceDeliveryType.(string); ok {
-		testBasal.DeliveryType = value
+	if value, ok := sourceSubType.(string); ok {
+		testBolus.SubType = value
 	}
-	return testBasal
+	return testBolus
 }
 
-var _ = Describe("Basal", func() {
+var _ = Describe("Bolus", func() {
 	Context("Type", func() {
 		It("returns the expected type", func() {
-			Expect(basal.Type()).To(Equal("basal"))
+			Expect(bolus.Type()).To(Equal("bolus"))
 		})
 	})
 
-	Context("with new basal", func() {
-		var testBasal *basal.Basal
+	Context("with new bolus", func() {
+		var testBolus *bolus.Bolus
 
 		BeforeEach(func() {
-			testBasal = &basal.Basal{}
+			testBolus = &bolus.Bolus{}
 		})
 
 		Context("Init", func() {
-			It("initializes the basal", func() {
-				testBasal.Init()
-				Expect(testBasal.ID).ToNot(BeEmpty())
-				Expect(testBasal.Type).To(Equal("basal"))
-				Expect(testBasal.DeliveryType).To(BeEmpty())
+			It("initializes the bolus", func() {
+				testBolus.Init()
+				Expect(testBolus.ID).ToNot(BeEmpty())
+				Expect(testBolus.Type).To(Equal("bolus"))
+				Expect(testBolus.SubType).To(BeEmpty())
 			})
 		})
 
 		Context("with initialized", func() {
 			BeforeEach(func() {
-				testBasal.Init()
+				testBolus.Init()
 			})
 
 			Context("Meta", func() {
-				It("returns the meta with no delivery type", func() {
-					testBasal.Init()
-					Expect(testBasal.Meta()).To(Equal(NewMeta("")))
+				It("returns the meta with no sub type", func() {
+					testBolus.Init()
+					Expect(testBolus.Meta()).To(Equal(NewMeta("")))
 				})
 
-				It("returns the meta with delivery type", func() {
-					testBasal.Init()
-					testBasal.DeliveryType = "scheduled"
-					Expect(testBasal.Meta()).To(Equal(NewMeta("scheduled")))
+				It("returns the meta with sub type", func() {
+					testBolus.Init()
+					testBolus.SubType = "dual/square"
+					Expect(testBolus.Meta()).To(Equal(NewMeta("dual/square")))
 				})
 			})
 
 			DescribeTable("Parse",
-				func(sourceObject *map[string]interface{}, expectedBasal *basal.Basal, expectedErrors []*service.Error) {
+				func(sourceObject *map[string]interface{}, expectedBolus *bolus.Bolus, expectedErrors []*service.Error) {
 					testContext, err := context.NewStandard(log.NewNull())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(testContext).ToNot(BeNil())
@@ -89,77 +89,77 @@ var _ = Describe("Basal", func() {
 					testParser, err := parser.NewStandardObject(testContext, testFactory, sourceObject, parser.AppendErrorNotParsed)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(testParser).ToNot(BeNil())
-					Expect(testBasal.Parse(testParser)).To(Succeed())
-					Expect(testBasal.Time).To(Equal(expectedBasal.Time))
-					Expect(testBasal.DeliveryType).To(Equal(expectedBasal.DeliveryType))
+					Expect(testBolus.Parse(testParser)).To(Succeed())
+					Expect(testBolus.Time).To(Equal(expectedBolus.Time))
+					Expect(testBolus.SubType).To(Equal(expectedBolus.SubType))
 					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
 				},
 				Entry("parses object that is nil",
 					nil,
-					NewTestBasal(nil, nil),
+					NewTestBolus(nil, nil),
 					[]*service.Error{}),
 				Entry("parses object that is empty",
 					&map[string]interface{}{},
-					NewTestBasal(nil, nil),
+					NewTestBolus(nil, nil),
 					[]*service.Error{}),
 				Entry("parses object that has valid time",
 					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00"},
-					NewTestBasal("2016-09-06T13:45:58-07:00", nil),
+					NewTestBolus("2016-09-06T13:45:58-07:00", nil),
 					[]*service.Error{}),
 				Entry("parses object that has invalid time",
 					&map[string]interface{}{"time": 0},
-					NewTestBasal(nil, nil),
+					NewTestBolus(nil, nil),
 					[]*service.Error{
 						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
-				Entry("does not parse delivery type",
-					&map[string]interface{}{"deliveryType": "scheduled"},
-					NewTestBasal(nil, nil),
+				Entry("does not parse sub type",
+					&map[string]interface{}{"subType": "dual/square"},
+					NewTestBolus(nil, nil),
 					[]*service.Error{}),
 				Entry("parses object that has multiple valid fields",
-					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "deliveryType": "scheduled"},
-					NewTestBasal("2016-09-06T13:45:58-07:00", nil),
+					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "subType": "dual/square"},
+					NewTestBolus("2016-09-06T13:45:58-07:00", nil),
 					[]*service.Error{}),
 				Entry("parses object that has multiple invalid fields",
-					&map[string]interface{}{"time": 0, "deliveryType": 0},
-					NewTestBasal(nil, nil),
+					&map[string]interface{}{"time": 0, "subType": 0},
+					NewTestBolus(nil, nil),
 					[]*service.Error{
 						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 			)
 
 			DescribeTable("Validate",
-				func(sourceBasal *basal.Basal, expectedErrors []*service.Error) {
+				func(sourceBolus *bolus.Bolus, expectedErrors []*service.Error) {
 					testContext, err := context.NewStandard(log.NewNull())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(testContext).ToNot(BeNil())
 					testValidator, err := validator.NewStandard(testContext)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(testValidator).ToNot(BeNil())
-					Expect(sourceBasal.Validate(testValidator)).To(Succeed())
+					Expect(sourceBolus.Validate(testValidator)).To(Succeed())
 					Expect(testContext.Errors()).To(ConsistOf(expectedErrors))
 				},
 				Entry("all valid",
-					NewTestBasal("2016-09-06T13:45:58-07:00", "scheduled"),
+					NewTestBolus("2016-09-06T13:45:58-07:00", "dual/square"),
 					[]*service.Error{}),
 				Entry("missing time",
-					NewTestBasal(nil, "scheduled"),
+					NewTestBolus(nil, "dual/square"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("scheduled")),
+						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("dual/square")),
 					}),
-				Entry("missing delivery type",
-					NewTestBasal("2016-09-06T13:45:58-07:00", nil),
+				Entry("missing sub type",
+					NewTestBolus("2016-09-06T13:45:58-07:00", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueEmpty(), "/deliveryType", NewMeta("")),
+						testing.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
 					}),
-				Entry("specified delivery type",
-					NewTestBasal("2016-09-06T13:45:58-07:00", "specified"),
+				Entry("specified sub type",
+					NewTestBolus("2016-09-06T13:45:58-07:00", "specified"),
 					[]*service.Error{}),
 				Entry("multiple",
-					NewTestBasal(nil, nil),
+					NewTestBolus(nil, nil),
 					[]*service.Error{
 						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
-						testing.ComposeError(service.ErrorValueEmpty(), "/deliveryType", NewMeta("")),
+						testing.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
 					}),
 			)
 
@@ -171,7 +171,7 @@ var _ = Describe("Basal", func() {
 					testNormalizer, err := normalizer.NewStandard(testContext)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(testNormalizer).ToNot(BeNil())
-					Expect(testBasal.Normalize(testNormalizer)).To(Succeed())
+					Expect(testBolus.Normalize(testNormalizer)).To(Succeed())
 				})
 			})
 
@@ -182,30 +182,30 @@ var _ = Describe("Basal", func() {
 				BeforeEach(func() {
 					userID = app.NewID()
 					deviceID = app.NewID()
-					testBasal.UserID = userID
-					testBasal.DeviceID = &deviceID
-					testBasal.Time = app.StringAsPointer("2016-09-06T13:45:58-07:00")
-					testBasal.DeliveryType = "scheduled"
+					testBolus.UserID = userID
+					testBolus.DeviceID = &deviceID
+					testBolus.Time = app.StringAsPointer("2016-09-06T13:45:58-07:00")
+					testBolus.SubType = "dual/square"
 				})
 
 				It("returns error if user id is empty", func() {
-					testBasal.UserID = ""
-					identityFields, err := testBasal.IdentityFields()
+					testBolus.UserID = ""
+					identityFields, err := testBolus.IdentityFields()
 					Expect(err).To(MatchError("base: user id is empty"))
 					Expect(identityFields).To(BeEmpty())
 				})
 
-				It("returns error if delivery type is empty", func() {
-					testBasal.DeliveryType = ""
-					identityFields, err := testBasal.IdentityFields()
-					Expect(err).To(MatchError("basal: delivery type is empty"))
+				It("returns error if sub type is empty", func() {
+					testBolus.SubType = ""
+					identityFields, err := testBolus.IdentityFields()
+					Expect(err).To(MatchError("bolus: sub type is empty"))
 					Expect(identityFields).To(BeEmpty())
 				})
 
 				It("returns the expected identity fields", func() {
-					identityFields, err := testBasal.IdentityFields()
+					identityFields, err := testBolus.IdentityFields()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(identityFields).To(Equal([]string{userID, deviceID, "2016-09-06T13:45:58-07:00", "basal", "scheduled"}))
+					Expect(identityFields).To(Equal([]string{userID, deviceID, "2016-09-06T13:45:58-07:00", "bolus", "dual/square"}))
 				})
 			})
 		})

--- a/data/types/base/device/device.go
+++ b/data/types/base/device/device.go
@@ -1,16 +1,17 @@
 package device
 
 /* CHECKLIST
- * [ ] Uses interfaces as appropriate
- * [ ] Private package variables use underscore prefix
- * [ ] All parameters validated
- * [ ] All errors handled
- * [ ] Reviewed for concurrency safety
- * [ ] Code complete
- * [ ] Full test coverage
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
  */
 
 import (
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/base"
 )
@@ -68,4 +69,17 @@ func (d *Device) Normalize(normalizer data.Normalizer) error {
 	normalizer.SetMeta(d.Meta())
 
 	return d.Base.Normalize(normalizer)
+}
+
+func (d *Device) IdentityFields() ([]string, error) {
+	identityFields, err := d.Base.IdentityFields()
+	if err != nil {
+		return nil, err
+	}
+
+	if d.SubType == "" {
+		return nil, app.Error("device", "sub type is empty")
+	}
+
+	return append(identityFields, d.SubType), nil
 }


### PR DESCRIPTION
@jh-bate The identity fields are the values for each data that are used to generate a unique hash for de-duplication. These are similar to `jellyfish`, but order is slightly different and one or two additional fields for ensuring uniqueness. Add full tests for `bolus` and `device` data.