### PR TITLE
Add functions to generate unique test data

### DIFF
--- a/data/deduplicator/delegate_test.go
+++ b/data/deduplicator/delegate_test.go
@@ -29,11 +29,11 @@ var _ = Describe("Delegate", func() {
 		})
 
 		It("returns success with one factory", func() {
-			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{&test.Factory{}})).ToNot(BeNil())
+			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{test.NewFactory()})).ToNot(BeNil())
 		})
 
 		It("returns success with multiple factories", func() {
-			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{&test.Factory{}, &test.Factory{}, &test.Factory{}, &test.Factory{}})).ToNot(BeNil())
+			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{test.NewFactory(), test.NewFactory(), test.NewFactory(), test.NewFactory()})).ToNot(BeNil())
 		})
 	})
 
@@ -45,8 +45,10 @@ var _ = Describe("Delegate", func() {
 
 		BeforeEach(func() {
 			var err error
-			testFirstFactory = &test.Factory{CanDeduplicateDatasetOutputs: []test.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}}
-			testSecondFactory = &test.Factory{CanDeduplicateDatasetOutputs: []test.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}}
+			testFirstFactory = test.NewFactory()
+			testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
+			testSecondFactory = test.NewFactory()
+			testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			testDelegateFactory, err = deduplicator.NewDelegateFactory([]deduplicator.Factory{testFirstFactory, testSecondFactory})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testDelegateFactory).ToNot(BeNil())
@@ -105,7 +107,7 @@ var _ = Describe("Delegate", func() {
 
 			BeforeEach(func() {
 				testLogger = log.NewNull()
-				testDataStoreSession = &testDataStore.Session{}
+				testDataStoreSession = testDataStore.NewSession()
 			})
 
 			AfterEach(func() {
@@ -154,7 +156,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns a deduplicator if any contained factory can deduplicate the dataset", func() {
-				secondDeduplicator := &testData.Deduplicator{}
+				secondDeduplicator := testData.NewDeduplicator()
 				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
 				testSecondFactory.NewDeduplicatorOutputs = []test.NewDeduplicatorOutput{{Deduplicator: secondDeduplicator, Error: nil}}
 				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
@@ -163,7 +165,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns a deduplicator if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
-				firstDeduplicator := &testData.Deduplicator{}
+				firstDeduplicator := testData.NewDeduplicator()
 				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
 				testFirstFactory.NewDeduplicatorOutputs = []test.NewDeduplicatorOutput{{Deduplicator: firstDeduplicator, Error: nil}}
 				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}

--- a/data/deduplicator/test/factory.go
+++ b/data/deduplicator/test/factory.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/base/upload"
@@ -24,12 +25,19 @@ type NewDeduplicatorOutput struct {
 }
 
 type Factory struct {
+	ID                               string
 	CanDeduplicateDatasetInvocations int
 	CanDeduplicateDatasetInputs      []*upload.Upload
 	CanDeduplicateDatasetOutputs     []CanDeduplicateDatasetOutput
 	NewDeduplicatoInvocations        int
 	NewDeduplicatorInputs            []NewDeduplicatorInput
 	NewDeduplicatorOutputs           []NewDeduplicatorOutput
+}
+
+func NewFactory() *Factory {
+	return &Factory{
+		ID: app.NewID(),
+	}
 }
 
 func (f *Factory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {

--- a/data/deduplicator/truncate_test.go
+++ b/data/deduplicator/truncate_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Truncate", func() {
 
 		Context("NewDeduplicator", func() {
 			It("returns an error if the logger is missing", func() {
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(nil, &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(nil, testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: logger is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
@@ -129,74 +129,74 @@ var _ = Describe("Truncate", func() {
 			})
 
 			It("returns an error if the dataset is missing", func() {
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, nil)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), nil)
 				Expect(err).To(MatchError("deduplicator: dataset is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset id is missing", func() {
 				testDataset.UploadID = ""
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset id is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset user id is missing", func() {
 				testDataset.UserID = ""
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset group id is missing", func() {
 				testDataset.GroupID = ""
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset device id is missing", func() {
 				testDataset.DeviceID = nil
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset device id is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset device id is empty", func() {
 				testDataset.DeviceID = app.StringAsPointer("")
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset device id is empty"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset device manufacturers is missing", func() {
 				testDataset.DeviceManufacturers = nil
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset device manufacturers is missing"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns false if the device manufacturers is empty", func() {
 				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{})
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset device manufacturers does not contain expected device manufacturer"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns false if the device manufacturers does not contain expected device manufacturer", func() {
 				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Cobra"})
-				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)
+				testTruncateDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset device manufacturers does not contain expected device manufacturer"))
 				Expect(testTruncateDeduplicator).To(BeNil())
 			})
 
 			It("returns a new deduplicator upon success", func() {
-				Expect(testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)).ToNot(BeNil())
+				Expect(testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)).ToNot(BeNil())
 			})
 
 			It("returns a new deduplicator upon success with multiple device manufacturers", func() {
 				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Animas", "Cobra"})
-				Expect(testFactory.NewDeduplicator(log.NewNull(), &testDataStore.Session{}, testDataset)).ToNot(BeNil())
+				Expect(testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)).ToNot(BeNil())
 			})
 		})
 
@@ -206,7 +206,7 @@ var _ = Describe("Truncate", func() {
 
 			BeforeEach(func() {
 				var err error
-				testDataStoreSession = &testDataStore.Session{}
+				testDataStoreSession = testDataStore.NewSession()
 				testTruncateDeduplicator, err = testFactory.NewDeduplicator(log.NewNull(), testDataStoreSession, testDataset)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(testTruncateDeduplicator).ToNot(BeNil())

--- a/data/factory/standard_test.go
+++ b/data/factory/standard_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Standard", func() {
 			})
 
 			It("returns a NewFunc that returns the datum that the datumFunc returns", func() {
-				testDatum := &testData.Datum{}
+				testDatum := testData.NewDatum()
 				newFunc := factory.NewNewFuncWithFunc(func() data.Datum { return testDatum })
 				Expect(newFunc).ToNot(BeNil())
 				Expect(newFunc(testInspector)).To(Equal(testDatum))
@@ -135,7 +135,7 @@ var _ = Describe("Standard", func() {
 		var testInspector *TestInspector
 
 		BeforeEach(func() {
-			testDatum = &testData.Datum{}
+			testDatum = testData.NewDatum()
 			testNewFuncMap = factory.NewFuncMap{
 				"value-datum-func-returns-datum": func(_ data.Inspector) (data.Datum, error) { return testDatum, nil },
 				"value-datum-func-returns-error": func(_ data.Inspector) (data.Datum, error) { return nil, errors.New("test: datum func returns error") },

--- a/data/normalizer/standard_test.go
+++ b/data/normalizer/standard_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Standard", func() {
 			var firstDatum *testData.Datum
 
 			BeforeEach(func() {
-				firstDatum = &testData.Datum{}
+				firstDatum = testData.NewDatum()
 				standard.AppendDatum(firstDatum)
 			})
 
@@ -84,7 +84,7 @@ var _ = Describe("Standard", func() {
 				var secondDatum *testData.Datum
 
 				BeforeEach(func() {
-					secondDatum = &testData.Datum{}
+					secondDatum = testData.NewDatum()
 					standard.AppendDatum(secondDatum)
 				})
 
@@ -117,7 +117,7 @@ var _ = Describe("Standard", func() {
 				var firstDatum *testData.Datum
 
 				BeforeEach(func() {
-					firstDatum = &testData.Datum{}
+					firstDatum = testData.NewDatum()
 					child.AppendDatum(firstDatum)
 				})
 
@@ -133,7 +133,7 @@ var _ = Describe("Standard", func() {
 					var secondDatum *testData.Datum
 
 					BeforeEach(func() {
-						secondDatum = &testData.Datum{}
+						secondDatum = testData.NewDatum()
 						standard.AppendDatum(secondDatum)
 					})
 

--- a/data/parser/parser_test.go
+++ b/data/parser/parser_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Parser", func() {
 		var testFactory *TestFactory
 
 		BeforeEach(func() {
-			testDatum = &testData.Datum{}
+			testDatum = testData.NewDatum()
 			testDatum.ParseOutputs = []error{nil}
 			testObjectParser = &TestObjectParser{}
 			testObjectParser.ObjectOutputs = []*map[string]interface{}{{}}
@@ -82,8 +82,8 @@ var _ = Describe("Parser", func() {
 		var testArrayParser *TestArrayParser
 
 		BeforeEach(func() {
-			testDatum1 = &testData.Datum{}
-			testDatum2 = &testData.Datum{}
+			testDatum1 = testData.NewDatum()
+			testDatum2 = testData.NewDatum()
 			testArrayParser = &TestArrayParser{}
 			testArrayParser.ArrayOutputs = []*[]interface{}{{testDatum1, testDatum2}}
 			testArrayParser.ParseDatumOutputs = []*data.Datum{&testDatum1, &testDatum2}

--- a/data/parser/standard_array_test.go
+++ b/data/parser/standard_array_test.go
@@ -548,7 +548,7 @@ var _ = Describe("StandardArray", func() {
 			var testDatum *testData.Datum
 
 			BeforeEach(func() {
-				testDatum = &testData.Datum{}
+				testDatum = testData.NewDatum()
 				testDatum.ParseOutputs = []error{nil}
 				testFactory.InitOutputs = []InitOutput{{testDatum, nil}}
 				standardArray, _ = parser.NewStandardArray(standardContext, testFactory, &[]interface{}{
@@ -614,9 +614,9 @@ var _ = Describe("StandardArray", func() {
 			var testDatum2 *testData.Datum
 
 			BeforeEach(func() {
-				testDatum1 = &testData.Datum{}
+				testDatum1 = testData.NewDatum()
 				testDatum1.ParseOutputs = []error{nil}
-				testDatum2 = &testData.Datum{}
+				testDatum2 = testData.NewDatum()
 				testDatum2.ParseOutputs = []error{nil}
 				testFactory.InitOutputs = []InitOutput{{testDatum1, nil}, {testDatum2, nil}}
 				standardArray, _ = parser.NewStandardArray(standardContext, testFactory, &[]interface{}{

--- a/data/parser/standard_object_test.go
+++ b/data/parser/standard_object_test.go
@@ -503,7 +503,7 @@ var _ = Describe("StandardObject", func() {
 			var testDatum *testData.Datum
 
 			BeforeEach(func() {
-				testDatum = &testData.Datum{}
+				testDatum = testData.NewDatum()
 				testDatum.ParseOutputs = []error{nil}
 				testFactory.InitOutputs = []InitOutput{{testDatum, nil}}
 				standardObject, _ = parser.NewStandardObject(standardContext, testFactory, &map[string]interface{}{
@@ -564,9 +564,9 @@ var _ = Describe("StandardObject", func() {
 			var testDatum2 *testData.Datum
 
 			BeforeEach(func() {
-				testDatum1 = &testData.Datum{}
+				testDatum1 = testData.NewDatum()
 				testDatum1.ParseOutputs = []error{nil}
-				testDatum2 = &testData.Datum{}
+				testDatum2 = testData.NewDatum()
 				testDatum2.ParseOutputs = []error{nil}
 				testFactory.InitOutputs = []InitOutput{{testDatum1, nil}, {testDatum2, nil}}
 				standardObject, _ = parser.NewStandardObject(standardContext, testFactory, &map[string]interface{}{

--- a/data/store/test/session.go
+++ b/data/store/test/session.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/base/upload"
@@ -29,6 +30,7 @@ type CreateDatasetDataInput struct {
 }
 
 type Session struct {
+	ID                                string
 	IsClosedInvocations               int
 	IsClosedOutputs                   []bool
 	CloseInvocations                  int
@@ -61,6 +63,12 @@ type Session struct {
 	DestroyDataForUserByIDInvocations int
 	DestroyDataForUserByIDInputs      []string
 	DestroyDataForUserByIDOutputs     []error
+}
+
+func NewSession() *Session {
+	return &Session{
+		ID: app.NewID(),
+	}
 }
 
 func (s *Session) IsClosed() bool {

--- a/data/test/datum.go
+++ b/data/test/datum.go
@@ -1,6 +1,9 @@
 package test
 
-import "github.com/tidepool-org/platform/data"
+import (
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+)
 
 type IdentityFieldsOutput struct {
 	IdentityFields []string
@@ -8,6 +11,7 @@ type IdentityFieldsOutput struct {
 }
 
 type Datum struct {
+	ID                                   string
 	InitInvocations                      int
 	MetaInvocations                      int
 	MetaOutputs                          []interface{}
@@ -46,6 +50,12 @@ type Datum struct {
 	DeduplicatorDescriptorOutputs        []*data.DeduplicatorDescriptor
 	SetDeduplicatorDescriptorInvocations int
 	SetDeduplicatorDescriptorInputs      []*data.DeduplicatorDescriptor
+}
+
+func NewDatum() *Datum {
+	return &Datum{
+		ID: app.NewID(),
+	}
 }
 
 func (d *Datum) Init() {

--- a/data/test/deduplicator.go
+++ b/data/test/deduplicator.go
@@ -1,8 +1,12 @@
 package test
 
-import "github.com/tidepool-org/platform/data"
+import (
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+)
 
 type Deduplicator struct {
+	ID                           string
 	InitializeDatasetInvocations int
 	InitializeDatasetOutputs     []error
 	AddDataToDatasetInvocations  int
@@ -10,6 +14,12 @@ type Deduplicator struct {
 	AddDataToDatasetOutputs      []error
 	FinalizeDatasetInvocations   int
 	FinalizeDatasetOutputs       []error
+}
+
+func NewDeduplicator() *Deduplicator {
+	return &Deduplicator{
+		ID: app.NewID(),
+	}
 }
 
 func (d *Deduplicator) InitializeDataset() error {

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -190,7 +190,7 @@ func NewTestContext() *TestContext {
 		},
 		MetricServicesClientImpl:  &TestMetricServicesClient{},
 		UserServicesClientImpl:    &TestUserServicesClient{},
-		DataStoreSessionImpl:      &testDataStore.Session{},
+		DataStoreSessionImpl:      testDataStore.NewSession(),
 		TaskStoreSessionImpl:      &TestTaskStoreSession{},
 		AuthenticationDetailsImpl: &TestAuthenticationDetails{},
 	}


### PR DESCRIPTION
@jh-bate By creating and using explicit New* functions for test mocks, we can add a unique identifier to each test mock for comparison purposes (implicitly used by the Gomega Equals/ConsistsOf matchers).