### PR TITLE
Test package cleanup

### DIFF
--- a/.govetignore
+++ b/.govetignore
@@ -1,4 +1,7 @@
 app/error_test.go:21: no formatting directive in Errorf call
+data/deduplicator.go:49: no formatting directive in Errorf call
+data/deduplicator/base.go:151: no formatting directive in Errorf call
+data/deduplicator/delegate.go:99: no formatting directive in Errorf call
 store/mongo/mongo.go:93: no formatting directive in Errorf call
 userservices/client/standard.go:238: no formatting directive in Errorf call
 userservices/client/standard.go:312: no formatting directive in Errorf call

--- a/data/blood/glucose/target_test.go
+++ b/data/blood/glucose/target_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
-	"github.com/tidepool-org/platform/data/types/testing"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -64,14 +64,14 @@ var _ = Describe("Target", func() {
 			NewTestTarget(120.0, 10.0, 110.0, 130.0), []*service.Error{}),
 		Entry("parses object that has multiple invalid fields", &map[string]interface{}{"target": "invalid", "range": "invalid", "low": "invalid", "high": "invalid"},
 			NewTestTarget(nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
 			}),
 		Entry("parses object that has additional fields", &map[string]interface{}{"target": 120.0, "range": 10.0, "low": 110.0, "high": 130.0, "additional": 0.0},
 			NewTestTarget(120.0, 10.0, 110.0, 130.0), []*service.Error{
-				testing.ComposeError(parser.ErrorNotParsed(), "/additional", nil),
+				testData.ComposeError(parser.ErrorNotParsed(), "/additional", nil),
 			}),
 	)
 
@@ -102,28 +102,28 @@ var _ = Describe("Target", func() {
 			Entry("parses object that is empty", &map[string]interface{}{}, NewTestTarget(nil, nil, nil, nil), []*service.Error{}),
 			Entry("parses object that has valid target", &map[string]interface{}{"target": 120.0}, NewTestTarget(120.0, nil, nil, nil), []*service.Error{}),
 			Entry("parses object that has invalid target", &map[string]interface{}{"target": "invalid"}, NewTestTarget(nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
 			}),
 			Entry("parses object that has valid range", &map[string]interface{}{"range": 10.0}, NewTestTarget(nil, 10.0, nil, nil), []*service.Error{}),
 			Entry("parses object that has invalid range", &map[string]interface{}{"range": "invalid"}, NewTestTarget(nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
 			}),
 			Entry("parses object that has valid low", &map[string]interface{}{"low": 110.0}, NewTestTarget(nil, nil, 110.0, nil), []*service.Error{}),
 			Entry("parses object that has invalid low", &map[string]interface{}{"low": "invalid"}, NewTestTarget(nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
 			}),
 			Entry("parses object that has valid high", &map[string]interface{}{"high": 130.0}, NewTestTarget(nil, nil, nil, 130.0), []*service.Error{}),
 			Entry("parses object that has invalid high", &map[string]interface{}{"high": "invalid"}, NewTestTarget(nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
 			}),
 			Entry("parses object that has multiple valid fields", &map[string]interface{}{"target": 120.0, "range": 10.0, "low": 110.0, "high": 130.0},
 				NewTestTarget(120.0, 10.0, 110.0, 130.0), []*service.Error{}),
 			Entry("parses object that has multiple invalid fields", &map[string]interface{}{"target": "invalid", "range": "invalid", "low": "invalid", "high": "invalid"},
 				NewTestTarget(nil, nil, nil, nil), []*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
 				}),
 		)
 
@@ -140,127 +140,127 @@ var _ = Describe("Target", func() {
 			},
 			Entry("validates a target with units of mmol/L; target/range; all valid", NewTestTarget(6.6, 1.0, nil, nil), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; target/range; target out of range", NewTestTarget(55.1, 1.0, nil, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/range; range out of range", NewTestTarget(6.6, 6.7, nil, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(6.7, 0, 6.6), "/range", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(6.7, 0, 6.6), "/range", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/range; low exists", NewTestTarget(6.6, 1.0, 5.6, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/range; high exists", NewTestTarget(6.6, 1.0, nil, 7.6), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/high", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/range; multiple", NewTestTarget(6.6, 6.7, 5.6, 7.6), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(6.7, 0, 6.6), "/range", nil),
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
-				testing.ComposeError(service.ErrorValueExists(), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(6.7, 0, 6.6), "/range", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/high; all valid", NewTestTarget(6.6, nil, nil, 7.6), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; target/high; target out of range", NewTestTarget(55.1, nil, nil, 7.6), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/high; low exists", NewTestTarget(6.6, nil, 5.6, 7.6), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/high; high out of range (lower)", NewTestTarget(6.6, nil, nil, 6.5), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(6.5, 6.6, 55), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(6.5, 6.6, 55), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/high; high out of range (upper)", NewTestTarget(6.6, nil, nil, 55.1), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 6.6, 55), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 6.6, 55), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/high; multiple", NewTestTarget(6.6, nil, 5.6, 55.1), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 6.6, 55), "/high", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 6.6, 55), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target; all valid", NewTestTarget(6.6, nil, nil, nil), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; target; target out of range", NewTestTarget(55.1, nil, nil, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target; low exists", NewTestTarget(6.6, nil, 5.6, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target; multiple", NewTestTarget(55.1, nil, 5.6, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 0, 55), "/target", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mmol/L; low/high; all valid", NewTestTarget(nil, nil, 5.6, 7.6), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; low/high; low out of range", NewTestTarget(nil, nil, -0.1, 7.6), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0, 55), "/low", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0, 55), "/low", nil),
 			}),
 			Entry("validates a target with units of mmol/L; low/high; high out of range (lower)", NewTestTarget(nil, nil, 5.6, 5.5), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(5.5, 5.6, 55), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(5.5, 5.6, 55), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; low/high; high out of range (upper)", NewTestTarget(nil, nil, 5.6, 55.1), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(55.1, 5.6, 55), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(55.1, 5.6, 55), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; low", NewTestTarget(nil, nil, 5.6, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotExists(), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotExists(), "/high", nil),
 			}),
 			Entry("validates a target with units of mmol/L; none", NewTestTarget(nil, nil, nil, nil), nil, []*service.Error{
-				testing.ComposeError(service.ErrorValueNotExists(), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotExists(), "/target", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; all valid", NewTestTarget(120.0, 10.0, nil, nil), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; target/range; target out of range", NewTestTarget(1001.0, 10.0, nil, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; range out of range", NewTestTarget(120.0, 130.0, nil, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(130, 0, 120), "/range", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(130, 0, 120), "/range", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; low exists", NewTestTarget(120.0, 10.0, 110.0, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; high exists", NewTestTarget(120.0, 10.0, nil, 130.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/high", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; multiple", NewTestTarget(120.0, 130.0, 110.0, 130.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(130, 0, 120), "/range", nil),
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
-				testing.ComposeError(service.ErrorValueExists(), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(130, 0, 120), "/range", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/high; all valid", NewTestTarget(120.0, nil, nil, 130.0), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; target/high; target out of range", NewTestTarget(1001.0, nil, nil, 130.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/high; low exists", NewTestTarget(120.0, nil, 110.0, 130.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/high; high out of range (lower)", NewTestTarget(120.0, nil, nil, 119.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(119, 120, 1000), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(119, 120, 1000), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/high; high out of range (upper)", NewTestTarget(120.0, nil, nil, 1001.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 120, 1000), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 120, 1000), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/high; multiple", NewTestTarget(120.0, nil, 110.0, 1001.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 120, 1000), "/high", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 120, 1000), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target; all valid", NewTestTarget(120.0, nil, nil, nil), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; target; target out of range", NewTestTarget(1001.0, nil, nil, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target; low exists", NewTestTarget(120.0, nil, 110.0, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target; multiple", NewTestTarget(1001.0, nil, 110.0, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
-				testing.ComposeError(service.ErrorValueExists(), "/low", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 0, 1000), "/target", nil),
+				testData.ComposeError(service.ErrorValueExists(), "/low", nil),
 			}),
 			Entry("validates a target with units of mg/dL; low/high; all valid", NewTestTarget(nil, nil, 110.0, 130.0), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; low/high; low out of range", NewTestTarget(nil, nil, -1.0, 130.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 1000), "/low", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 1000), "/low", nil),
 			}),
 			Entry("validates a target with units of mg/dL; low/high; high out of range (lower)", NewTestTarget(nil, nil, 110.0, 109.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(109, 110, 1000), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(109, 110, 1000), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; low/high; high out of range (upper)", NewTestTarget(nil, nil, 110.0, 1001.0), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(1001, 110, 1000), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(1001, 110, 1000), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; low", NewTestTarget(nil, nil, 110.0, nil), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotExists(), "/high", nil),
+				testData.ComposeError(service.ErrorValueNotExists(), "/high", nil),
 			}),
 			Entry("validates a target with units of mg/dL; none", NewTestTarget(nil, nil, nil, nil), nil, []*service.Error{
-				testing.ComposeError(service.ErrorValueNotExists(), "/target", nil),
+				testData.ComposeError(service.ErrorValueNotExists(), "/target", nil),
 			}),
 		)
 

--- a/data/data_suite_test.go
+++ b/data/data_suite_test.go
@@ -1,4 +1,4 @@
-package types_test
+package data_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types")
+	RunSpecs(t, "data")
 }

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -10,13 +10,45 @@ package data
  * [x] Full test coverage
  */
 
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+)
+
 type Deduplicator interface {
-	InitializeDataset() error
-	AddDataToDataset(datasetData []Datum) error
-	FinalizeDataset() error
+	Name() string
+
+	RegisterDataset() error
+
+	AddDatasetData(datasetData []Datum) error
+	DeduplicateDataset() error
+
+	DeleteDataset() error
 }
 
 type DeduplicatorDescriptor struct {
 	Name string `bson:"name,omitempty"`
 	Hash string `bson:"hash,omitempty"`
+}
+
+func NewDeduplicatorDescriptor() *DeduplicatorDescriptor {
+	return &DeduplicatorDescriptor{}
+}
+
+func (d *DeduplicatorDescriptor) IsRegisteredWithAnyDeduplicator() bool {
+	return d.Name != ""
+}
+
+func (d *DeduplicatorDescriptor) IsRegisteredWithNamedDeduplicator(name string) bool {
+	return d.Name == name
+}
+
+func (d *DeduplicatorDescriptor) RegisterWithNamedDeduplicator(name string) error {
+	if d.Name != "" {
+		return app.Errorf("data", "deduplicator descriptor already registered with %s", strconv.Quote(d.Name))
+	}
+
+	d.Name = name
+	return nil
 }

--- a/data/deduplicator/after_deactivate_old.go
+++ b/data/deduplicator/after_deactivate_old.go
@@ -1,0 +1,114 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type afterDeactivateOldFactory struct {
+	*BaseFactory
+}
+
+type afterDeactivateOldDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _AfterDeactivateOldDeduplicatorName = "after-deactivate-old"
+
+var _AfterDeactivateOldExpectedDeviceManufacturers = []string{"UNUSED"}
+
+func NewAfterDeactivateOldFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_AfterDeactivateOldDeduplicatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &afterDeactivateOldFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (a *afterDeactivateOldFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := a.BaseFactory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	if dataset.DeviceID == nil {
+		return false, nil
+	}
+	if *dataset.DeviceID == "" {
+		return false, nil
+	}
+	if dataset.DeviceManufacturers == nil {
+		return false, nil
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _AfterDeactivateOldExpectedDeviceManufacturers) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (a *afterDeactivateOldFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(a.name, logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataset.DeviceID == nil {
+		return nil, app.Error("deduplicator", "dataset device id is missing")
+	}
+	if *dataset.DeviceID == "" {
+		return nil, app.Error("deduplicator", "dataset device id is empty")
+	}
+	if dataset.DeviceManufacturers == nil {
+		return nil, app.Error("deduplicator", "dataset device manufacturers is missing")
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _AfterDeactivateOldExpectedDeviceManufacturers) {
+		return nil, app.Error("deduplicator", "dataset device manufacturers does not contain expected device manufacturers")
+	}
+
+	return &afterDeactivateOldDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (a *afterDeactivateOldDeduplicator) DeduplicateDataset() error {
+	afterTime, err := a.dataStoreSession.FindEarliestDatasetDataTime(a.dataset)
+	if err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to get earliest data in dataset with id %s", strconv.Quote(a.dataset.UploadID))
+	}
+
+	// TODO: Technically, ActivateDatasetData could succeed, but DeactivateOtherDatasetDataAfterTime fail. This would
+	// result in duplicate (and possible incorrect) data. Is there a way to resolve this? Would be nice to have transactions.
+
+	if err = a.BaseDeduplicator.DeduplicateDataset(); err != nil {
+		return err
+	}
+
+	if afterTime != "" {
+		if err = a.dataStoreSession.DeactivateOtherDatasetDataAfterTime(a.dataset, afterTime); err != nil {
+			return app.ExtErrorf(err, "deduplicator", "unable to remove all other data except dataset with id %s", strconv.Quote(a.dataset.UploadID))
+		}
+	}
+
+	return nil
+}

--- a/data/deduplicator/base.go
+++ b/data/deduplicator/base.go
@@ -1,0 +1,196 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type BaseFactory struct {
+	Factory
+	name string
+}
+
+type BaseDeduplicator struct {
+	name             string
+	logger           log.Logger
+	dataStoreSession store.Session
+	dataset          *upload.Upload
+}
+
+func NewBaseFactory(name string) (*BaseFactory, error) {
+	if name == "" {
+		return nil, app.Error("deduplicator", "name is missing")
+	}
+
+	factory := &BaseFactory{
+		name: name,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (b *BaseFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if dataset == nil {
+		return false, app.Error("deduplicator", "dataset is missing")
+	}
+
+	if dataset.UploadID == "" {
+		return false, nil
+	}
+	if dataset.UserID == "" {
+		return false, nil
+	}
+	if dataset.GroupID == "" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (b *BaseFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	return NewBaseDeduplicator(b.name, logger, dataStoreSession, dataset)
+}
+
+func (b *BaseFactory) IsRegisteredWithDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := b.Factory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	deduplicatorDescriptor := dataset.DeduplicatorDescriptor()
+	if deduplicatorDescriptor == nil {
+		return false, nil
+	}
+	if !deduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(b.name) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (b *BaseFactory) NewRegisteredDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	deduplicator, err := b.Factory.NewDeduplicatorForDataset(logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	deduplicatorDescriptor := dataset.DeduplicatorDescriptor()
+	if deduplicatorDescriptor == nil {
+		return nil, app.Error("deduplicator", "dataset deduplicator descriptor is missing")
+	}
+	if !deduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(b.name) {
+		return nil, app.Error("deduplicator", "dataset deduplicator descriptor is not registered with expected deduplicator")
+	}
+
+	return deduplicator, nil
+}
+
+func NewBaseDeduplicator(name string, logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (*BaseDeduplicator, error) {
+	if name == "" {
+		return nil, app.Error("deduplicator", "name is missing")
+	}
+	if logger == nil {
+		return nil, app.Error("deduplicator", "logger is missing")
+	}
+	if dataStoreSession == nil {
+		return nil, app.Error("deduplicator", "data store session is missing")
+	}
+	if dataset == nil {
+		return nil, app.Error("deduplicator", "dataset is missing")
+	}
+	if dataset.UploadID == "" {
+		return nil, app.Error("deduplicator", "dataset id is missing")
+	}
+	if dataset.UserID == "" {
+		return nil, app.Error("deduplicator", "dataset user id is missing")
+	}
+	if dataset.GroupID == "" {
+		return nil, app.Error("deduplicator", "dataset group id is missing")
+	}
+
+	logger = logger.WithFields(log.Fields{
+		"deduplicatorName": name,
+		"datasetId":        dataset.UploadID,
+	})
+
+	return &BaseDeduplicator{
+		name:             name,
+		logger:           logger,
+		dataStoreSession: dataStoreSession,
+		dataset:          dataset,
+	}, nil
+}
+
+func (b *BaseDeduplicator) Name() string {
+	return b.name
+}
+
+func (b *BaseDeduplicator) RegisterDataset() error {
+	b.logger.Debug("RegisterDataset")
+
+	deduplicatorDescriptor := b.dataset.DeduplicatorDescriptor()
+
+	if deduplicatorDescriptor == nil {
+		deduplicatorDescriptor = data.NewDeduplicatorDescriptor()
+	} else if deduplicatorDescriptor.IsRegisteredWithAnyDeduplicator() {
+		return app.Errorf("deduplicator", "already registered dataset with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+	deduplicatorDescriptor.RegisterWithNamedDeduplicator(b.name)
+
+	b.dataset.SetDeduplicatorDescriptor(deduplicatorDescriptor)
+
+	if err := b.dataStoreSession.UpdateDataset(b.dataset); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to update dataset with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}
+
+func (b *BaseDeduplicator) AddDatasetData(datasetData []data.Datum) error {
+	b.logger.WithField("datasetDataLength", len(datasetData)).Debug("AddDatasetData")
+
+	if len(datasetData) == 0 {
+		return nil
+	}
+
+	if err := b.dataStoreSession.CreateDatasetData(b.dataset, datasetData); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to create dataset data with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}
+
+func (b *BaseDeduplicator) DeduplicateDataset() error {
+	b.logger.Debug("DeduplicateDataset")
+
+	if err := b.dataStoreSession.ActivateDatasetData(b.dataset); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to activate dataset data with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}
+
+func (b *BaseDeduplicator) DeleteDataset() error {
+	b.logger.Debug("DeleteDataset")
+
+	if err := b.dataStoreSession.DeleteDataset(b.dataset); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to delete dataset with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}

--- a/data/deduplicator/base_test.go
+++ b/data/deduplicator/base_test.go
@@ -1,0 +1,494 @@
+package deduplicator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+	"fmt"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/deduplicator"
+	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+var _ = Describe("Base", func() {
+	var testName string
+
+	BeforeEach(func() {
+		testName = app.NewID()
+	})
+
+	Context("BaseFactory", func() {
+		Context("NewBaseFactory", func() {
+			It("returns an error if the name is missing", func() {
+				testFactory, err := deduplicator.NewBaseFactory("")
+				Expect(err).To(MatchError("deduplicator: name is missing"))
+				Expect(testFactory).To(BeNil())
+			})
+
+			It("returns a new factory", func() {
+				testFactory, err := deduplicator.NewBaseFactory(testName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testFactory).ToNot(BeNil())
+				Expect(testFactory.Factory).ToNot(BeNil())
+			})
+		})
+
+		Context("with a new factory", func() {
+			var testFactory *deduplicator.BaseFactory
+			var testDataset *upload.Upload
+
+			BeforeEach(func() {
+				var err error
+				testFactory, err = deduplicator.NewBaseFactory(testName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testFactory).ToNot(BeNil())
+				testDataset = upload.Init()
+				Expect(testDataset).ToNot(BeNil())
+				testDataset.UserID = app.NewID()
+				testDataset.GroupID = app.NewID()
+			})
+
+			Context("CanDeduplicateDataset", func() {
+				It("returns an error if the dataset is missing", func() {
+					can, err := testFactory.CanDeduplicateDataset(nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(can).To(BeFalse())
+				})
+
+				It("returns false if the dataset id is missing", func() {
+					testDataset.UploadID = ""
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+				})
+
+				It("returns false if the dataset user id is missing", func() {
+					testDataset.UserID = ""
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+				})
+
+				It("returns false if the dataset group id is missing", func() {
+					testDataset.GroupID = ""
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+				})
+
+				It("returns true if successful", func() {
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+				})
+			})
+
+			Context("with logger and data store session", func() {
+				var testLogger log.Logger
+				var testDataStoreSession *testDataStore.Session
+
+				BeforeEach(func() {
+					testLogger = log.NewNull()
+					Expect(testLogger).ToNot(BeNil())
+					testDataStoreSession = testDataStore.NewSession()
+					Expect(testDataStoreSession).ToNot(BeNil())
+				})
+
+				AfterEach(func() {
+					Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				})
+
+				Context("NewDeduplicatorForDataset", func() {
+					It("returns an error if the logger is missing", func() {
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: logger is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the data store session is missing", func() {
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, nil, testDataset)
+						Expect(err).To(MatchError("deduplicator: data store session is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset is missing", func() {
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+						Expect(err).To(MatchError("deduplicator: dataset is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset id is missing", func() {
+						testDataset.UploadID = ""
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset user id is missing", func() {
+						testDataset.UserID = ""
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset group id is missing", func() {
+						testDataset.GroupID = ""
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns a new deduplicator upon success", func() {
+						Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+					})
+				})
+			})
+
+			Context("with registered dataset", func() {
+				BeforeEach(func() {
+					testDataset.Deduplicator = data.NewDeduplicatorDescriptor()
+					testDataset.Deduplicator.RegisterWithNamedDeduplicator(testName)
+				})
+
+				Context("IsRegisteredWithDataset", func() {
+					It("returns an error if the dataset is missing", func() {
+						can, err := testFactory.IsRegisteredWithDataset(nil)
+						Expect(err).To(MatchError("deduplicator: dataset is missing"))
+						Expect(can).To(BeFalse())
+					})
+
+					It("returns false if the dataset id is missing", func() {
+						testDataset.UploadID = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the dataset user id is missing", func() {
+						testDataset.UserID = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the dataset group id is missing", func() {
+						testDataset.GroupID = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if there is no deduplicator descriptor", func() {
+						testDataset.Deduplicator = nil
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the deduplicator descriptor name is missing", func() {
+						testDataset.Deduplicator.Name = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the deduplicator descriptor name does not match", func() {
+						testDataset.Deduplicator.Name = app.NewID()
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns true if successful", func() {
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeTrue())
+					})
+				})
+
+				Context("with logger and data store session", func() {
+					var testLogger log.Logger
+					var testDataStoreSession *testDataStore.Session
+
+					BeforeEach(func() {
+						testLogger = log.NewNull()
+						Expect(testLogger).ToNot(BeNil())
+						testDataStoreSession = testDataStore.NewSession()
+						Expect(testDataStoreSession).ToNot(BeNil())
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+					})
+
+					Context("NewRegisteredDeduplicatorForDataset", func() {
+						It("returns an error if the logger is missing", func() {
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: logger is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the data store session is missing", func() {
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, nil, testDataset)
+							Expect(err).To(MatchError("deduplicator: data store session is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset is missing", func() {
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+							Expect(err).To(MatchError("deduplicator: dataset is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset id is missing", func() {
+							testDataset.UploadID = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset user id is missing", func() {
+							testDataset.UserID = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset group id is missing", func() {
+							testDataset.GroupID = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if there is no deduplicator descriptor", func() {
+							testDataset.Deduplicator = nil
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset deduplicator descriptor is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the deduplicator descriptor name is missing", func() {
+							testDataset.Deduplicator.Name = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset deduplicator descriptor is not registered with expected deduplicator"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the deduplicator descriptor name does not match", func() {
+							testDataset.Deduplicator.Name = app.NewID()
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset deduplicator descriptor is not registered with expected deduplicator"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns a new deduplicator upon success", func() {
+							Expect(testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+						})
+					})
+				})
+			})
+		})
+	})
+
+	Context("BaseDeduplicator", func() {
+		var testLogger log.Logger
+		var testDataStoreSession *testDataStore.Session
+		var testDataset *upload.Upload
+
+		BeforeEach(func() {
+			testLogger = log.NewNull()
+			Expect(testLogger).ToNot(BeNil())
+			testDataStoreSession = testDataStore.NewSession()
+			Expect(testDataStoreSession).ToNot(BeNil())
+			testDataset = upload.Init()
+			Expect(testDataset).ToNot(BeNil())
+			testDataset.UserID = app.NewID()
+			testDataset.GroupID = app.NewID()
+		})
+
+		AfterEach(func() {
+			Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+		})
+
+		Context("NewBaseDeduplicator", func() {
+			It("returns an error if the name is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator("", testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: name is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the logger is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, nil, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: logger is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the data store session is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, nil, testDataset)
+				Expect(err).To(MatchError("deduplicator: data store session is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, nil)
+				Expect(err).To(MatchError("deduplicator: dataset is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset id is missing", func() {
+				testDataset.UploadID = ""
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset user id is missing", func() {
+				testDataset.UserID = ""
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset group id is missing", func() {
+				testDataset.GroupID = ""
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("successfully returns a new deduplicator", func() {
+				Expect(deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+			})
+		})
+
+		Context("with a new deduplicator", func() {
+			var testDeduplicator data.Deduplicator
+
+			BeforeEach(func() {
+				var err error
+				testDeduplicator, err = deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testDeduplicator).ToNot(BeNil())
+			})
+
+			Context("Name", func() {
+				It("returns the name", func() {
+					Expect(testDeduplicator.Name()).To(Equal(testName))
+				})
+			})
+
+			Context("RegisterDataset", func() {
+				It("returns an error if a deduplicator already registered dataset", func() {
+					testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: "test"})
+					err := testDeduplicator.RegisterDataset()
+					Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: already registered dataset with id "%s"`, testDataset.UploadID)))
+				})
+
+				Context("with updating dataset", func() {
+					BeforeEach(func() {
+						testDataStoreSession.UpdateDatasetOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
+					})
+
+					It("returns an error if there is an error with UpdateDataset", func() {
+						testDataStoreSession.UpdateDatasetOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.RegisterDataset()
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to update dataset with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.RegisterDataset()).To(Succeed())
+						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName}))
+					})
+
+					It("returns successfully even if there is a deduplicator description just without a name", func() {
+						testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Hash: "test"})
+						Expect(testDeduplicator.RegisterDataset()).To(Succeed())
+						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName, Hash: "test"}))
+					})
+				})
+			})
+
+			Context("AddDatasetData", func() {
+				var testDataData []*testData.Datum
+				var testDatasetData []data.Datum
+
+				BeforeEach(func() {
+					testDataData = []*testData.Datum{}
+					testDatasetData = []data.Datum{}
+					for i := 0; i < 3; i++ {
+						testDatum := testData.NewDatum()
+						testDataData = append(testDataData, testDatum)
+						testDatasetData = append(testDatasetData, testDatum)
+					}
+				})
+
+				AfterEach(func() {
+					for _, testDataDatum := range testDataData {
+						Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+					}
+				})
+
+				It("returns successfully if the data is missing", func() {
+					Expect(testDeduplicator.AddDatasetData(nil)).To(Succeed())
+				})
+
+				It("returns successfully if the data is empty", func() {
+					Expect(testDeduplicator.AddDatasetData([]data.Datum{})).To(Succeed())
+				})
+
+				Context("with creating dataset data", func() {
+					BeforeEach(func() {
+						testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{Dataset: testDataset, DatasetData: testDatasetData}))
+					})
+
+					It("returns an error if there is an error with CreateDatasetData", func() {
+						testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to create dataset data with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+					})
+				})
+			})
+
+			Context("DeduplicateDataset", func() {
+				Context("with activating dataset data", func() {
+					BeforeEach(func() {
+						testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
+					})
+
+					It("returns an error if there is an error with ActivateDatasetData", func() {
+						testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.DeduplicateDataset()
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to activate dataset data with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.DeduplicateDataset()).To(Succeed())
+					})
+				})
+			})
+
+			Context("DeleteDataset", func() {
+				Context("with deleting dataset", func() {
+					BeforeEach(func() {
+						testDataStoreSession.DeleteDatasetOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.DeleteDatasetInputs).To(ConsistOf(testDataset))
+					})
+
+					It("returns an error if there is an error with DeleteDataset", func() {
+						testDataStoreSession.DeleteDatasetOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.DeleteDataset()
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to delete dataset with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.DeleteDataset()).To(Succeed())
+					})
+				})
+			})
+		})
+	})
+})

--- a/data/deduplicator/delegate_test.go
+++ b/data/deduplicator/delegate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"errors"
 
+	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
 	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
@@ -15,7 +16,7 @@ import (
 )
 
 var _ = Describe("Delegate", func() {
-	Context("NewFactory", func() {
+	Context("NewDelegateFactory", func() {
 		It("returns an error if factories is nil", func() {
 			testFactory, err := deduplicator.NewDelegateFactory(nil)
 			Expect(err).To(MatchError("deduplicator: factories is missing"))
@@ -37,7 +38,7 @@ var _ = Describe("Delegate", func() {
 		})
 	})
 
-	Context("with a new factory", func() {
+	Context("with a new delegate factory", func() {
 		var testFirstFactory *testDataDeduplicator.Factory
 		var testSecondFactory *testDataDeduplicator.Factory
 		var testDelegateFactory deduplicator.Factory
@@ -46,9 +47,7 @@ var _ = Describe("Delegate", func() {
 		BeforeEach(func() {
 			var err error
 			testFirstFactory = testDataDeduplicator.NewFactory()
-			testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			testSecondFactory = testDataDeduplicator.NewFactory()
-			testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			testDelegateFactory, err = deduplicator.NewDelegateFactory([]deduplicator.Factory{testFirstFactory, testSecondFactory})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testDelegateFactory).ToNot(BeNil())
@@ -61,128 +60,289 @@ var _ = Describe("Delegate", func() {
 			Expect(testFirstFactory.UnusedOutputsCount()).To(Equal(0))
 		})
 
-		Context("CanDeduplicateDataset", func() {
-			It("returns an error if the dataset is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				can, err := testDelegateFactory.CanDeduplicateDataset(nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(can).To(BeFalse())
+		Context("with unregistered dataset", func() {
+			BeforeEach(func() {
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			})
 
-			It("returns an error if any contained factory returns an error", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
-				can, err := testDelegateFactory.CanDeduplicateDataset(testDataset)
-				Expect(err).To(MatchError("test error"))
-				Expect(can).To(BeFalse())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+			Context("CanDeduplicateDataset", func() {
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					can, err := testDelegateFactory.CanDeduplicateDataset(nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(can).To(BeFalse())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
+					can, err := testDelegateFactory.CanDeduplicateDataset(testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(can).To(BeFalse())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("return false if no factory can deduplicate the dataset", func() {
+					Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory can deduplicate the dataset", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(BeEmpty())
+				})
 			})
 
-			It("return false if no factory can deduplicate the dataset", func() {
-				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+			Context("NewDeduplicatorForDataset", func() {
+				var testLogger log.Logger
+				var testDataStoreSession *testDataStore.Session
 
-			It("returns true if any contained factory can deduplicate the dataset", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				BeforeEach(func() {
+					testLogger = log.NewNull()
+					Expect(testLogger).ToNot(BeNil())
+					testDataStoreSession = testDataStore.NewSession()
+					Expect(testDataStoreSession).ToNot(BeNil())
+				})
 
-			It("returns true if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(BeEmpty())
+				AfterEach(func() {
+					Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				})
+
+				It("returns an error if the logger is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: logger is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data store session is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, nil, testDataset)
+					Expect(err).To(MatchError("deduplicator: data store session is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns an error if no factory can deduplicate the dataset", func() {
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: deduplicator not found"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory can deduplicate the dataset", func() {
+					secondDeduplicator := testData.NewDeduplicator()
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testSecondFactory.NewDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewDeduplicatorForDatasetOutput{{Deduplicator: secondDeduplicator, Error: nil}}
+					Expect(testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
+					firstDeduplicator := testData.NewDeduplicator()
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testFirstFactory.NewDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewDeduplicatorForDatasetOutput{{Deduplicator: firstDeduplicator, Error: nil}}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					Expect(testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testFirstFactory.NewDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
+
+				It("returns an error if any contained factory can deduplicate the dataset, but returns an error when creating", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testSecondFactory.NewDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewDeduplicatorForDatasetOutput{{Deduplicator: nil, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.NewDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
 			})
 		})
 
-		Context("NewDeduplicator", func() {
-			var testLogger log.Logger
-			var testDataStoreSession *testDataStore.Session
-
+		Context("with registered dataset", func() {
 			BeforeEach(func() {
-				testLogger = log.NewNull()
-				testDataStoreSession = testDataStore.NewSession()
+				testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: nil}}
+				testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: nil}}
+				testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: "test"})
 			})
 
-			AfterEach(func() {
-				Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+			Context("IsRegisteredWithDataset", func() {
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					can, err := testDelegateFactory.IsRegisteredWithDataset(nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(can).To(BeFalse())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: errors.New("test error")}}
+					can, err := testDelegateFactory.IsRegisteredWithDataset(testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(can).To(BeFalse())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("return false if no factory is registered with the dataset", func() {
+					Expect(testDelegateFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory is registered with the dataset", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					Expect(testDelegateFactory.IsRegisteredWithDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory is registered with the dataset even if a later factory returns an error", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					Expect(testDelegateFactory.IsRegisteredWithDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(BeEmpty())
+				})
 			})
 
-			It("returns an error if the logger is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(nil, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("deduplicator: logger is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
+			Context("NewRegisteredDeduplicatorForDataset", func() {
+				var testLogger log.Logger
+				var testDataStoreSession *testDataStore.Session
 
-			It("returns an error if the data store session is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, nil, testDataset)
-				Expect(err).To(MatchError("deduplicator: data store session is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
+				BeforeEach(func() {
+					testLogger = log.NewNull()
+					testDataStoreSession = testDataStore.NewSession()
+					Expect(testDataStoreSession).ToNot(BeNil())
+				})
 
-			It("returns an error if the dataset is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
+				AfterEach(func() {
+					Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				})
 
-			It("returns an error if any contained factory returns an error", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("test error"))
-				Expect(deduplicator).To(BeNil())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				It("returns an error if the logger is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: logger is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns an error if no factory can deduplicate the dataset", func() {
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("deduplicator: deduplicator not found"))
-				Expect(deduplicator).To(BeNil())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				It("returns an error if the data store session is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, nil, testDataset)
+					Expect(err).To(MatchError("deduplicator: data store session is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns a deduplicator if any contained factory can deduplicate the dataset", func() {
-				secondDeduplicator := testData.NewDeduplicator()
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: secondDeduplicator, Error: nil}}
-				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns a deduplicator if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
-				firstDeduplicator := testData.NewDeduplicator()
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testFirstFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: firstDeduplicator, Error: nil}}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testFirstFactory.NewDeduplicatorInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
-			})
+				It("returns an error if the dataset is not registered with a deduplicator", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDataset.SetDeduplicatorDescriptor(nil)
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset not registered with deduplicator"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns an error if any contained factory can deduplicate the dataset, but returns an error when creating", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: nil, Error: errors.New("test error")}}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("test error"))
-				Expect(deduplicator).To(BeNil())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.NewDeduplicatorInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				It("returns an error if the dataset is not registered with a deduplicator with a name", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{})
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset not registered with deduplicator"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns an error if no factory is registered with the dataset", func() {
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: deduplicator not found"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory is registered with the dataset", func() {
+					secondDeduplicator := testData.NewDeduplicator()
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testSecondFactory.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: secondDeduplicator, Error: nil}}
+					Expect(testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory is registered with the dataset even if a later factory returns an error", func() {
+					firstDeduplicator := testData.NewDeduplicator()
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testFirstFactory.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: firstDeduplicator, Error: nil}}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					Expect(testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testFirstFactory.NewRegisteredDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
+
+				It("returns an error if any contained factory is registered with the dataset, but returns an error when creating", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testSecondFactory.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: nil, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.NewRegisteredDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
 			})
 		})
 	})

--- a/data/deduplicator/delegate_test.go
+++ b/data/deduplicator/delegate_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 
 	"github.com/tidepool-org/platform/data/deduplicator"
-	"github.com/tidepool-org/platform/data/deduplicator/test"
+	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
 	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/upload"
@@ -29,26 +29,26 @@ var _ = Describe("Delegate", func() {
 		})
 
 		It("returns success with one factory", func() {
-			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{test.NewFactory()})).ToNot(BeNil())
+			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{testDataDeduplicator.NewFactory()})).ToNot(BeNil())
 		})
 
 		It("returns success with multiple factories", func() {
-			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{test.NewFactory(), test.NewFactory(), test.NewFactory(), test.NewFactory()})).ToNot(BeNil())
+			Expect(deduplicator.NewDelegateFactory([]deduplicator.Factory{testDataDeduplicator.NewFactory(), testDataDeduplicator.NewFactory(), testDataDeduplicator.NewFactory(), testDataDeduplicator.NewFactory()})).ToNot(BeNil())
 		})
 	})
 
 	Context("with a new factory", func() {
-		var testFirstFactory *test.Factory
-		var testSecondFactory *test.Factory
+		var testFirstFactory *testDataDeduplicator.Factory
+		var testSecondFactory *testDataDeduplicator.Factory
 		var testDelegateFactory deduplicator.Factory
 		var testDataset *upload.Upload
 
 		BeforeEach(func() {
 			var err error
-			testFirstFactory = test.NewFactory()
-			testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
-			testSecondFactory = test.NewFactory()
-			testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
+			testFirstFactory = testDataDeduplicator.NewFactory()
+			testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
+			testSecondFactory = testDataDeduplicator.NewFactory()
+			testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			testDelegateFactory, err = deduplicator.NewDelegateFactory([]deduplicator.Factory{testFirstFactory, testSecondFactory})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testDelegateFactory).ToNot(BeNil())
@@ -63,15 +63,15 @@ var _ = Describe("Delegate", func() {
 
 		Context("CanDeduplicateDataset", func() {
 			It("returns an error if the dataset is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
 				can, err := testDelegateFactory.CanDeduplicateDataset(nil)
 				Expect(err).To(MatchError("deduplicator: dataset is missing"))
 				Expect(can).To(BeFalse())
 			})
 
 			It("returns an error if any contained factory returns an error", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
 				can, err := testDelegateFactory.CanDeduplicateDataset(testDataset)
 				Expect(err).To(MatchError("test error"))
 				Expect(can).To(BeFalse())
@@ -86,15 +86,15 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns true if any contained factory can deduplicate the dataset", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
 				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
 				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
 				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
 			})
 
 			It("returns true if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
 				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
 				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
 				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(BeEmpty())
@@ -115,31 +115,31 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns an error if the logger is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
 				deduplicator, err := testDelegateFactory.NewDeduplicator(nil, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("deduplicator: logger is missing"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			It("returns an error if the data store session is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
 				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, nil, testDataset)
 				Expect(err).To(MatchError("deduplicator: data store session is missing"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
 				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, nil)
 				Expect(err).To(MatchError("deduplicator: dataset is missing"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			It("returns an error if any contained factory returns an error", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
 				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("test error"))
 				Expect(deduplicator).To(BeNil())
@@ -157,8 +157,8 @@ var _ = Describe("Delegate", func() {
 
 			It("returns a deduplicator if any contained factory can deduplicate the dataset", func() {
 				secondDeduplicator := testData.NewDeduplicator()
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.NewDeduplicatorOutputs = []test.NewDeduplicatorOutput{{Deduplicator: secondDeduplicator, Error: nil}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+				testSecondFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: secondDeduplicator, Error: nil}}
 				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
 				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
 				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
@@ -166,23 +166,23 @@ var _ = Describe("Delegate", func() {
 
 			It("returns a deduplicator if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
 				firstDeduplicator := testData.NewDeduplicator()
-				testFirstFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testFirstFactory.NewDeduplicatorOutputs = []test.NewDeduplicatorOutput{{Deduplicator: firstDeduplicator, Error: nil}}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{}
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+				testFirstFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: firstDeduplicator, Error: nil}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
 				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
 				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testFirstFactory.NewDeduplicatorInputs).To(ConsistOf(test.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				Expect(testFirstFactory.NewDeduplicatorInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
 			})
 
 			It("returns an error if any contained factory can deduplicate the dataset, but returns an error when creating", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []test.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.NewDeduplicatorOutputs = []test.NewDeduplicatorOutput{{Deduplicator: nil, Error: errors.New("test error")}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+				testSecondFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: nil, Error: errors.New("test error")}}
 				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("test error"))
 				Expect(deduplicator).To(BeNil())
 				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
 				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.NewDeduplicatorInputs).To(ConsistOf(test.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				Expect(testSecondFactory.NewDeduplicatorInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
 			})
 		})
 	})

--- a/data/deduplicator/factory.go
+++ b/data/deduplicator/factory.go
@@ -19,5 +19,8 @@ import (
 
 type Factory interface {
 	CanDeduplicateDataset(dataset *upload.Upload) (bool, error)
-	NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
+	NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
+
+	IsRegisteredWithDataset(dataset *upload.Upload) (bool, error)
+	NewRegisteredDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
 }

--- a/data/deduplicator/hash.go
+++ b/data/deduplicator/hash.go
@@ -1,154 +1,58 @@
 package deduplicator
 
 /* CHECKLIST
- * [ ] Uses interfaces as appropriate
- * [ ] Private package variables use underscore prefix
- * [ ] All parameters validated
- * [ ] All errors handled
- * [ ] Reviewed for concurrency safety
- * [ ] Code complete
- * [ ] Full test coverage
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
  */
 
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"strconv"
 	"strings"
 
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
-	"github.com/tidepool-org/platform/data/store"
-	"github.com/tidepool-org/platform/data/types/upload"
-	"github.com/tidepool-org/platform/log"
 )
 
-type HashFactory struct{}
+const _HashIdentityFieldsSeparator = "|"
 
-type HashDeduplicator struct {
-	logger           log.Logger
-	dataStoreSession store.Session
-	dataset          *upload.Upload
-}
-
-const HashDeduplicatorName = "hash"
-const HashIdentityFieldsSeparator = "|"
-
-func NewHashFactory() (*HashFactory, error) {
-	return &HashFactory{}, nil
-}
-
-func (h *HashFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
-	if dataset == nil {
-		return false, app.Error("deduplicator", "dataset is missing")
-	}
-
-	if dataset.Deduplicator != nil {
-		return dataset.Deduplicator.Name == HashDeduplicatorName, nil
-	}
-
-	if dataset.UploadID == "" || dataset.UserID == "" || dataset.GroupID == "" {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func (h *HashFactory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
-	if logger == nil {
-		return nil, app.Error("deduplicator", "logger is missing")
-	}
-	if dataStoreSession == nil {
-		return nil, app.Error("deduplicator", "data store session is missing")
-	}
-	if dataset == nil {
-		return nil, app.Error("deduplicator", "dataset is missing")
-	}
-	if dataset.UploadID == "" {
-		return nil, app.Error("deduplicator", "dataset id is missing")
-	}
-	if dataset.UserID == "" {
-		return nil, app.Error("deduplicator", "dataset user id is missing")
-	}
-	if dataset.GroupID == "" {
-		return nil, app.Error("deduplicator", "dataset group id is missing")
-	}
-
-	return &HashDeduplicator{
-		logger:           logger,
-		dataStoreSession: dataStoreSession,
-		dataset:          dataset,
-	}, nil
-}
-
-func (h *HashDeduplicator) InitializeDataset() error {
-	h.dataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: HashDeduplicatorName})
-
-	if err := h.dataStoreSession.UpdateDataset(h.dataset); err != nil {
-		return app.ExtError(err, "deduplicator", "unable to initialize dataset")
-	}
-
-	return nil
-}
-
-func (h *HashDeduplicator) AddDataToDataset(datasetData []data.Datum) error {
-	if datasetData == nil {
-		return app.Error("deduplicator", "dataset data is missing")
-	}
-
+func AssignDatasetDataIdentityHashes(datasetData []data.Datum) ([]string, error) {
 	if len(datasetData) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	hashes := []string{}
 	for _, datasetDatum := range datasetData {
 		fields, err := datasetDatum.IdentityFields()
 		if err != nil {
-			return app.ExtError(err, "deduplicator", "unable to gather identity fields for datum")
+			return nil, app.ExtError(err, "deduplicator", "unable to gather identity fields for datum")
 		}
 
-		hash, err := generateIdentityHash(fields)
+		hash, err := GenerateIdentityHash(fields)
 		if err != nil {
-			return app.ExtError(err, "deduplicator", "unable to generate identity hash for datum")
+			return nil, app.ExtError(err, "deduplicator", "unable to generate identity hash for datum")
 		}
 
-		datasetDatum.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: HashDeduplicatorName, Hash: hash})
+		deduplicatorDescriptor := datasetDatum.DeduplicatorDescriptor()
+		if deduplicatorDescriptor == nil {
+			deduplicatorDescriptor = data.NewDeduplicatorDescriptor()
+		}
+		deduplicatorDescriptor.Hash = hash
+
+		datasetDatum.SetDeduplicatorDescriptor(deduplicatorDescriptor)
 
 		hashes = append(hashes, hash)
 	}
 
-	hashes, err := h.dataStoreSession.FindDatasetDataDeduplicatorHashes(h.dataset.UserID, hashes)
-	if err != nil {
-		return app.ExtError(err, "deduplicator", "unable to find existing identity hashes")
-	}
-
-	uniqueDatasetData := []data.Datum{}
-	for _, datasetDatum := range datasetData {
-		if !app.StringsContainsString(hashes, datasetDatum.DeduplicatorDescriptor().Hash) {
-			uniqueDatasetData = append(uniqueDatasetData, datasetDatum)
-		}
-	}
-
-	if len(uniqueDatasetData) == 0 {
-		return nil
-	}
-
-	if err = h.dataStoreSession.CreateDatasetData(h.dataset, uniqueDatasetData); err != nil {
-		return app.ExtError(err, "deduplicator", "unable to add data to dataset")
-	}
-
-	return nil
+	return hashes, nil
 }
 
-func (h *HashDeduplicator) FinalizeDataset() error {
-	if err := h.dataStoreSession.ActivateDatasetData(h.dataset); err != nil {
-		return app.ExtErrorf(err, "deduplicator", "unable to activate data in dataset with id %s", strconv.Quote(h.dataset.UploadID))
-	}
-
-	return nil
-}
-
-func generateIdentityHash(identityFields []string) (string, error) {
+func GenerateIdentityHash(identityFields []string) (string, error) {
 	if len(identityFields) == 0 {
 		return "", app.Error("deduplicator", "identity fields are missing")
 	}
@@ -159,7 +63,7 @@ func generateIdentityHash(identityFields []string) (string, error) {
 		}
 	}
 
-	identityString := strings.Join(identityFields, HashIdentityFieldsSeparator)
+	identityString := strings.Join(identityFields, _HashIdentityFieldsSeparator)
 	identitySum := sha256.Sum256([]byte(identityString))
 	identityHash := base64.StdEncoding.EncodeToString(identitySum[:])
 

--- a/data/deduplicator/hash_deactivate_old.go
+++ b/data/deduplicator/hash_deactivate_old.go
@@ -1,0 +1,142 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type hashDeactivateOldFactory struct {
+	*BaseFactory
+}
+
+type hashDeactivateOldDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _HashDeactivateOldDeduplicatorName = "hash-deactivate-old"
+
+var _HashDeactivateOldExpectedDeviceManufacturers = []string{"Medtronic"}
+
+func NewHashDeactivateOldFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_HashDeactivateOldDeduplicatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &hashDeactivateOldFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (h *hashDeactivateOldFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := h.BaseFactory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	if dataset.DeviceID == nil {
+		return false, nil
+	}
+	if *dataset.DeviceID == "" {
+		return false, nil
+	}
+	if dataset.DeviceManufacturers == nil {
+		return false, nil
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDeactivateOldExpectedDeviceManufacturers) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (h *hashDeactivateOldFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(h.name, logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataset.DeviceID == nil {
+		return nil, app.Error("deduplicator", "dataset device id is missing")
+	}
+	if *dataset.DeviceID == "" {
+		return nil, app.Error("deduplicator", "dataset device id is empty")
+	}
+	if dataset.DeviceManufacturers == nil {
+		return nil, app.Error("deduplicator", "dataset device manufacturers is missing")
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDeactivateOldExpectedDeviceManufacturers) {
+		return nil, app.Error("deduplicator", "dataset device manufacturers does not contain expected device manufacturers")
+	}
+
+	return &hashDeactivateOldDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (h *hashDeactivateOldDeduplicator) AddDatasetData(datasetData []data.Datum) error {
+	hashes, err := AssignDatasetDataIdentityHashes(datasetData)
+	if err != nil {
+		return err
+	} else if len(hashes) == 0 {
+		return nil
+	}
+
+	return h.BaseDeduplicator.AddDatasetData(datasetData)
+}
+
+func (h *hashDeactivateOldDeduplicator) DeduplicateDataset() error {
+	if err := h.setPreviousDatasetDataActiveUsingHashes(false); err != nil {
+		return err
+	}
+
+	return h.BaseDeduplicator.DeduplicateDataset()
+}
+
+func (h *hashDeactivateOldDeduplicator) DeleteDataset() error {
+	if err := h.setPreviousDatasetDataActiveUsingHashes(true); err != nil {
+		return err
+	}
+
+	return h.BaseDeduplicator.DeleteDataset()
+}
+
+func (h *hashDeactivateOldDeduplicator) setPreviousDatasetDataActiveUsingHashes(active bool) error {
+	previousDataset, err := h.dataStoreSession.FindPreviousActiveDatasetForDevice(h.dataset)
+	if err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to find previous dataset from dataset with id %s", strconv.Quote(h.dataset.UploadID))
+	} else if previousDataset == nil {
+		return nil
+	}
+
+	var hashes []string
+	hashes, err = h.dataStoreSession.GetDatasetDataDeduplicatorHashes(h.dataset, active)
+	if err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to get dataset data deduplicator hashes from dataset with id %s", strconv.Quote(h.dataset.UploadID))
+	}
+
+	if len(hashes) > 0 {
+		if err = h.dataStoreSession.SetDatasetDataActiveUsingHashes(previousDataset, hashes, active); err != nil {
+			return app.ExtErrorf(err, "deduplicator", "unable to set dataset data active using hashes from dataset with id %s", strconv.Quote(previousDataset.UploadID))
+		}
+	}
+
+	return nil
+}

--- a/data/deduplicator/hash_deactivate_old_test.go
+++ b/data/deduplicator/hash_deactivate_old_test.go
@@ -1,0 +1,501 @@
+package deduplicator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+	"fmt"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/deduplicator"
+	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+var _ = Describe("HashDeactivateOld", func() {
+	Context("NewHashDeactivateOldFactory", func() {
+		It("returns a new factory", func() {
+			Expect(deduplicator.NewHashDeactivateOldFactory()).ToNot(BeNil())
+		})
+	})
+
+	Context("with a new factory", func() {
+		var testFactory deduplicator.Factory
+		var testUploadID string
+		var testUserID string
+		var testDataset *upload.Upload
+
+		BeforeEach(func() {
+			var err error
+			testFactory, err = deduplicator.NewHashDeactivateOldFactory()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testFactory).ToNot(BeNil())
+			testUploadID = app.NewID()
+			testUserID = app.NewID()
+			testDataset = upload.Init()
+			Expect(testDataset).ToNot(BeNil())
+			testDataset.UploadID = testUploadID
+			testDataset.UserID = testUserID
+			testDataset.GroupID = app.NewID()
+			testDataset.DeviceID = app.StringAsPointer(app.NewID())
+			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Medtronic"})
+		})
+
+		Context("CanDeduplicateDataset", func() {
+			It("returns an error if the dataset is missing", func() {
+				can, err := testFactory.CanDeduplicateDataset(nil)
+				Expect(err).To(MatchError("deduplicator: dataset is missing"))
+				Expect(can).To(BeFalse())
+			})
+
+			It("returns false if the dataset id is missing", func() {
+				testDataset.UploadID = ""
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the dataset user id is missing", func() {
+				testDataset.UserID = ""
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the dataset group id is missing", func() {
+				testDataset.GroupID = ""
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device id is missing", func() {
+				testDataset.DeviceID = nil
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device id is empty", func() {
+				testDataset.DeviceID = app.StringAsPointer("")
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device manufacturers is missing", func() {
+				testDataset.DeviceManufacturers = nil
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device manufacturers is empty", func() {
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{})
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device manufacturers does not contain expected device manufacturer", func() {
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Cobra"})
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns true if the device id and expected device manufacturer are specified", func() {
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+			})
+
+			It("returns true if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Medtronic", "Cobra"})
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+			})
+		})
+
+		Context("with logger and data store session", func() {
+			var testLogger log.Logger
+			var testDataStoreSession *testDataStore.Session
+
+			BeforeEach(func() {
+				testLogger = log.NewNull()
+				Expect(testLogger).ToNot(BeNil())
+				testDataStoreSession = testDataStore.NewSession()
+				Expect(testDataStoreSession).ToNot(BeNil())
+			})
+
+			AfterEach(func() {
+				Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+			})
+
+			Context("NewDeduplicatorForDataset", func() {
+				It("returns an error if the logger is missing", func() {
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: logger is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data store session is missing", func() {
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, nil, testDataset)
+					Expect(err).To(MatchError("deduplicator: data store session is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset is missing", func() {
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset id is missing", func() {
+					testDataset.UploadID = ""
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset user id is missing", func() {
+					testDataset.UserID = ""
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset group id is missing", func() {
+					testDataset.GroupID = ""
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset device id is missing", func() {
+					testDataset.DeviceID = nil
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset device id is empty", func() {
+					testDataset.DeviceID = app.StringAsPointer("")
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device id is empty"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the device manufacturers is missing", func() {
+					testDataset.DeviceManufacturers = nil
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device manufacturers is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the device manufacturers is empty", func() {
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{})
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device manufacturers does not contain expected device manufacturers"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the device manufacturers does not contain expected device manufacturer", func() {
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Cobra"})
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device manufacturers does not contain expected device manufacturers"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns a new deduplicator upon success", func() {
+					Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+				})
+
+				It("returns a new deduplicator upon success if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Medtronic", "Cobra"})
+					Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+				})
+			})
+
+			Context("with a new deduplicator", func() {
+				var testDeduplicator data.Deduplicator
+				var testDataData []*testData.Datum
+				var testDatasetData []data.Datum
+
+				BeforeEach(func() {
+					var err error
+					testDeduplicator, err = testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testDeduplicator).ToNot(BeNil())
+					testDataData = []*testData.Datum{}
+					testDatasetData = []data.Datum{}
+					for i := 0; i < 3; i++ {
+						testDatum := testData.NewDatum()
+						testDataData = append(testDataData, testDatum)
+						testDatasetData = append(testDatasetData, testDatum)
+					}
+				})
+
+				AfterEach(func() {
+					for _, testDataDatum := range testDataData {
+						Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+					}
+				})
+
+				Context("AddDatasetData", func() {
+					It("returns successfully if the data is nil", func() {
+						Expect(testDeduplicator.AddDatasetData(nil)).To(Succeed())
+					})
+
+					It("returns successfully if there is no data", func() {
+						Expect(testDeduplicator.AddDatasetData([]data.Datum{})).To(Succeed())
+					})
+
+					It("returns an error if any datum returns an error getting identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
+					})
+
+					It("returns an error if any datum returns no identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns any empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
+					})
+
+					Context("with identity fields", func() {
+						BeforeEach(func() {
+							testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "0"}, Error: nil}}
+							testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "1"}, Error: nil}}
+							testDataData[2].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "2"}, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(testDataData[0].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg="}))
+							Expect(testDataData[1].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8="}))
+							Expect(testDataData[2].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78="}))
+						})
+
+						Context("with creating dataset data", func() {
+							BeforeEach(func() {
+								testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{
+									Dataset:     testDataset,
+									DatasetData: testDatasetData,
+								}))
+							})
+
+							It("returns an error if there is an error with CreateDatasetDataInput", func() {
+								testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
+								err := testDeduplicator.AddDatasetData(testDatasetData)
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to create dataset data with id "%s"; test error`, testDataset.UploadID)))
+							})
+
+							It("returns successfully if there is no error", func() {
+								Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+							})
+						})
+					})
+				})
+
+				Context("DeduplicateDataset", func() {
+					AssertWithCreatingDatasetData := func() {
+						Context("with creating dataset data", func() {
+							BeforeEach(func() {
+								testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
+							})
+
+							It("returns an error if there is an error with CreateDatasetData", func() {
+								testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
+								err := testDeduplicator.DeduplicateDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to activate dataset data with id "%s"; test error`, testUploadID)))
+							})
+
+							It("returns successfully if there is no error", func() {
+								Expect(testDeduplicator.DeduplicateDataset()).To(Succeed())
+							})
+						})
+					}
+
+					Context("with finding previous active dataset for device", func() {
+						var testPreviousDataset *upload.Upload
+
+						BeforeEach(func() {
+							testPreviousDataset = upload.Init()
+							Expect(testPreviousDataset).ToNot(BeNil())
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: testPreviousDataset, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(testDataStoreSession.FindPreviousActiveDatasetForDeviceInputs).To(Equal([]*upload.Upload{testDataset}))
+						})
+
+						It("returns an error if there is an error with FindPreviousActiveDatasetForDevice", func() {
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: errors.New("test error")}}
+							err := testDeduplicator.DeduplicateDataset()
+							Expect(err).To(MatchError(`deduplicator: unable to find previous dataset from dataset with id "` + testUploadID + `"; test error`))
+						})
+
+						Context("without previous dataset", func() {
+							BeforeEach(func() {
+								testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: nil}}
+							})
+
+							AssertWithCreatingDatasetData()
+						})
+
+						Context("with getting dataset data deduplicator hashes", func() {
+							var testHashes []string
+
+							BeforeEach(func() {
+								testHashes = []string{app.NewID(), app.NewID(), app.NewID()}
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: testHashes, Error: nil}}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.GetDatasetDataDeduplicatorHashesInputs).To(Equal([]testDataStore.GetDatasetDataDeduplicatorHashesInput{{Dataset: testDataset, Active: false}}))
+							})
+
+							It("returns an error if there is an error with GetDatasetDataDeduplicatorHashes", func() {
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: errors.New("test error")}}
+								err := testDeduplicator.DeduplicateDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to get dataset data deduplicator hashes from dataset with id "%s"; test error`, testUploadID)))
+							})
+
+							Context("without dataset data deduplicator hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: nil}}
+								})
+
+								AssertWithCreatingDatasetData()
+							})
+
+							Context("with set dataset data active using hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(testDataStoreSession.SetDatasetDataActiveUsingHashesInputs).To(Equal([]testDataStore.SetDatasetDataActiveUsingHashesInput{{Dataset: testPreviousDataset, Hashes: testHashes, Active: false}}))
+								})
+
+								It("returns an error if there is an error with SetDatasetDataActiveUsingHashes", func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{errors.New("test error")}
+									err := testDeduplicator.DeduplicateDataset()
+									Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to set dataset data active using hashes from dataset with id "%s"; test error`, testPreviousDataset.UploadID)))
+								})
+
+								AssertWithCreatingDatasetData()
+							})
+						})
+					})
+				})
+
+				Context("DeleteDataset", func() {
+					AssertWithDeletingDataset := func() {
+						Context("with deleting dataset", func() {
+							BeforeEach(func() {
+								testDataStoreSession.DeleteDatasetOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.DeleteDatasetInputs).To(ConsistOf(testDataset))
+							})
+
+							It("returns an error if there is an error with DeleteDataset", func() {
+								testDataStoreSession.DeleteDatasetOutputs = []error{errors.New("test error")}
+								err := testDeduplicator.DeleteDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to delete dataset with id "%s"; test error`, testUploadID)))
+							})
+
+							It("returns successfully if there is no error", func() {
+								Expect(testDeduplicator.DeleteDataset()).To(Succeed())
+							})
+						})
+					}
+
+					Context("with finding previous active dataset for device", func() {
+						var testPreviousDataset *upload.Upload
+
+						BeforeEach(func() {
+							testPreviousDataset = upload.Init()
+							Expect(testPreviousDataset).ToNot(BeNil())
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: testPreviousDataset, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(testDataStoreSession.FindPreviousActiveDatasetForDeviceInputs).To(Equal([]*upload.Upload{testDataset}))
+						})
+
+						It("returns an error if there is an error with FindPreviousActiveDatasetForDevice", func() {
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: errors.New("test error")}}
+							err := testDeduplicator.DeleteDataset()
+							Expect(err).To(MatchError(`deduplicator: unable to find previous dataset from dataset with id "` + testUploadID + `"; test error`))
+						})
+
+						Context("without previous dataset", func() {
+							BeforeEach(func() {
+								testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: nil}}
+							})
+
+							AssertWithDeletingDataset()
+						})
+
+						Context("with getting dataset data deduplicator hashes", func() {
+							var testHashes []string
+
+							BeforeEach(func() {
+								testHashes = []string{app.NewID(), app.NewID(), app.NewID()}
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: testHashes, Error: nil}}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.GetDatasetDataDeduplicatorHashesInputs).To(Equal([]testDataStore.GetDatasetDataDeduplicatorHashesInput{{Dataset: testDataset, Active: true}}))
+							})
+
+							It("returns an error if there is an error with GetDatasetDataDeduplicatorHashes", func() {
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: errors.New("test error")}}
+								err := testDeduplicator.DeleteDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to get dataset data deduplicator hashes from dataset with id "%s"; test error`, testUploadID)))
+							})
+
+							Context("without dataset data deduplicator hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: nil}}
+								})
+
+								AssertWithDeletingDataset()
+							})
+
+							Context("with set dataset data active using hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(testDataStoreSession.SetDatasetDataActiveUsingHashesInputs).To(Equal([]testDataStore.SetDatasetDataActiveUsingHashesInput{{Dataset: testPreviousDataset, Hashes: testHashes, Active: true}}))
+								})
+
+								It("returns an error if there is an error with SetDatasetDataActiveUsingHashes", func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{errors.New("test error")}
+									err := testDeduplicator.DeleteDataset()
+									Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to set dataset data active using hashes from dataset with id "%s"; test error`, testPreviousDataset.UploadID)))
+								})
+
+								AssertWithDeletingDataset()
+							})
+						})
+					})
+				})
+			})
+		})
+	})
+})

--- a/data/deduplicator/hash_drop_new.go
+++ b/data/deduplicator/hash_drop_new.go
@@ -1,0 +1,113 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type hashDropNewFactory struct {
+	*BaseFactory
+}
+
+type hashDropNewDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _HashDropNewDeduplicatorName = "hash-drop-new"
+
+var _HashDropNewExpectedDeviceManufacturers = []string{"UNUSED"}
+
+func NewHashDropNewFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_HashDropNewDeduplicatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &hashDropNewFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (h *hashDropNewFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := h.BaseFactory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	if dataset.DeviceID == nil {
+		return false, nil
+	}
+	if *dataset.DeviceID == "" {
+		return false, nil
+	}
+	if dataset.DeviceManufacturers == nil {
+		return false, nil
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDropNewExpectedDeviceManufacturers) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (h *hashDropNewFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(h.name, logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataset.DeviceID == nil {
+		return nil, app.Error("deduplicator", "dataset device id is missing")
+	}
+	if *dataset.DeviceID == "" {
+		return nil, app.Error("deduplicator", "dataset device id is empty")
+	}
+	if dataset.DeviceManufacturers == nil {
+		return nil, app.Error("deduplicator", "dataset device manufacturers is missing")
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDropNewExpectedDeviceManufacturers) {
+		return nil, app.Error("deduplicator", "dataset device manufacturers does not contain expected device manufacturers")
+	}
+
+	return &hashDropNewDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (h *hashDropNewDeduplicator) AddDatasetData(datasetData []data.Datum) error {
+	hashes, err := AssignDatasetDataIdentityHashes(datasetData)
+	if err != nil {
+		return err
+	} else if len(hashes) == 0 {
+		return nil
+	}
+
+	hashes, err = h.dataStoreSession.FindAllDatasetDataDeduplicatorHashesForDevice(h.dataset.UserID, *h.dataset.DeviceID, hashes)
+	if err != nil {
+		return app.ExtError(err, "deduplicator", "unable to find all dataset data deduplicator hashes for device")
+	}
+
+	uniqueDatasetData := []data.Datum{}
+	for _, datasetDatum := range datasetData {
+		if !app.StringsContainsString(hashes, datasetDatum.DeduplicatorDescriptor().Hash) {
+			uniqueDatasetData = append(uniqueDatasetData, datasetDatum)
+		}
+	}
+
+	return h.BaseDeduplicator.AddDatasetData(uniqueDatasetData)
+}

--- a/data/deduplicator/hash_drop_new_test.go
+++ b/data/deduplicator/hash_drop_new_test.go
@@ -11,32 +11,37 @@ import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/upload"
 	"github.com/tidepool-org/platform/log"
 )
 
-var _ = Describe("Truncate", func() {
-	Context("NewTruncateFactory", func() {
+var _ = Describe("HashDropNew", func() {
+	Context("NewHashDropNewFactory", func() {
 		It("returns a new factory", func() {
-			Expect(deduplicator.NewTruncateFactory()).ToNot(BeNil())
+			Expect(deduplicator.NewHashDropNewFactory()).ToNot(BeNil())
 		})
 	})
 
 	Context("with a new factory", func() {
 		var testFactory deduplicator.Factory
+		var testUserID string
+		var testDeviceID string
 		var testDataset *upload.Upload
 
 		BeforeEach(func() {
 			var err error
-			testFactory, err = deduplicator.NewTruncateFactory()
+			testFactory, err = deduplicator.NewHashDropNewFactory()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testFactory).ToNot(BeNil())
+			testUserID = app.NewID()
+			testDeviceID = app.NewID()
 			testDataset = upload.Init()
 			Expect(testDataset).ToNot(BeNil())
-			testDataset.UserID = app.NewID()
+			testDataset.UserID = testUserID
 			testDataset.GroupID = app.NewID()
-			testDataset.DeviceID = app.StringAsPointer(app.NewID())
-			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Animas"})
+			testDataset.DeviceID = app.StringAsPointer(testDeviceID)
+			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"UNUSED"})
 		})
 
 		Context("CanDeduplicateDataset", func() {
@@ -91,7 +96,7 @@ var _ = Describe("Truncate", func() {
 			})
 
 			It("returns true if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
-				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Animas", "Cobra"})
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "UNUSED", "Cobra"})
 				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
 			})
 		})
@@ -191,7 +196,7 @@ var _ = Describe("Truncate", func() {
 				})
 
 				It("returns a new deduplicator upon success if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
-					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Animas", "Cobra"})
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "UNUSED", "Cobra"})
 					Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
 				})
 			})
@@ -206,39 +211,139 @@ var _ = Describe("Truncate", func() {
 					Expect(testDeduplicator).ToNot(BeNil())
 				})
 
-				Context("DeduplicateDataset", func() {
-					Context("with activating dataset data", func() {
+				Context("AddDatasetData", func() {
+					var testDataData []*testData.Datum
+					var testDatasetData []data.Datum
+
+					BeforeEach(func() {
+						testDataData = []*testData.Datum{}
+						testDatasetData = []data.Datum{}
+						for i := 0; i < 3; i++ {
+							testDatum := testData.NewDatum()
+							testDataData = append(testDataData, testDatum)
+							testDatasetData = append(testDatasetData, testDatum)
+						}
+					})
+
+					AfterEach(func() {
+						for _, testDataDatum := range testDataData {
+							Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+						}
+					})
+
+					It("returns successfully if the data is nil", func() {
+						Expect(testDeduplicator.AddDatasetData(nil)).To(Succeed())
+					})
+
+					It("returns successfully if there is no data", func() {
+						Expect(testDeduplicator.AddDatasetData([]data.Datum{})).To(Succeed())
+					})
+
+					It("returns an error if any datum returns an error getting identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
+					})
+
+					It("returns an error if any datum returns no identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns any empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
+					})
+
+					Context("with identity fields", func() {
 						BeforeEach(func() {
-							testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
+							testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "0"}, Error: nil}}
+							testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "1"}, Error: nil}}
+							testDataData[2].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "2"}, Error: nil}}
 						})
 
 						AfterEach(func() {
-							Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
+							Expect(testDataData[0].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg="}))
+							Expect(testDataData[1].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8="}))
+							Expect(testDataData[2].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78="}))
 						})
 
-						It("returns an error if there is an error with ActivateDatasetData", func() {
-							testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
-							err := testDeduplicator.DeduplicateDataset()
-							Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to activate dataset data with id "%s"; test error`, testDataset.UploadID)))
-						})
-
-						Context("with deleting other dataset data", func() {
+						Context("with finding all dataset data deduplicator hashes for device", func() {
 							BeforeEach(func() {
-								testDataStoreSession.DeleteOtherDatasetDataOutputs = []error{nil}
+								testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = []testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceOutput{{
+									Hashes: []string{
+										"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+									},
+									Error: nil,
+								}}
 							})
 
 							AfterEach(func() {
-								Expect(testDataStoreSession.DeleteOtherDatasetDataInputs).To(ConsistOf(testDataset))
+								Expect(testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceInputs).To(Equal([]testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceInput{{
+									UserID:   testUserID,
+									DeviceID: testDeviceID,
+									Hashes: []string{
+										"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
+										"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+										"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
+									},
+								}}))
 							})
 
-							It("returns an error if there is an error with DeleteOtherDatasetData", func() {
-								testDataStoreSession.DeleteOtherDatasetDataOutputs = []error{errors.New("test error")}
-								err := testDeduplicator.DeduplicateDataset()
-								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to remove all other data except dataset with id "%s"; test error`, testDataset.UploadID)))
+							It("returns an error if finding all dataset data deduplicator hashes for device returns an error", func() {
+								testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = []testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceOutput{{Hashes: nil, Error: errors.New("test error")}}
+								err := testDeduplicator.AddDatasetData(testDatasetData)
+								Expect(err).To(MatchError("deduplicator: unable to find all dataset data deduplicator hashes for device; test error"))
 							})
 
-							It("returns successfully if there is no error", func() {
-								Expect(testDeduplicator.DeduplicateDataset()).To(Succeed())
+							It("returns success if finding all dataset data deduplicator hashes for device returns all hashes", func() {
+								testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = []testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceOutput{{
+									Hashes: []string{
+										"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
+										"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+										"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
+									},
+									Error: nil,
+								}}
+								Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+							})
+
+							Context("with creating dataset data", func() {
+								BeforeEach(func() {
+									testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{
+										Dataset: testDataset,
+										DatasetData: []data.Datum{
+											testDataData[0],
+											testDataData[2],
+										},
+									}))
+								})
+
+								It("returns an error if there is an error with CreateDatasetDataInput", func() {
+									testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
+									err := testDeduplicator.AddDatasetData(testDatasetData)
+									Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to create dataset data with id "%s"; test error`, testDataset.UploadID)))
+								})
+
+								It("returns successfully if there is no error", func() {
+									Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+								})
 							})
 						})
 					})

--- a/data/deduplicator/hash_test.go
+++ b/data/deduplicator/hash_test.go
@@ -1,339 +1,138 @@
 package deduplicator_test
 
 import (
-	"errors"
-	"strconv"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"errors"
 
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
-	testDataStore "github.com/tidepool-org/platform/data/store/test"
 	testData "github.com/tidepool-org/platform/data/test"
-	"github.com/tidepool-org/platform/data/types/upload"
-	"github.com/tidepool-org/platform/log"
 )
 
 var _ = Describe("Hash", func() {
-	Context("NewFactory", func() {
-		It("returns a new factory", func() {
-			Expect(deduplicator.NewHashFactory()).ToNot(BeNil())
-		})
-	})
-
-	Context("with a new factory", func() {
-		var testFactory deduplicator.Factory
-		var userID string
-		var testDataset *upload.Upload
+	Context("AssignDatasetDataIdentityHashes", func() {
+		var testDataData []*testData.Datum
+		var testDatasetData []data.Datum
 
 		BeforeEach(func() {
-			var err error
-			testFactory, err = deduplicator.NewHashFactory()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(testFactory).ToNot(BeNil())
-			userID = app.NewID()
-			testDataset = upload.Init()
-			Expect(testDataset).ToNot(BeNil())
-			testDataset.UserID = userID
-			testDataset.GroupID = app.NewID()
-			testDataset.DeviceID = app.StringAsPointer(app.NewID())
-			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Medtronic"})
+			testDataData = []*testData.Datum{}
+			testDatasetData = []data.Datum{}
+			for i := 0; i < 3; i++ {
+				testDatum := testData.NewDatum()
+				testDataData = append(testDataData, testDatum)
+				testDatasetData = append(testDatasetData, testDatum)
+			}
 		})
 
-		Context("CanDeduplicateDataset", func() {
-			It("returns an error if the dataset is missing", func() {
-				can, err := testFactory.CanDeduplicateDataset(nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(can).To(BeFalse())
-			})
-
-			Context("with deduplicator", func() {
-				BeforeEach(func() {
-					testDataset.Deduplicator = &data.DeduplicatorDescriptor{Name: "hash"}
-				})
-
-				It("returns false if the deduplicator name is empty", func() {
-					testDataset.Deduplicator.Name = ""
-					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-				})
-
-				It("returns false if the deduplicator name does not match", func() {
-					testDataset.Deduplicator.Name = "not-hash"
-					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-				})
-
-				It("returns true if the deduplicator name does match", func() {
-					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-				})
-			})
-
-			It("returns false if the dataset id is missing", func() {
-				testDataset.UploadID = ""
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-			})
-
-			It("returns false if the user id is missing", func() {
-				testDataset.UserID = ""
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-			})
-
-			It("returns false if the group id is missing", func() {
-				testDataset.GroupID = ""
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-			})
-
-			It("returns true if dataset id, user id, and group id are specified", func() {
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-			})
+		AfterEach(func() {
+			for _, testDataDatum := range testDataData {
+				Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+			}
 		})
 
-		Context("NewDeduplicator", func() {
-			It("returns an error if the logger is missing", func() {
-				testDeduplicator, err := testFactory.NewDeduplicator(nil, testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: logger is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the data store session is missing", func() {
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), nil, testDataset)
-				Expect(err).To(MatchError("deduplicator: data store session is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset is missing", func() {
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset id is missing", func() {
-				testDataset.UploadID = ""
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: dataset id is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset user id is missing", func() {
-				testDataset.UserID = ""
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset group id is missing", func() {
-				testDataset.GroupID = ""
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns a new deduplicator upon success", func() {
-				Expect(testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)).ToNot(BeNil())
-			})
+		It("returns successfully if the data is nil", func() {
+			Expect(deduplicator.AssignDatasetDataIdentityHashes(nil)).To(BeNil())
 		})
 
-		Context("with a new deduplicator", func() {
-			var testDataStoreSession *testDataStore.Session
-			var testDeduplicator data.Deduplicator
+		It("returns successfully if there is no data", func() {
+			Expect(deduplicator.AssignDatasetDataIdentityHashes([]data.Datum{})).To(BeNil())
+		})
 
+		It("returns an error if any datum returns an error getting identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
+			Expect(hashes).To(BeNil())
+		})
+
+		It("returns an error if any datum returns no identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+			Expect(hashes).To(BeNil())
+		})
+
+		It("returns an error if any datum returns empty identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+			Expect(hashes).To(BeNil())
+		})
+
+		It("returns an error if any datum returns any empty identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
+			Expect(hashes).To(BeNil())
+		})
+
+		Context("with identity fields", func() {
 			BeforeEach(func() {
-				var err error
-				testDataStoreSession = testDataStore.NewSession()
-				testDeduplicator, err = testFactory.NewDeduplicator(log.NewNull(), testDataStoreSession, testDataset)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(testDeduplicator).ToNot(BeNil())
+				testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "0"}, Error: nil}}
+				testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "1"}, Error: nil}}
+				testDataData[2].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "2"}, Error: nil}}
 			})
 
 			AfterEach(func() {
-				Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				Expect(testDataData[0].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg="}))
+				Expect(testDataData[1].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8="}))
+				Expect(testDataData[2].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78="}))
 			})
 
-			Context("InitializeDataset", func() {
-				It("returns an error if there is an error", func() {
-					testDataStoreSession.UpdateDatasetOutputs = []error{errors.New("test error")}
-					err := testDeduplicator.InitializeDataset()
-					Expect(err).To(MatchError("deduplicator: unable to initialize dataset; test error"))
-					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
-				})
-
-				It("returns successfully if there is no error", func() {
-					testDataStoreSession.UpdateDatasetOutputs = []error{nil}
-					Expect(testDeduplicator.InitializeDataset()).To(Succeed())
-					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
-				})
-
-				It("sets the dataset deduplicator if there is no error", func() {
-					testDataStoreSession.UpdateDatasetOutputs = []error{nil}
-					Expect(testDeduplicator.InitializeDataset()).To(Succeed())
-					Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: "hash"}))
-					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
-				})
+			It("returns successfully", func() {
+				hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hashes).To(Equal([]string{
+					"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
+					"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+					"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
+				}))
 			})
+		})
+	})
 
-			Context("AddDataToDataset", func() {
-				var testDataData []*testData.Datum
-				var testDatasetData []data.Datum
+	Context("GenerateIdentityHash", func() {
+		It("returns an error if identity fields is missing", func() {
+			hash, err := deduplicator.GenerateIdentityHash(nil)
+			Expect(err).To(MatchError("deduplicator: identity fields are missing"))
+			Expect(hash).To(Equal(""))
+		})
 
-				BeforeEach(func() {
-					testDataData = []*testData.Datum{}
-					testDatasetData = []data.Datum{}
-					for i := 0; i < 3; i++ {
-						testDatum := testData.NewDatum()
-						testDataData = append(testDataData, testDatum)
-						testDatasetData = append(testDatasetData, testDatum)
-					}
-				})
+		It("returns an error if identity fields is empty", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{})
+			Expect(err).To(MatchError("deduplicator: identity fields are missing"))
+			Expect(hash).To(Equal(""))
+		})
 
-				AfterEach(func() {
-					for _, testDataDatum := range testDataData {
-						Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
-					}
-				})
+		It("returns an error if an identity fields empty", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"alpha", "", "charlie"})
+			Expect(err).To(MatchError("deduplicator: identity field is empty"))
+			Expect(hash).To(Equal(""))
+		})
 
-				It("returns an error if the dataset is missing", func() {
-					err := testDeduplicator.AddDataToDataset(nil)
-					Expect(err).To(MatchError("deduplicator: dataset data is missing"))
-				})
+		It("successfully returns a hash with one identity field", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"zero"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal("+RlOc/npRZ40UOoQoXnN93qvppW+7NO5NEqY0RFiIkM="))
+		})
 
-				It("returns successfully if there is no data", func() {
-					Expect(testDeduplicator.AddDataToDataset([]data.Datum{})).To(Succeed())
-				})
+		It("successfully returns a hash with three identity fields", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"alpha", "bravo", "charlie"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal("dO3wei6LXqnM+oEql2hguPTmyM0+QnmIZPyxzlvL2xY="))
+		})
 
-				It("returns an error if any datum returns an error getting identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
-				})
-
-				It("returns an error if any datum returns no identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
-				})
-
-				It("returns an error if any datum returns empty identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
-				})
-
-				It("returns an error if any datum returns any empty identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
-				})
-
-				Context("with identity fields", func() {
-					BeforeEach(func() {
-						for index, testDataDatum := range testDataData {
-							testDataDatum.IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", strconv.Itoa(index)}, Error: nil}}
-						}
-						testDataStoreSession.FindDatasetDataDeduplicatorHashesOutputs = []testDataStore.FindDatasetDataDeduplicatorHashesOutput{{
-							Hashes: []string{
-								"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-							},
-							Error: nil,
-						}}
-					})
-
-					AfterEach(func() {
-						for _, testDataDatum := range testDataData {
-							Expect(testDataDatum.SetDeduplicatorDescriptorInputs).To(HaveLen(1))
-							Expect(testDataDatum.SetDeduplicatorDescriptorInputs[0].Name).To(Equal("hash"))
-							Expect(testDataDatum.SetDeduplicatorDescriptorInputs[0].Hash).ToNot(BeEmpty())
-						}
-						Expect(testDataStoreSession.FindDatasetDataDeduplicatorHashesInputs).To(Equal([]testDataStore.FindDatasetDataDeduplicatorHashesInput{{
-							UserID: userID,
-							Hashes: []string{
-								"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-								"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
-								"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
-							},
-						}}))
-					})
-
-					It("returns an error if finding deduplicator hashes returns an error", func() {
-						testDataStoreSession.FindDatasetDataDeduplicatorHashesOutputs = []testDataStore.FindDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: errors.New("test error")}}
-						err := testDeduplicator.AddDataToDataset(testDatasetData)
-						Expect(err).To(MatchError("deduplicator: unable to find existing identity hashes; test error"))
-					})
-
-					Context("with deduplicator descriptor", func() {
-						BeforeEach(func() {
-							testDataData[0].DeduplicatorDescriptorOutputs = []*data.DeduplicatorDescriptor{{
-								Name: "hash",
-								Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-							}}
-							testDataData[1].DeduplicatorDescriptorOutputs = []*data.DeduplicatorDescriptor{{
-								Name: "hash",
-								Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
-							}}
-							testDataData[2].DeduplicatorDescriptorOutputs = []*data.DeduplicatorDescriptor{{
-								Name: "hash",
-								Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
-							}}
-						})
-
-						It("returns success if finding deduplicator hashes returns all hashes", func() {
-							testDataStoreSession.FindDatasetDataDeduplicatorHashesOutputs = []testDataStore.FindDatasetDataDeduplicatorHashesOutput{{
-								Hashes: []string{
-									"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-									"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
-									"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
-								},
-								Error: nil,
-							}}
-							Expect(testDeduplicator.AddDataToDataset(testDatasetData)).To(Succeed())
-						})
-
-						Context("with creating dataset data", func() {
-							AfterEach(func() {
-								Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{
-									Dataset: testDataset,
-									DatasetData: []data.Datum{
-										testDataData[1],
-										testDataData[2],
-									},
-								}))
-							})
-
-							It("returns an error if there is an error with CreateDatasetDataInput", func() {
-								testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
-								err := testDeduplicator.AddDataToDataset(testDatasetData)
-								Expect(err).To(MatchError("deduplicator: unable to add data to dataset; test error"))
-							})
-
-							It("returns successfully if there is no error", func() {
-								testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
-								Expect(testDeduplicator.AddDataToDataset(testDatasetData)).To(Succeed())
-							})
-						})
-					})
-				})
-			})
-
-			Context("FinalizeDataset", func() {
-				It("returns an error if there is an error on activate", func() {
-					uploadID := app.NewID()
-					testDataset.UploadID = uploadID
-					testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
-					err := testDeduplicator.FinalizeDataset()
-					Expect(err).To(MatchError(`deduplicator: unable to activate data in dataset with id "` + uploadID + `"; test error`))
-					Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
-				})
-
-				It("returns successfully if there is no error", func() {
-					testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
-					Expect(testDeduplicator.FinalizeDataset()).To(Succeed())
-					Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
-				})
-			})
+		It("successfully returns a hash with five identity fields", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"one", "two", "three", "four", "five"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal("8HUIFZUXmOuySpngHvl+fJECoeELTiCRxwNxxgDzmVQ="))
 		})
 	})
 })

--- a/data/deduplicator/test/factory.go
+++ b/data/deduplicator/test/factory.go
@@ -13,25 +13,47 @@ type CanDeduplicateDatasetOutput struct {
 	Error error
 }
 
-type NewDeduplicatorInput struct {
+type NewDeduplicatorForDatasetInput struct {
 	Logger           log.Logger
 	DataStoreSession store.Session
 	Dataset          *upload.Upload
 }
 
-type NewDeduplicatorOutput struct {
+type NewDeduplicatorForDatasetOutput struct {
+	Deduplicator data.Deduplicator
+	Error        error
+}
+
+type IsRegisteredWithDatasetOutput struct {
+	Is    bool
+	Error error
+}
+
+type NewRegisteredDeduplicatorForDatasetInput struct {
+	Logger           log.Logger
+	DataStoreSession store.Session
+	Dataset          *upload.Upload
+}
+
+type NewRegisteredDeduplicatorForDatasetOutput struct {
 	Deduplicator data.Deduplicator
 	Error        error
 }
 
 type Factory struct {
-	ID                               string
-	CanDeduplicateDatasetInvocations int
-	CanDeduplicateDatasetInputs      []*upload.Upload
-	CanDeduplicateDatasetOutputs     []CanDeduplicateDatasetOutput
-	NewDeduplicatoInvocations        int
-	NewDeduplicatorInputs            []NewDeduplicatorInput
-	NewDeduplicatorOutputs           []NewDeduplicatorOutput
+	ID                                             string
+	CanDeduplicateDatasetInvocations               int
+	CanDeduplicateDatasetInputs                    []*upload.Upload
+	CanDeduplicateDatasetOutputs                   []CanDeduplicateDatasetOutput
+	NewDeduplicatorForDatasetInvocations           int
+	NewDeduplicatorForDatasetInputs                []NewDeduplicatorForDatasetInput
+	NewDeduplicatorForDatasetOutputs               []NewDeduplicatorForDatasetOutput
+	IsRegisteredWithDatasetInvocations             int
+	IsRegisteredWithDatasetInputs                  []*upload.Upload
+	IsRegisteredWithDatasetOutputs                 []IsRegisteredWithDatasetOutput
+	NewRegisteredDeduplicatorForDatasetInvocations int
+	NewRegisteredDeduplicatorForDatasetInputs      []NewRegisteredDeduplicatorForDatasetInput
+	NewRegisteredDeduplicatorForDatasetOutputs     []NewRegisteredDeduplicatorForDatasetOutput
 }
 
 func NewFactory() *Factory {
@@ -54,21 +76,51 @@ func (f *Factory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
 	return output.Can, output.Error
 }
 
-func (f *Factory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
-	f.NewDeduplicatoInvocations++
+func (f *Factory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	f.NewDeduplicatorForDatasetInvocations++
 
-	f.NewDeduplicatorInputs = append(f.NewDeduplicatorInputs, NewDeduplicatorInput{logger, dataStoreSession, dataset})
+	f.NewDeduplicatorForDatasetInputs = append(f.NewDeduplicatorForDatasetInputs, NewDeduplicatorForDatasetInput{logger, dataStoreSession, dataset})
 
-	if len(f.NewDeduplicatorOutputs) == 0 {
-		panic("Unexpected invocation of NewDeduplicator on Factory")
+	if len(f.NewDeduplicatorForDatasetOutputs) == 0 {
+		panic("Unexpected invocation of NewDeduplicatorForDataset on Factory")
 	}
 
-	output := f.NewDeduplicatorOutputs[0]
-	f.NewDeduplicatorOutputs = f.NewDeduplicatorOutputs[1:]
+	output := f.NewDeduplicatorForDatasetOutputs[0]
+	f.NewDeduplicatorForDatasetOutputs = f.NewDeduplicatorForDatasetOutputs[1:]
+	return output.Deduplicator, output.Error
+}
+
+func (f *Factory) IsRegisteredWithDataset(dataset *upload.Upload) (bool, error) {
+	f.IsRegisteredWithDatasetInvocations++
+
+	f.IsRegisteredWithDatasetInputs = append(f.IsRegisteredWithDatasetInputs, dataset)
+
+	if len(f.IsRegisteredWithDatasetOutputs) == 0 {
+		panic("Unexpected invocation of IsRegisteredWithDataset on Factory")
+	}
+
+	output := f.IsRegisteredWithDatasetOutputs[0]
+	f.IsRegisteredWithDatasetOutputs = f.IsRegisteredWithDatasetOutputs[1:]
+	return output.Is, output.Error
+}
+
+func (f *Factory) NewRegisteredDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	f.NewRegisteredDeduplicatorForDatasetInvocations++
+
+	f.NewRegisteredDeduplicatorForDatasetInputs = append(f.NewRegisteredDeduplicatorForDatasetInputs, NewRegisteredDeduplicatorForDatasetInput{logger, dataStoreSession, dataset})
+
+	if len(f.NewRegisteredDeduplicatorForDatasetOutputs) == 0 {
+		panic("Unexpected invocation of NewRegisteredDeduplicatorForDataset on Factory")
+	}
+
+	output := f.NewRegisteredDeduplicatorForDatasetOutputs[0]
+	f.NewRegisteredDeduplicatorForDatasetOutputs = f.NewRegisteredDeduplicatorForDatasetOutputs[1:]
 	return output.Deduplicator, output.Error
 }
 
 func (f *Factory) UnusedOutputsCount() int {
 	return len(f.CanDeduplicateDatasetOutputs) +
-		len(f.NewDeduplicatorOutputs)
+		len(f.NewDeduplicatorForDatasetOutputs) +
+		len(f.IsRegisteredWithDatasetOutputs) +
+		len(f.NewRegisteredDeduplicatorForDatasetOutputs)
 }

--- a/data/deduplicator_test.go
+++ b/data/deduplicator_test.go
@@ -1,0 +1,73 @@
+package data_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"fmt"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+)
+
+var _ = Describe("Delegate", func() {
+	Context("DeduplicatorDescriptor", func() {
+		Context("NewDeduplicatorDescriptor", func() {
+			It("returns a new deduplicator descriptor", func() {
+				Expect(data.NewDeduplicatorDescriptor()).ToNot(BeNil())
+			})
+		})
+
+		Context("with a new deduplicator descriptor", func() {
+			var testDeduplicatorDescriptor *data.DeduplicatorDescriptor
+			var testName string
+
+			BeforeEach(func() {
+				testDeduplicatorDescriptor = data.NewDeduplicatorDescriptor()
+				Expect(testDeduplicatorDescriptor).ToNot(BeNil())
+				testName = app.NewID()
+				testDeduplicatorDescriptor.Name = testName
+			})
+
+			Context("IsRegisteredWithAnyDeduplicator", func() {
+				It("returns false if the deduplicator descriptor name is missing", func() {
+					testDeduplicatorDescriptor.Name = ""
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithAnyDeduplicator()).To(BeFalse())
+				})
+
+				It("returns true if the deduplicator descriptor name is present", func() {
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithAnyDeduplicator()).To(BeTrue())
+				})
+			})
+
+			Context("IsRegisteredWithNamedDeduplicator", func() {
+				It("returns false if the deduplicator descriptor name is missing", func() {
+					testDeduplicatorDescriptor.Name = ""
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(testName)).To(BeFalse())
+				})
+
+				It("returns true if the deduplicator descriptor name is present, but does not match", func() {
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(app.NewID())).To(BeFalse())
+				})
+
+				It("returns true if the deduplicator descriptor name is present and matches", func() {
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(testName)).To(BeTrue())
+				})
+			})
+
+			Context("RegisterWithNamedDeduplicator", func() {
+				It("returns error if the deduplicator descriptor already has a name", func() {
+					err := testDeduplicatorDescriptor.RegisterWithNamedDeduplicator(app.NewID())
+					Expect(err).To(MatchError(fmt.Sprintf(`data: deduplicator descriptor already registered with "%s"`, testName)))
+				})
+
+				It("returns successfully if the deduplicator descriptor does not already have a name", func() {
+					testDeduplicatorDescriptor.Name = ""
+					err := testDeduplicatorDescriptor.RegisterWithNamedDeduplicator(testName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testDeduplicatorDescriptor.Name).To(Equal(testName))
+				})
+			})
+		})
+	})
+})

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -29,12 +29,17 @@ type Session interface {
 
 	GetDatasetsForUserByID(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
 	GetDatasetByID(datasetID string) (*upload.Upload, error)
+	FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error)
 	CreateDataset(dataset *upload.Upload) error
 	UpdateDataset(dataset *upload.Upload) error
 	DeleteDataset(dataset *upload.Upload) error
-	FindDatasetDataDeduplicatorHashes(userID string, queryHashes []string) ([]string, error)
+	GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error)
+	FindAllDatasetDataDeduplicatorHashesForDevice(userID string, deviceID string, queryHashes []string) ([]string, error)
 	CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error
+	FindEarliestDatasetDataTime(dataset *upload.Upload) (string, error)
 	ActivateDatasetData(dataset *upload.Upload) error
+	SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error
+	DeactivateOtherDatasetDataAfterTime(dataset *upload.Upload, time string) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
 	DestroyDataForUserByID(userID string) error
 }

--- a/data/store/test/session.go
+++ b/data/store/test/session.go
@@ -24,12 +24,28 @@ type GetDatasetByIDOutput struct {
 	Error   error
 }
 
-type FindDatasetDataDeduplicatorHashesInput struct {
-	UserID string
-	Hashes []string
+type FindPreviousActiveDatasetForDeviceOutput struct {
+	Dataset *upload.Upload
+	Error   error
 }
 
-type FindDatasetDataDeduplicatorHashesOutput struct {
+type GetDatasetDataDeduplicatorHashesInput struct {
+	Dataset *upload.Upload
+	Active  bool
+}
+
+type GetDatasetDataDeduplicatorHashesOutput struct {
+	Hashes []string
+	Error  error
+}
+
+type FindAllDatasetDataDeduplicatorHashesForDeviceInput struct {
+	UserID   string
+	DeviceID string
+	Hashes   []string
+}
+
+type FindAllDatasetDataDeduplicatorHashesForDeviceOutput struct {
 	Hashes []string
 	Error  error
 }
@@ -39,43 +55,74 @@ type CreateDatasetDataInput struct {
 	DatasetData []data.Datum
 }
 
+type FindEarliestDatasetDataTimeOutput struct {
+	Time  string
+	Error error
+}
+
+type SetDatasetDataActiveUsingHashesInput struct {
+	Dataset *upload.Upload
+	Hashes  []string
+	Active  bool
+}
+
+type DeactivateOtherDatasetDataAfterTimeInput struct {
+	Dataset *upload.Upload
+	Time    string
+}
+
 type Session struct {
-	ID                                           string
-	IsClosedInvocations                          int
-	IsClosedOutputs                              []bool
-	CloseInvocations                             int
-	SetAgentInvocations                          int
-	SetAgentInputs                               []commonStore.Agent
-	GetDatasetsForUserByIDInvocations            int
-	GetDatasetsForUserByIDInputs                 []GetDatasetsForUserByIDInput
-	GetDatasetsForUserByIDOutputs                []GetDatasetsForUserByIDOutput
-	GetDatasetByIDInvocations                    int
-	GetDatasetByIDInputs                         []string
-	GetDatasetByIDOutputs                        []GetDatasetByIDOutput
-	CreateDatasetInvocations                     int
-	CreateDatasetInputs                          []*upload.Upload
-	CreateDatasetOutputs                         []error
-	UpdateDatasetInvocations                     int
-	UpdateDatasetInputs                          []*upload.Upload
-	UpdateDatasetOutputs                         []error
-	DeleteDatasetInvocations                     int
-	DeleteDatasetInputs                          []*upload.Upload
-	DeleteDatasetOutputs                         []error
-	FindDatasetDataDeduplicatorHashesInvocations int
-	FindDatasetDataDeduplicatorHashesInputs      []FindDatasetDataDeduplicatorHashesInput
-	FindDatasetDataDeduplicatorHashesOutputs     []FindDatasetDataDeduplicatorHashesOutput
-	CreateDatasetDataInvocations                 int
-	CreateDatasetDataInputs                      []CreateDatasetDataInput
-	CreateDatasetDataOutputs                     []error
-	ActivateDatasetDataInvocations               int
-	ActivateDatasetDataInputs                    []*upload.Upload
-	ActivateDatasetDataOutputs                   []error
-	DeleteOtherDatasetDataInvocations            int
-	DeleteOtherDatasetDataInputs                 []*upload.Upload
-	DeleteOtherDatasetDataOutputs                []error
-	DestroyDataForUserByIDInvocations            int
-	DestroyDataForUserByIDInputs                 []string
-	DestroyDataForUserByIDOutputs                []error
+	ID                                                       string
+	IsClosedInvocations                                      int
+	IsClosedOutputs                                          []bool
+	CloseInvocations                                         int
+	SetAgentInvocations                                      int
+	SetAgentInputs                                           []commonStore.Agent
+	GetDatasetsForUserByIDInvocations                        int
+	GetDatasetsForUserByIDInputs                             []GetDatasetsForUserByIDInput
+	GetDatasetsForUserByIDOutputs                            []GetDatasetsForUserByIDOutput
+	GetDatasetByIDInvocations                                int
+	GetDatasetByIDInputs                                     []string
+	GetDatasetByIDOutputs                                    []GetDatasetByIDOutput
+	FindPreviousActiveDatasetForDeviceInvocations            int
+	FindPreviousActiveDatasetForDeviceInputs                 []*upload.Upload
+	FindPreviousActiveDatasetForDeviceOutputs                []FindPreviousActiveDatasetForDeviceOutput
+	CreateDatasetInvocations                                 int
+	CreateDatasetInputs                                      []*upload.Upload
+	CreateDatasetOutputs                                     []error
+	UpdateDatasetInvocations                                 int
+	UpdateDatasetInputs                                      []*upload.Upload
+	UpdateDatasetOutputs                                     []error
+	DeleteDatasetInvocations                                 int
+	DeleteDatasetInputs                                      []*upload.Upload
+	DeleteDatasetOutputs                                     []error
+	GetDatasetDataDeduplicatorHashesInvocations              int
+	GetDatasetDataDeduplicatorHashesInputs                   []GetDatasetDataDeduplicatorHashesInput
+	GetDatasetDataDeduplicatorHashesOutputs                  []GetDatasetDataDeduplicatorHashesOutput
+	FindAllDatasetDataDeduplicatorHashesForDeviceInvocations int
+	FindAllDatasetDataDeduplicatorHashesForDeviceInputs      []FindAllDatasetDataDeduplicatorHashesForDeviceInput
+	FindAllDatasetDataDeduplicatorHashesForDeviceOutputs     []FindAllDatasetDataDeduplicatorHashesForDeviceOutput
+	CreateDatasetDataInvocations                             int
+	CreateDatasetDataInputs                                  []CreateDatasetDataInput
+	CreateDatasetDataOutputs                                 []error
+	FindEarliestDatasetDataTimeInvocations                   int
+	FindEarliestDatasetDataTimeInputs                        []*upload.Upload
+	FindEarliestDatasetDataTimeOutputs                       []FindEarliestDatasetDataTimeOutput
+	ActivateDatasetDataInvocations                           int
+	ActivateDatasetDataInputs                                []*upload.Upload
+	ActivateDatasetDataOutputs                               []error
+	SetDatasetDataActiveUsingHashesInvocations               int
+	SetDatasetDataActiveUsingHashesInputs                    []SetDatasetDataActiveUsingHashesInput
+	SetDatasetDataActiveUsingHashesOutputs                   []error
+	DeactivateOtherDatasetDataAfterTimeInvocations           int
+	DeactivateOtherDatasetDataAfterTimeInputs                []DeactivateOtherDatasetDataAfterTimeInput
+	DeactivateOtherDatasetDataAfterTimeOutputs               []error
+	DeleteOtherDatasetDataInvocations                        int
+	DeleteOtherDatasetDataInputs                             []*upload.Upload
+	DeleteOtherDatasetDataOutputs                            []error
+	DestroyDataForUserByIDInvocations                        int
+	DestroyDataForUserByIDInputs                             []string
+	DestroyDataForUserByIDOutputs                            []error
 }
 
 func NewSession() *Session {
@@ -134,6 +181,20 @@ func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	return output.Dataset, output.Error
 }
 
+func (s *Session) FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error) {
+	s.FindPreviousActiveDatasetForDeviceInvocations++
+
+	s.FindPreviousActiveDatasetForDeviceInputs = append(s.FindPreviousActiveDatasetForDeviceInputs, dataset)
+
+	if len(s.FindPreviousActiveDatasetForDeviceOutputs) == 0 {
+		panic("Unexpected invocation of FindPreviousActiveDatasetForDevice on Session")
+	}
+
+	output := s.FindPreviousActiveDatasetForDeviceOutputs[0]
+	s.FindPreviousActiveDatasetForDeviceOutputs = s.FindPreviousActiveDatasetForDeviceOutputs[1:]
+	return output.Dataset, output.Error
+}
+
 func (s *Session) CreateDataset(dataset *upload.Upload) error {
 	s.CreateDatasetInvocations++
 
@@ -176,17 +237,31 @@ func (s *Session) DeleteDataset(dataset *upload.Upload) error {
 	return output
 }
 
-func (s *Session) FindDatasetDataDeduplicatorHashes(userID string, queryHashes []string) ([]string, error) {
-	s.FindDatasetDataDeduplicatorHashesInvocations++
+func (s *Session) GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error) {
+	s.GetDatasetDataDeduplicatorHashesInvocations++
 
-	s.FindDatasetDataDeduplicatorHashesInputs = append(s.FindDatasetDataDeduplicatorHashesInputs, FindDatasetDataDeduplicatorHashesInput{userID, queryHashes})
+	s.GetDatasetDataDeduplicatorHashesInputs = append(s.GetDatasetDataDeduplicatorHashesInputs, GetDatasetDataDeduplicatorHashesInput{dataset, active})
 
-	if len(s.FindDatasetDataDeduplicatorHashesOutputs) == 0 {
-		panic("Unexpected invocation of FindDatasetDataDeduplicatorHashes on Session")
+	if len(s.GetDatasetDataDeduplicatorHashesOutputs) == 0 {
+		panic("Unexpected invocation of GetDatasetDataDeduplicatorHashes on Session")
 	}
 
-	output := s.FindDatasetDataDeduplicatorHashesOutputs[0]
-	s.FindDatasetDataDeduplicatorHashesOutputs = s.FindDatasetDataDeduplicatorHashesOutputs[1:]
+	output := s.GetDatasetDataDeduplicatorHashesOutputs[0]
+	s.GetDatasetDataDeduplicatorHashesOutputs = s.GetDatasetDataDeduplicatorHashesOutputs[1:]
+	return output.Hashes, output.Error
+}
+
+func (s *Session) FindAllDatasetDataDeduplicatorHashesForDevice(userID string, deviceID string, queryHashes []string) ([]string, error) {
+	s.FindAllDatasetDataDeduplicatorHashesForDeviceInvocations++
+
+	s.FindAllDatasetDataDeduplicatorHashesForDeviceInputs = append(s.FindAllDatasetDataDeduplicatorHashesForDeviceInputs, FindAllDatasetDataDeduplicatorHashesForDeviceInput{userID, deviceID, queryHashes})
+
+	if len(s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs) == 0 {
+		panic("Unexpected invocation of FindAllDatasetDataDeduplicatorHashesForDevice on Session")
+	}
+
+	output := s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs[0]
+	s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs[1:]
 	return output.Hashes, output.Error
 }
 
@@ -204,6 +279,20 @@ func (s *Session) CreateDatasetData(dataset *upload.Upload, datasetData []data.D
 	return output
 }
 
+func (s *Session) FindEarliestDatasetDataTime(dataset *upload.Upload) (string, error) {
+	s.FindEarliestDatasetDataTimeInvocations++
+
+	s.FindEarliestDatasetDataTimeInputs = append(s.FindEarliestDatasetDataTimeInputs, dataset)
+
+	if len(s.FindEarliestDatasetDataTimeOutputs) == 0 {
+		panic("Unexpected invocation of FindEarliestDatasetDataTime on Session")
+	}
+
+	output := s.FindEarliestDatasetDataTimeOutputs[0]
+	s.FindEarliestDatasetDataTimeOutputs = s.FindEarliestDatasetDataTimeOutputs[1:]
+	return output.Time, output.Error
+}
+
 func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 	s.ActivateDatasetDataInvocations++
 
@@ -215,6 +304,34 @@ func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 
 	output := s.ActivateDatasetDataOutputs[0]
 	s.ActivateDatasetDataOutputs = s.ActivateDatasetDataOutputs[1:]
+	return output
+}
+
+func (s *Session) SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error {
+	s.SetDatasetDataActiveUsingHashesInvocations++
+
+	s.SetDatasetDataActiveUsingHashesInputs = append(s.SetDatasetDataActiveUsingHashesInputs, SetDatasetDataActiveUsingHashesInput{dataset, queryHashes, active})
+
+	if len(s.SetDatasetDataActiveUsingHashesOutputs) == 0 {
+		panic("Unexpected invocation of SetDatasetDataActiveUsingHashes on Session")
+	}
+
+	output := s.SetDatasetDataActiveUsingHashesOutputs[0]
+	s.SetDatasetDataActiveUsingHashesOutputs = s.SetDatasetDataActiveUsingHashesOutputs[1:]
+	return output
+}
+
+func (s *Session) DeactivateOtherDatasetDataAfterTime(dataset *upload.Upload, time string) error {
+	s.DeactivateOtherDatasetDataAfterTimeInvocations++
+
+	s.DeactivateOtherDatasetDataAfterTimeInputs = append(s.DeactivateOtherDatasetDataAfterTimeInputs, DeactivateOtherDatasetDataAfterTimeInput{dataset, time})
+
+	if len(s.DeactivateOtherDatasetDataAfterTimeOutputs) == 0 {
+		panic("Unexpected invocation of DeactivateOtherDatasetDataAfterTime on Session")
+	}
+
+	output := s.DeactivateOtherDatasetDataAfterTimeOutputs[0]
+	s.DeactivateOtherDatasetDataAfterTimeOutputs = s.DeactivateOtherDatasetDataAfterTimeOutputs[1:]
 	return output
 }
 
@@ -250,11 +367,17 @@ func (s *Session) UnusedOutputsCount() int {
 	return len(s.IsClosedOutputs) +
 		len(s.GetDatasetsForUserByIDOutputs) +
 		len(s.GetDatasetByIDOutputs) +
+		len(s.FindPreviousActiveDatasetForDeviceOutputs) +
 		len(s.CreateDatasetOutputs) +
 		len(s.UpdateDatasetOutputs) +
 		len(s.DeleteDatasetOutputs) +
+		len(s.GetDatasetDataDeduplicatorHashesOutputs) +
+		len(s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs) +
 		len(s.CreateDatasetDataOutputs) +
+		len(s.FindEarliestDatasetDataTimeOutputs) +
 		len(s.ActivateDatasetDataOutputs) +
+		len(s.SetDatasetDataActiveUsingHashesOutputs) +
+		len(s.DeactivateOtherDatasetDataAfterTimeOutputs) +
 		len(s.DeleteOtherDatasetDataOutputs) +
 		len(s.DestroyDataForUserByIDOutputs)
 }

--- a/data/test/datum.go
+++ b/data/test/datum.go
@@ -46,10 +46,9 @@ type Datum struct {
 	SetDeletedTimeInputs                 []string
 	SetDeletedUserIDInvocations          int
 	SetDeletedUserIDInputs               []string
+	DeduplicatorDescriptorValue          *data.DeduplicatorDescriptor
 	DeduplicatorDescriptorInvocations    int
-	DeduplicatorDescriptorOutputs        []*data.DeduplicatorDescriptor
 	SetDeduplicatorDescriptorInvocations int
-	SetDeduplicatorDescriptorInputs      []*data.DeduplicatorDescriptor
 }
 
 func NewDatum() *Datum {
@@ -66,7 +65,7 @@ func (d *Datum) Meta() interface{} {
 	d.MetaInvocations++
 
 	if len(d.MetaOutputs) == 0 {
-		panic("Unexpected invocation of Meta on Session")
+		panic("Unexpected invocation of Meta on Datum")
 	}
 
 	output := d.MetaOutputs[0]
@@ -80,7 +79,7 @@ func (d *Datum) Parse(parser data.ObjectParser) error {
 	d.ParseInputs = append(d.ParseInputs, parser)
 
 	if len(d.ParseOutputs) == 0 {
-		panic("Unexpected invocation of Parse on Session")
+		panic("Unexpected invocation of Parse on Datum")
 	}
 
 	output := d.ParseOutputs[0]
@@ -94,7 +93,7 @@ func (d *Datum) Validate(validator data.Validator) error {
 	d.ValidateInputs = append(d.ValidateInputs, validator)
 
 	if len(d.ValidateOutputs) == 0 {
-		panic("Unexpected invocation of Validate on Session")
+		panic("Unexpected invocation of Validate on Datum")
 	}
 
 	output := d.ValidateOutputs[0]
@@ -108,7 +107,7 @@ func (d *Datum) Normalize(normalizer data.Normalizer) error {
 	d.NormalizeInputs = append(d.NormalizeInputs, normalizer)
 
 	if len(d.NormalizeOutputs) == 0 {
-		panic("Unexpected invocation of Normalize on Session")
+		panic("Unexpected invocation of Normalize on Datum")
 	}
 
 	output := d.NormalizeOutputs[0]
@@ -120,7 +119,7 @@ func (d *Datum) IdentityFields() ([]string, error) {
 	d.IdentityFieldsInvocations++
 
 	if len(d.IdentityFieldsOutputs) == 0 {
-		panic("Unexpected invocation of IdentityFields on Session")
+		panic("Unexpected invocation of IdentityFields on Datum")
 	}
 
 	output := d.IdentityFieldsOutputs[0]
@@ -191,19 +190,13 @@ func (d *Datum) SetDeletedUserID(deletedUserID string) {
 func (d *Datum) DeduplicatorDescriptor() *data.DeduplicatorDescriptor {
 	d.DeduplicatorDescriptorInvocations++
 
-	if len(d.DeduplicatorDescriptorOutputs) == 0 {
-		panic("Unexpected invocation of DeduplicatorDescriptor on Session")
-	}
-
-	output := d.DeduplicatorDescriptorOutputs[0]
-	d.DeduplicatorDescriptorOutputs = d.DeduplicatorDescriptorOutputs[1:]
-	return output
+	return d.DeduplicatorDescriptorValue
 }
 
 func (d *Datum) SetDeduplicatorDescriptor(deduplicatorDescriptor *data.DeduplicatorDescriptor) {
 	d.SetDeduplicatorDescriptorInvocations++
 
-	d.SetDeduplicatorDescriptorInputs = append(d.SetDeduplicatorDescriptorInputs, deduplicatorDescriptor)
+	d.DeduplicatorDescriptorValue = deduplicatorDescriptor
 }
 
 func (d *Datum) UnusedOutputsCount() int {
@@ -211,6 +204,5 @@ func (d *Datum) UnusedOutputsCount() int {
 		len(d.ParseOutputs) +
 		len(d.ValidateOutputs) +
 		len(d.NormalizeOutputs) +
-		len(d.IdentityFieldsOutputs) +
-		len(d.DeduplicatorDescriptorOutputs)
+		len(d.IdentityFieldsOutputs)
 }

--- a/data/test/deduplicator.go
+++ b/data/test/deduplicator.go
@@ -6,14 +6,18 @@ import (
 )
 
 type Deduplicator struct {
-	ID                           string
-	InitializeDatasetInvocations int
-	InitializeDatasetOutputs     []error
-	AddDataToDatasetInvocations  int
-	AddDataToDatasetInputs       [][]data.Datum
-	AddDataToDatasetOutputs      []error
-	FinalizeDatasetInvocations   int
-	FinalizeDatasetOutputs       []error
+	ID                            string
+	NameInvocations               int
+	NameOutputs                   []string
+	RegisterDatasetInvocations    int
+	RegisterDatasetOutputs        []error
+	AddDatasetDataInvocations     int
+	AddDatasetDataInputs          [][]data.Datum
+	AddDatasetDataOutputs         []error
+	DeduplicateDatasetInvocations int
+	DeduplicateDatasetOutputs     []error
+	DeleteDatasetInvocations      int
+	DeleteDatasetOutputs          []error
 }
 
 func NewDeduplicator() *Deduplicator {
@@ -22,46 +26,72 @@ func NewDeduplicator() *Deduplicator {
 	}
 }
 
-func (d *Deduplicator) InitializeDataset() error {
-	d.InitializeDatasetInvocations++
+func (d *Deduplicator) Name() string {
+	d.NameInvocations++
 
-	if len(d.InitializeDatasetOutputs) == 0 {
-		panic("Unexpected invocation of InitializeDataset on Deduplicator")
+	if len(d.NameOutputs) == 0 {
+		panic("Unexpected invocation of Name on Deduplicator")
 	}
 
-	output := d.InitializeDatasetOutputs[0]
-	d.InitializeDatasetOutputs = d.InitializeDatasetOutputs[1:]
+	output := d.NameOutputs[0]
+	d.NameOutputs = d.NameOutputs[1:]
 	return output
 }
 
-func (d *Deduplicator) AddDataToDataset(datasetData []data.Datum) error {
-	d.AddDataToDatasetInvocations++
+func (d *Deduplicator) RegisterDataset() error {
+	d.RegisterDatasetInvocations++
 
-	d.AddDataToDatasetInputs = append(d.AddDataToDatasetInputs, datasetData)
-
-	if len(d.AddDataToDatasetOutputs) == 0 {
-		panic("Unexpected invocation of AddDataToDataset on Deduplicator")
+	if len(d.RegisterDatasetOutputs) == 0 {
+		panic("Unexpected invocation of RegisterDataset on Deduplicator")
 	}
 
-	output := d.AddDataToDatasetOutputs[0]
-	d.AddDataToDatasetOutputs = d.AddDataToDatasetOutputs[1:]
+	output := d.RegisterDatasetOutputs[0]
+	d.RegisterDatasetOutputs = d.RegisterDatasetOutputs[1:]
 	return output
 }
 
-func (d *Deduplicator) FinalizeDataset() error {
-	d.FinalizeDatasetInvocations++
+func (d *Deduplicator) AddDatasetData(datasetData []data.Datum) error {
+	d.AddDatasetDataInvocations++
 
-	if len(d.FinalizeDatasetOutputs) == 0 {
-		panic("Unexpected invocation of FinalizeDataset on Deduplicator")
+	d.AddDatasetDataInputs = append(d.AddDatasetDataInputs, datasetData)
+
+	if len(d.AddDatasetDataOutputs) == 0 {
+		panic("Unexpected invocation of AddDatasetData on Deduplicator")
 	}
 
-	output := d.FinalizeDatasetOutputs[0]
-	d.FinalizeDatasetOutputs = d.FinalizeDatasetOutputs[1:]
+	output := d.AddDatasetDataOutputs[0]
+	d.AddDatasetDataOutputs = d.AddDatasetDataOutputs[1:]
+	return output
+}
+
+func (d *Deduplicator) DeduplicateDataset() error {
+	d.DeduplicateDatasetInvocations++
+
+	if len(d.DeduplicateDatasetOutputs) == 0 {
+		panic("Unexpected invocation of DeduplicateDataset on Deduplicator")
+	}
+
+	output := d.DeduplicateDatasetOutputs[0]
+	d.DeduplicateDatasetOutputs = d.DeduplicateDatasetOutputs[1:]
+	return output
+}
+
+func (d *Deduplicator) DeleteDataset() error {
+	d.DeleteDatasetInvocations++
+
+	if len(d.DeleteDatasetOutputs) == 0 {
+		panic("Unexpected invocation of DeleteDataset on Deduplicator")
+	}
+
+	output := d.DeleteDatasetOutputs[0]
+	d.DeleteDatasetOutputs = d.DeleteDatasetOutputs[1:]
 	return output
 }
 
 func (d *Deduplicator) UnusedOutputsCount() int {
-	return len(d.InitializeDatasetOutputs) +
-		len(d.AddDataToDatasetOutputs) +
-		len(d.FinalizeDatasetOutputs)
+	return len(d.NameOutputs) +
+		len(d.RegisterDatasetOutputs) +
+		len(d.AddDatasetDataOutputs) +
+		len(d.DeduplicateDatasetOutputs) +
+		len(d.DeleteDatasetOutputs)
 }

--- a/data/test/test.go
+++ b/data/test/test.go
@@ -1,4 +1,4 @@
-package testing
+package test
 
 import (
 	"github.com/onsi/gomega"

--- a/data/types/basal/basal_suite_test.go
+++ b/data/types/basal/basal_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/basal")
+	RunSpecs(t, "data/types/basal")
 }

--- a/data/types/basal/basal_test.go
+++ b/data/types/basal/basal_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -110,7 +110,7 @@ var _ = Describe("Basal", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestBasal(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 				Entry("does not parse delivery type",
 					&map[string]interface{}{"deliveryType": "scheduled"},
@@ -124,7 +124,7 @@ var _ = Describe("Basal", func() {
 					&map[string]interface{}{"time": 0, "deliveryType": 0},
 					NewTestBasal(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 			)
 
@@ -145,12 +145,12 @@ var _ = Describe("Basal", func() {
 				Entry("missing time",
 					NewTestBasal(nil, "scheduled"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("scheduled")),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("scheduled")),
 					}),
 				Entry("missing delivery type",
 					NewTestBasal("2016-09-06T13:45:58-07:00", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueEmpty(), "/deliveryType", NewMeta("")),
+						testData.ComposeError(service.ErrorValueEmpty(), "/deliveryType", NewMeta("")),
 					}),
 				Entry("specified delivery type",
 					NewTestBasal("2016-09-06T13:45:58-07:00", "specified"),
@@ -158,8 +158,8 @@ var _ = Describe("Basal", func() {
 				Entry("multiple",
 					NewTestBasal(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
-						testing.ComposeError(service.ErrorValueEmpty(), "/deliveryType", NewMeta("")),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorValueEmpty(), "/deliveryType", NewMeta("")),
 					}),
 			)
 

--- a/data/types/basal/scheduled/scheduled_suite_test.go
+++ b/data/types/basal/scheduled/scheduled_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/basal/scheduled")
+	RunSpecs(t, "data/types/basal/scheduled")
 }

--- a/data/types/basal/scheduled/scheduled_test.go
+++ b/data/types/basal/scheduled/scheduled_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
 	"github.com/tidepool-org/platform/data/types/basal/scheduled"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -140,7 +140,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestScheduled(nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
 					}),
 				Entry("parses object that has valid duration",
 					&map[string]interface{}{"duration": 3600000},
@@ -150,7 +150,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"duration": "invalid"},
 					NewTestScheduled(nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
 					}),
 				Entry("parses object that has valid expected duration",
 					&map[string]interface{}{"expectedDuration": 7200000},
@@ -160,7 +160,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"expectedDuration": "invalid"},
 					NewTestScheduled(nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
 					}),
 				Entry("parses object that has valid rate",
 					&map[string]interface{}{"rate": 1.0},
@@ -170,7 +170,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"rate": "invalid"},
 					NewTestScheduled(nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
 					}),
 				Entry("parses object that has valid schedule name",
 					&map[string]interface{}{"scheduleName": "Weekday"},
@@ -180,7 +180,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"scheduleName": 0},
 					NewTestScheduled(nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", NewMeta()),
 					}),
 				Entry("parses object that has multiple valid fields",
 					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "duration": 3600000, "expectedDuration": 7200000, "rate": 1.0, "scheduleName": "Weekday"},
@@ -190,11 +190,11 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"time": 0, "duration": "invalid", "expectedDuration": "invalid", "rate": "invalid", "scheduleName": 0, "suppressed": "invalid"},
 					NewTestScheduled(nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", NewMeta()),
 					}),
 			)
 
@@ -215,17 +215,17 @@ var _ = Describe("Temporary", func() {
 				Entry("missing time",
 					NewTestScheduled(nil, 3600000, 7200000, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing duration",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", nil, 7200000, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("duration out of range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", -1, 7200000, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 					}),
 				Entry("duration in range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 0, 7200000, 1.0, "Weekday"),
@@ -236,12 +236,12 @@ var _ = Describe("Temporary", func() {
 				Entry("duration out of range (upper)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 604800001, nil, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 					}),
 				Entry("expected duration out of range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 3599999, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(3599999, 3600000, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(3599999, 3600000, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("expected duration in range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 3600000, 1.0, "Weekday"),
@@ -252,39 +252,39 @@ var _ = Describe("Temporary", func() {
 				Entry("expected duration out of range (upper)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 604800001, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 3600000, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 3600000, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration out of range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", nil, -1, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration in range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", nil, 0, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration in range (upper)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", nil, 604800000, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration out of range (upper)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", nil, 604800001, 1.0, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing rate",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 7200000, nil, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/rate", NewMeta()),
 					}),
 				Entry("rate out of range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 7200000, -0.1, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", NewMeta()),
 					}),
 				Entry("rate in range (lower)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 7200000, 0.0, "Weekday"),
@@ -295,21 +295,21 @@ var _ = Describe("Temporary", func() {
 				Entry("rate out of range (upper)",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 7200000, 100.1, "Weekday"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
 					}),
 				Entry("schedule name empty",
 					NewTestScheduled("2016-09-06T13:45:58-07:00", 3600000, 7200000, 1.0, ""),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueEmpty(), "/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorValueEmpty(), "/scheduleName", NewMeta()),
 					}),
 				Entry("multiple",
 					NewTestScheduled(nil, nil, 604800001, 100.1, ""),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
-						testing.ComposeError(service.ErrorValueEmpty(), "/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueEmpty(), "/scheduleName", NewMeta()),
 					}),
 			)
 

--- a/data/types/basal/suppressed_test.go
+++ b/data/types/basal/suppressed_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -62,17 +62,17 @@ var _ = Describe("Target", func() {
 			&map[string]interface{}{"type": 0, "deliveryType": 0, "rate": "invalid", "scheduleName": 0, "suppressed": 0},
 			NewTestSuppressed(nil, nil, nil, nil, nil),
 			[]*service.Error{
-				testing.ComposeError(service.ErrorTypeNotString(0), "/type", nil),
-				testing.ComposeError(service.ErrorTypeNotString(0), "/deliveryType", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", nil),
-				testing.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", nil),
-				testing.ComposeError(service.ErrorTypeNotObject(0), "/suppressed", nil),
+				testData.ComposeError(service.ErrorTypeNotString(0), "/type", nil),
+				testData.ComposeError(service.ErrorTypeNotString(0), "/deliveryType", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", nil),
+				testData.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", nil),
+				testData.ComposeError(service.ErrorTypeNotObject(0), "/suppressed", nil),
 			}),
 		Entry("parses object that has additional fields",
 			&map[string]interface{}{"type": "basal", "deliveryType": "temp", "rate": 2.0, "suppressed": map[string]interface{}{"type": "basal", "deliveryType": "scheduled", "rate": 1.0, "scheduleName": "Weekday"}, "additional": 0.0},
 			NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)),
 			[]*service.Error{
-				testing.ComposeError(parser.ErrorNotParsed(), "/additional", nil),
+				testData.ComposeError(parser.ErrorNotParsed(), "/additional", nil),
 			}),
 	)
 
@@ -115,7 +115,7 @@ var _ = Describe("Target", func() {
 				&map[string]interface{}{"type": 0},
 				NewTestSuppressed(nil, nil, nil, nil, nil),
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotString(0), "/type", nil),
+					testData.ComposeError(service.ErrorTypeNotString(0), "/type", nil),
 				}),
 			Entry("parses object that has valid delivery type",
 				&map[string]interface{}{"deliveryType": "temp"},
@@ -125,7 +125,7 @@ var _ = Describe("Target", func() {
 				&map[string]interface{}{"deliveryType": 0},
 				NewTestSuppressed(nil, nil, nil, nil, nil),
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotString(0), "/deliveryType", nil),
+					testData.ComposeError(service.ErrorTypeNotString(0), "/deliveryType", nil),
 				}),
 			Entry("parses object that has valid rate",
 				&map[string]interface{}{"rate": 2.0},
@@ -135,7 +135,7 @@ var _ = Describe("Target", func() {
 				&map[string]interface{}{"rate": "invalid"},
 				NewTestSuppressed(nil, nil, nil, nil, nil),
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", nil),
 				}),
 			Entry("parses object that has valid schedule name",
 				&map[string]interface{}{"scheduleName": "Weekday"},
@@ -145,7 +145,7 @@ var _ = Describe("Target", func() {
 				&map[string]interface{}{"scheduleName": 0},
 				NewTestSuppressed(nil, nil, nil, nil, nil),
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", nil),
+					testData.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", nil),
 				}),
 			Entry("parses object that has valid suppressed",
 				&map[string]interface{}{"suppressed": map[string]interface{}{}},
@@ -159,7 +159,7 @@ var _ = Describe("Target", func() {
 				&map[string]interface{}{"suppressed": 0},
 				NewTestSuppressed(nil, nil, nil, nil, nil),
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotObject(0), "/suppressed", nil),
+					testData.ComposeError(service.ErrorTypeNotObject(0), "/suppressed", nil),
 				}),
 			Entry("parses object that has multiple valid fields",
 				&map[string]interface{}{"type": "basal", "deliveryType": "temp", "rate": 2.0, "suppressed": map[string]interface{}{"type": "basal", "deliveryType": "scheduled", "rate": 1.0, "scheduleName": "Weekday"}},
@@ -169,11 +169,11 @@ var _ = Describe("Target", func() {
 				&map[string]interface{}{"type": 0, "deliveryType": 0, "rate": "invalid", "scheduleName": 0, "suppressed": 0},
 				NewTestSuppressed(nil, nil, nil, nil, nil),
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotString(0), "/type", nil),
-					testing.ComposeError(service.ErrorTypeNotString(0), "/deliveryType", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", nil),
-					testing.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", nil),
-					testing.ComposeError(service.ErrorTypeNotObject(0), "/suppressed", nil),
+					testData.ComposeError(service.ErrorTypeNotString(0), "/type", nil),
+					testData.ComposeError(service.ErrorTypeNotString(0), "/deliveryType", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", nil),
+					testData.ComposeError(service.ErrorTypeNotString(0), "/scheduleName", nil),
+					testData.ComposeError(service.ErrorTypeNotObject(0), "/suppressed", nil),
 				}),
 		)
 
@@ -194,32 +194,32 @@ var _ = Describe("Target", func() {
 			Entry("validates a suppressed with type scheduled; type missing",
 				NewTestSuppressed(nil, "scheduled", 1.0, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/type", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/type", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; type not basal",
 				NewTestSuppressed("invalid", "scheduled", 1.0, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
+					testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; deliveryType missing",
 				NewTestSuppressed("basal", nil, 1.0, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/deliveryType", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/deliveryType", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; deliveryType not allowed",
 				NewTestSuppressed("basal", "invalid", 1.0, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"scheduled"}), "/deliveryType", nil),
+					testData.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"scheduled"}), "/deliveryType", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; rate missing",
 				NewTestSuppressed("basal", "scheduled", nil, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/rate", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/rate", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; rate out of range (lower)",
 				NewTestSuppressed("basal", "scheduled", -0.1, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; rate at limit (lower)",
 				NewTestSuppressed("basal", "scheduled", 0.0, "Weekday", nil), []string{"scheduled"},
@@ -230,25 +230,25 @@ var _ = Describe("Target", func() {
 			Entry("validates a suppressed with type scheduled; rate out of range (upper)",
 				NewTestSuppressed("basal", "scheduled", 100.1, "Weekday", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; schedule name empty",
 				NewTestSuppressed("basal", "scheduled", 1.0, "", nil), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueEmpty(), "/scheduleName", nil),
+					testData.ComposeError(service.ErrorValueEmpty(), "/scheduleName", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; suppressed exists",
 				NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", NewTestSuppressed(nil, nil, nil, nil, nil)), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueExists(), "/suppressed", nil),
+					testData.ComposeError(service.ErrorValueExists(), "/suppressed", nil),
 				}),
 			Entry("validates a suppressed with type scheduled; multiple",
 				NewTestSuppressed("invalid", "scheduled", 100.1, "", NewTestSuppressed(nil, nil, nil, nil, nil)), []string{"scheduled"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
-					testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
-					testing.ComposeError(service.ErrorValueEmpty(), "/scheduleName", nil),
-					testing.ComposeError(service.ErrorValueExists(), "/suppressed", nil),
+					testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
+					testData.ComposeError(service.ErrorValueEmpty(), "/scheduleName", nil),
+					testData.ComposeError(service.ErrorValueExists(), "/suppressed", nil),
 				}),
 			Entry("validates a suppressed with type temp; all valid",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
@@ -256,32 +256,32 @@ var _ = Describe("Target", func() {
 			Entry("validates a suppressed with type temp; type missing",
 				NewTestSuppressed(nil, "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/type", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/type", nil),
 				}),
 			Entry("validates a suppressed with type temp; type not basal",
 				NewTestSuppressed("invalid", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
+					testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
 				}),
 			Entry("validates a suppressed with type temp; deliveryType missing",
 				NewTestSuppressed("basal", nil, 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/deliveryType", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/deliveryType", nil),
 				}),
 			Entry("validates a suppressed with type temp; deliveryType not allowed",
 				NewTestSuppressed("basal", "invalid", 2.0, "Weekday", NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"scheduled", "temp"}), "/deliveryType", nil),
+					testData.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"scheduled", "temp"}), "/deliveryType", nil),
 				}),
 			Entry("validates a suppressed with type temp; rate missing",
 				NewTestSuppressed("basal", "temp", nil, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/rate", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/rate", nil),
 				}),
 			Entry("validates a suppressed with type temp; rate out of range (lower)",
 				NewTestSuppressed("basal", "temp", -0.1, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", nil),
 				}),
 			Entry("validates a suppressed with type temp; rate at limit (lower)",
 				NewTestSuppressed("basal", "temp", 0.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
@@ -292,55 +292,55 @@ var _ = Describe("Target", func() {
 			Entry("validates a suppressed with type temp; rate out of range (upper)",
 				NewTestSuppressed("basal", "temp", 100.1, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
 				}),
 			Entry("validates a suppressed with type temp; schedule name exists",
 				NewTestSuppressed("basal", "temp", 2.0, "Weekday", NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueExists(), "/scheduleName", nil),
+					testData.ComposeError(service.ErrorValueExists(), "/scheduleName", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed missing",
 				NewTestSuppressed("basal", "temp", 2.0, nil, nil), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/suppressed", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/suppressed", nil),
 				}),
 			Entry("validates a suppressed with type temp; multiple",
 				NewTestSuppressed("invalid", "temp", 100.1, "Weekday", nil), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
-					testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
-					testing.ComposeError(service.ErrorValueExists(), "/scheduleName", nil),
-					testing.ComposeError(service.ErrorValueNotExists(), "/suppressed", nil),
+					testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/type", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", nil),
+					testData.ComposeError(service.ErrorValueExists(), "/scheduleName", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/suppressed", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed type missing",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed(nil, "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/suppressed/type", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/suppressed/type", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed type not basal",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("invalid", "scheduled", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", nil),
+					testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed deliveryType missing",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", nil, 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/suppressed/deliveryType", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/suppressed/deliveryType", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed deliveryType not allowed",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "temp", 1.0, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueStringNotOneOf("temp", []string{"scheduled"}), "/suppressed/deliveryType", nil),
+					testData.ComposeError(service.ErrorValueStringNotOneOf("temp", []string{"scheduled"}), "/suppressed/deliveryType", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed rate missing",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", nil, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotExists(), "/suppressed/rate", nil),
+					testData.ComposeError(service.ErrorValueNotExists(), "/suppressed/rate", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed rate out of range (lower)",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", -0.1, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/suppressed/rate", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/suppressed/rate", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed rate at limit (lower)",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 0.0, "Weekday", nil)), []string{"scheduled", "temp"},
@@ -351,25 +351,25 @@ var _ = Describe("Target", func() {
 			Entry("validates a suppressed with type temp; suppressed rate out of range (upper)",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 100.1, "Weekday", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed schedule name empty",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "", nil)), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", nil),
+					testData.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed suppressed exists",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", NewTestSuppressed(nil, nil, nil, nil, nil))), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", nil),
+					testData.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", nil),
 				}),
 			Entry("validates a suppressed with type temp; suppressed multiple",
 				NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("invalid", "scheduled", 100.1, "", NewTestSuppressed(nil, nil, nil, nil, nil))), []string{"scheduled", "temp"},
 				[]*service.Error{
-					testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", nil),
-					testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", nil),
-					testing.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", nil),
-					testing.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", nil),
+					testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", nil),
+					testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", nil),
+					testData.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", nil),
+					testData.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", nil),
 				}),
 		)
 	})

--- a/data/types/basal/suspend/suspend_suite_test.go
+++ b/data/types/basal/suspend/suspend_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/basal/suspend")
+	RunSpecs(t, "data/types/basal/suspend")
 }

--- a/data/types/basal/suspend/suspend_test.go
+++ b/data/types/basal/suspend/suspend_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
 	"github.com/tidepool-org/platform/data/types/basal/suspend"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -150,7 +150,7 @@ var _ = Describe("Suspend", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestSuspend(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
 					}),
 				Entry("parses object that has valid duration",
 					&map[string]interface{}{"duration": 3600000},
@@ -160,7 +160,7 @@ var _ = Describe("Suspend", func() {
 					&map[string]interface{}{"duration": "invalid"},
 					NewTestSuspend(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
 					}),
 				Entry("parses object that has valid expected duration",
 					&map[string]interface{}{"expectedDuration": 7200000},
@@ -170,7 +170,7 @@ var _ = Describe("Suspend", func() {
 					&map[string]interface{}{"expectedDuration": "invalid"},
 					NewTestSuspend(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
 					}),
 				Entry("parses object that has valid suppressed",
 					&map[string]interface{}{"suppressed": map[string]interface{}{"type": "basal", "deliveryType": "scheduled", "rate": 1.0, "scheduleName": "Weekday"}},
@@ -180,7 +180,7 @@ var _ = Describe("Suspend", func() {
 					&map[string]interface{}{"suppressed": "invalid"},
 					NewTestSuspend(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
 					}),
 				Entry("parses object that has multiple valid fields",
 					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "duration": 3600000, "expectedDuration": 7200000},
@@ -190,10 +190,10 @@ var _ = Describe("Suspend", func() {
 					&map[string]interface{}{"time": 0, "duration": "invalid", "expectedDuration": "invalid", "suppressed": "invalid"},
 					NewTestSuspend(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
 					}),
 			)
 
@@ -214,17 +214,17 @@ var _ = Describe("Suspend", func() {
 				Entry("missing time",
 					NewTestSuspend(nil, 3600000, 7200000, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing duration",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", nil, 7200000, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("duration out of range (lower)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", -1, 7200000, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 					}),
 				Entry("duration in range (lower)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 0, 7200000, nil),
@@ -235,12 +235,12 @@ var _ = Describe("Suspend", func() {
 				Entry("duration out of range (upper)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 604800001, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 					}),
 				Entry("expected duration out of range (lower)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 3599999, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(3599999, 3600000, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(3599999, 3600000, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("expected duration in range (lower)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 3600000, nil),
@@ -251,36 +251,36 @@ var _ = Describe("Suspend", func() {
 				Entry("expected duration out of range (upper)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 604800001, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 3600000, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 3600000, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration out of range (lower)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", nil, -1, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration in range (lower)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", nil, 0, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration in range (upper)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", nil, 604800000, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration out of range (upper)",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", nil, 604800001, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("multiple",
 					NewTestSuspend(nil, nil, 604800001, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("suppressed scheduled",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 7200000, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil)),
@@ -288,10 +288,10 @@ var _ = Describe("Suspend", func() {
 				Entry("suppressed scheduled multiple",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 7200000, NewTestSuppressed("invalid", "scheduled", 100.1, "", NewTestSuppressed(nil, nil, nil, nil, nil))),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", NewMeta()),
-						testing.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", NewMeta()),
-						testing.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
 					}),
 				Entry("suppressed temp with suppressed scheduled",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 7200000, NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("basal", "scheduled", 1.0, "Weekday", nil))),
@@ -299,10 +299,10 @@ var _ = Describe("Suspend", func() {
 				Entry("suppressed temp with suppressed multiple",
 					NewTestSuspend("2016-09-06T13:45:58-07:00", 3600000, 7200000, NewTestSuppressed("basal", "temp", 2.0, nil, NewTestSuppressed("invalid", "scheduled", 100.1, "", NewTestSuppressed(nil, nil, nil, nil, nil)))),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/suppressed/type", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/suppressed/rate", NewMeta()),
-						testing.ComposeError(service.ErrorValueEmpty(), "/suppressed/suppressed/scheduleName", NewMeta()),
-						testing.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/suppressed/type", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/suppressed/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueEmpty(), "/suppressed/suppressed/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed/suppressed", NewMeta()),
 					}),
 			)
 

--- a/data/types/basal/temporary/temporary_suite_test.go
+++ b/data/types/basal/temporary/temporary_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/basal/temporary")
+	RunSpecs(t, "data/types/basal/temporary")
 }

--- a/data/types/basal/temporary/temporary_test.go
+++ b/data/types/basal/temporary/temporary_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
 	"github.com/tidepool-org/platform/data/types/basal/temporary"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -162,7 +162,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
 					}),
 				Entry("parses object that has valid duration",
 					&map[string]interface{}{"duration": 3600000},
@@ -172,7 +172,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"duration": "invalid"},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
 					}),
 				Entry("parses object that has valid expected duration",
 					&map[string]interface{}{"expectedDuration": 7200000},
@@ -182,7 +182,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"expectedDuration": "invalid"},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
 					}),
 				Entry("parses object that has valid rate",
 					&map[string]interface{}{"rate": 1.0},
@@ -192,7 +192,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"rate": "invalid"},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
 					}),
 				Entry("parses object that has valid percent",
 					&map[string]interface{}{"percent": 0.5},
@@ -202,7 +202,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"percent": "invalid"},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/percent", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/percent", NewMeta()),
 					}),
 				Entry("parses object that has valid suppressed",
 					&map[string]interface{}{"suppressed": map[string]interface{}{"type": "basal", "deliveryType": "scheduled", "rate": 1.0, "scheduleName": "Weekday"}},
@@ -212,7 +212,7 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"suppressed": "invalid"},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
 					}),
 				Entry("parses object that has multiple valid fields",
 					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "duration": 3600000, "expectedDuration": 7200000, "rate": 1.0, "percent": 0.5},
@@ -222,12 +222,12 @@ var _ = Describe("Temporary", func() {
 					&map[string]interface{}{"time": 0, "duration": "invalid", "expectedDuration": "invalid", "rate": "invalid", "percent": "invalid", "suppressed": "invalid"},
 					NewTestTemporary(nil, nil, nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/percent", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/percent", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotObject("invalid"), "/suppressed", NewMeta()),
 					}),
 			)
 
@@ -248,17 +248,17 @@ var _ = Describe("Temporary", func() {
 				Entry("missing time",
 					NewTestTemporary(nil, 3600000, 7200000, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing duration",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", nil, 7200000, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("duration out of range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", -1, 7200000, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 					}),
 				Entry("duration in range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 0, 7200000, 1.0, 0.5, nil),
@@ -269,12 +269,12 @@ var _ = Describe("Temporary", func() {
 				Entry("duration out of range (upper)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 604800001, nil, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 					}),
 				Entry("expected duration out of range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 3599999, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(3599999, 3600000, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(3599999, 3600000, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("expected duration in range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 3600000, 1.0, 0.5, nil),
@@ -285,39 +285,39 @@ var _ = Describe("Temporary", func() {
 				Entry("expected duration out of range (upper)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 604800001, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 3600000, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 3600000, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration out of range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", nil, -1, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration in range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", nil, 0, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration in range (upper)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", nil, 604800000, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 					}),
 				Entry("missing duration; expected duration out of range (upper)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", nil, 604800001, 1.0, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 					}),
 				Entry("missing rate",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, nil, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/rate", NewMeta()),
 					}),
 				Entry("rate out of range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, -0.1, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", NewMeta()),
 					}),
 				Entry("rate in range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 0.0, 0.5, nil),
@@ -328,12 +328,12 @@ var _ = Describe("Temporary", func() {
 				Entry("rate out of range (upper)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 100.1, 0.5, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
 					}),
 				Entry("percent out of range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 1.0, -0.1, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 10.0), "/percent", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 10.0), "/percent", NewMeta()),
 					}),
 				Entry("percent in range (lower)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 1.0, 0.0, nil),
@@ -344,29 +344,29 @@ var _ = Describe("Temporary", func() {
 				Entry("percent out of range (upper)",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 1.0, 10.1, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/percent", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/percent", NewMeta()),
 					}),
 				Entry("multiple",
 					NewTestTemporary(nil, nil, 604800001, 100.1, 10.1, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/percent", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/percent", NewMeta()),
 					}),
 				Entry("suppressed not scheduled",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 1.0, 0.5, NewTestSuppressed("basal", "temp", 1.0, "Weekday", nil)),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("temp", []string{"scheduled"}), "/suppressed/deliveryType", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("temp", []string{"scheduled"}), "/suppressed/deliveryType", NewMeta()),
 					}),
 				Entry("suppressed multiple",
 					NewTestTemporary("2016-09-06T13:45:58-07:00", 3600000, 7200000, 1.0, 0.5, NewTestSuppressed("invalid", "scheduled", 100.1, "", NewTestSuppressed(nil, nil, nil, nil, nil))),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", NewMeta()),
-						testing.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", NewMeta()),
-						testing.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotEqualTo("invalid", "basal"), "/suppressed/type", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/suppressed/rate", NewMeta()),
+						testData.ComposeError(service.ErrorValueEmpty(), "/suppressed/scheduleName", NewMeta()),
+						testData.ComposeError(service.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
 					}),
 			)
 

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -54,6 +54,7 @@ func (b *Base) Init() {
 	b.Active = false
 	b.CreatedTime = ""
 	b.CreatedUserID = ""
+	b.Deduplicator = nil
 	b.DeletedTime = ""
 	b.DeletedUserID = ""
 	b.GroupID = ""

--- a/data/types/blood/blood_suite_test.go
+++ b/data/types/blood/blood_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood")
+	RunSpecs(t, "data/types/blood")
 }

--- a/data/types/blood/blood_test.go
+++ b/data/types/blood/blood_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/blood"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -96,7 +96,7 @@ var _ = Describe("Blood", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestBlood(nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
 					}),
 				Entry("parses object that has valid units",
 					&map[string]interface{}{"units": "mmol/L"},
@@ -106,7 +106,7 @@ var _ = Describe("Blood", func() {
 					&map[string]interface{}{"units": 0},
 					NewTestBlood(nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
 					}),
 				Entry("parses object that has valid value",
 					&map[string]interface{}{"value": 1.0},
@@ -116,7 +116,7 @@ var _ = Describe("Blood", func() {
 					&map[string]interface{}{"value": "invalid"},
 					NewTestBlood(nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
 					}),
 				Entry("parses object that has multiple valid fields",
 					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "units": "mmol/L", "value": 1.0},
@@ -126,9 +126,9 @@ var _ = Describe("Blood", func() {
 					&map[string]interface{}{"time": 0, "units": 0, "value": "invalid"},
 					NewTestBlood(nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
 					}),
 			)
 
@@ -149,24 +149,24 @@ var _ = Describe("Blood", func() {
 				Entry("missing time",
 					NewTestBlood(nil, "mmol/L", 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing units",
 					NewTestBlood("2016-09-06T13:45:58-07:00", nil, 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
 					}),
 				Entry("missing value",
 					NewTestBlood("2016-09-06T13:45:58-07:00", "mmol/L", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 				Entry("multiple",
 					NewTestBlood(nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 			)
 

--- a/data/types/blood/glucose/continuous/continuous_suite_test.go
+++ b/data/types/blood/glucose/continuous/continuous_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood/glucose/continuous")
+	RunSpecs(t, "data/types/blood/glucose/continuous")
 }

--- a/data/types/blood/glucose/glucose_suite_test.go
+++ b/data/types/blood/glucose/glucose_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood/glucose")
+	RunSpecs(t, "data/types/blood/glucose")
 }

--- a/data/types/blood/glucose/glucose_test.go
+++ b/data/types/blood/glucose/glucose_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/normalizer"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/blood/glucose"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -71,17 +71,17 @@ var _ = Describe("Glucose", func() {
 				Entry("missing time",
 					NewTestGlucose(nil, "mmol/L", 10.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing units",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", nil, 10.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
 					}),
 				Entry("unknown units",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", 10.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 					}),
 				Entry("mmol/L units",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 10.0),
@@ -98,22 +98,22 @@ var _ = Describe("Glucose", func() {
 				Entry("missing value",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 				Entry("unknown units; value in range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", -math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 					}),
 				Entry("unknown units; value in range (upper)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "unknown", math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 					}),
 				Entry("mmol/L units; value out of range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", -0.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/L units; value in range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 0.0),
@@ -124,12 +124,12 @@ var _ = Describe("Glucose", func() {
 				Entry("mmol/L units; value out of range (upper)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/L", 55.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/l units; value out of range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", -0.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/l units; value in range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 0.0),
@@ -140,12 +140,12 @@ var _ = Describe("Glucose", func() {
 				Entry("mmol/l units; value out of range (upper)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mmol/l", 55.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dL units; value out of range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", -0.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dL units; value in range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 0.0),
@@ -156,12 +156,12 @@ var _ = Describe("Glucose", func() {
 				Entry("mg/dL units; value out of range (upper)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dL", 1000.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dl units; value out of range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", -0.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dl units; value in range (lower)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 0.0),
@@ -172,14 +172,14 @@ var _ = Describe("Glucose", func() {
 				Entry("mg/dl units; value out of range (upper)",
 					NewTestGlucose("2016-09-06T13:45:58-07:00", "mg/dl", 1000.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("multiple",
 					NewTestGlucose(nil, "unknown", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 			)
 

--- a/data/types/blood/glucose/selfmonitored/selfmonitored_suite_test.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood/glucose/selfmonitored")
+	RunSpecs(t, "data/types/blood/glucose/selfmonitored")
 }

--- a/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/blood/glucose/selfmonitored"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -126,7 +126,7 @@ var _ = Describe("SelfMonitored", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestSelfMonitored(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
 					}),
 				Entry("parses object that has valid units",
 					&map[string]interface{}{"units": "mmol/L"},
@@ -136,7 +136,7 @@ var _ = Describe("SelfMonitored", func() {
 					&map[string]interface{}{"units": 0},
 					NewTestSelfMonitored(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
 					}),
 				Entry("parses object that has valid value",
 					&map[string]interface{}{"value": 10.0},
@@ -146,7 +146,7 @@ var _ = Describe("SelfMonitored", func() {
 					&map[string]interface{}{"value": "invalid"},
 					NewTestSelfMonitored(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
 					}),
 				Entry("parses object that has valid sub type",
 					&map[string]interface{}{"subType": "linked"},
@@ -156,7 +156,7 @@ var _ = Describe("SelfMonitored", func() {
 					&map[string]interface{}{"subType": 0},
 					NewTestSelfMonitored(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/subType", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/subType", NewMeta()),
 					}),
 				Entry("parses object that has multiple valid fields",
 					&map[string]interface{}{"time": "2016-09-06T13:45:58-07:00", "units": "mmol/L", "value": 10.0, "subType": "linked"},
@@ -166,10 +166,10 @@ var _ = Describe("SelfMonitored", func() {
 					&map[string]interface{}{"time": 0, "units": 0, "value": "invalid", "subType": 0},
 					NewTestSelfMonitored(nil, nil, nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
-						testing.ComposeError(service.ErrorTypeNotString(0), "/subType", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/subType", NewMeta()),
 					}),
 			)
 
@@ -190,17 +190,17 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("missing time",
 					NewTestSelfMonitored(nil, "mmol/L", 10.0, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing units",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", nil, 10.0, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
 					}),
 				Entry("unknown units",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "unknown", 10.0, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 					}),
 				Entry("mmol/L units",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "linked"),
@@ -217,22 +217,22 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("missing value",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", nil, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 				Entry("unknown units; value in range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "unknown", -math.MaxFloat64, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 					}),
 				Entry("unknown units; value in range (upper)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "unknown", math.MaxFloat64, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 					}),
 				Entry("mmol/L units; value out of range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", -0.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/L units; value in range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 0.0, "linked"),
@@ -243,12 +243,12 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("mmol/L units; value out of range (upper)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 55.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/l units; value out of range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", -0.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/l units; value in range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", 0.0, "linked"),
@@ -259,12 +259,12 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("mmol/l units; value out of range (upper)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/l", 55.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dL units; value out of range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", -0.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dL units; value in range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", 0.0, "linked"),
@@ -275,12 +275,12 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("mg/dL units; value out of range (upper)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dL", 1000.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dl units; value out of range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", -0.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dl units; value in range (lower)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", 0.0, "linked"),
@@ -291,12 +291,12 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("mg/dl units; value out of range (upper)",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mg/dl", 1000.1, "linked"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
 					}),
 				Entry("unknown sub type",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "unknown"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"linked", "manual"}), "/subType", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"linked", "manual"}), "/subType", NewMeta()),
 					}),
 				Entry("linked sub type",
 					NewTestSelfMonitored("2016-09-06T13:45:58-07:00", "mmol/L", 10.0, "linked"),
@@ -307,10 +307,10 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("multiple",
 					NewTestSelfMonitored(nil, "unknown", nil, "unknown"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"linked", "manual"}), "/subType", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"linked", "manual"}), "/subType", NewMeta()),
 					}),
 			)
 		})

--- a/data/types/blood/ketone/ketone_suite_test.go
+++ b/data/types/blood/ketone/ketone_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/blood/ketone")
+	RunSpecs(t, "data/types/blood/ketone")
 }

--- a/data/types/blood/ketone/ketone_test.go
+++ b/data/types/blood/ketone/ketone_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/normalizer"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/blood/ketone"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -105,17 +105,17 @@ var _ = Describe("Ketone", func() {
 				Entry("missing time",
 					NewTestKetone(nil, "mmol/L", 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
 					}),
 				Entry("missing units",
 					NewTestKetone("2016-09-06T13:45:58-07:00", nil, 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/units", NewMeta()),
 					}),
 				Entry("unknown units",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "unknown", 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("mmol/L units",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/L", 1.0),
@@ -126,32 +126,32 @@ var _ = Describe("Ketone", func() {
 				Entry("mg/dL units",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mg/dL", 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("mg/dL", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("mg/dL", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("mg/dl units",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mg/dl", 1.0),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("mg/dl", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("mg/dl", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("missing value",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/L", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 				Entry("unknown units; value in range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "unknown", -math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("unknown units; value in range (upper)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "unknown", math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("mmol/L units; value out of range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/L", -0.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 10.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 10.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/L units; value in range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/L", 0.0),
@@ -162,12 +162,12 @@ var _ = Describe("Ketone", func() {
 				Entry("mmol/L units; value out of range (upper)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/L", 10.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/l units; value out of range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/l", -0.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 10.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 10.0), "/value", NewMeta()),
 					}),
 				Entry("mmol/l units; value in range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/l", 0.0),
@@ -178,34 +178,34 @@ var _ = Describe("Ketone", func() {
 				Entry("mmol/l units; value out of range (upper)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mmol/l", 10.1),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotInRange(10.1, 0.0, 10.0), "/value", NewMeta()),
 					}),
 				Entry("mg/dL units; value in range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mg/dL", -math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("mg/dL", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("mg/dL", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("mg/dL units; value in range (upper)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mg/dL", math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("mg/dL", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("mg/dL", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("mg/dl units; value in range (lower)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mg/dl", -math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("mg/dl", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("mg/dl", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("mg/dl units; value in range (upper)",
 					NewTestKetone("2016-09-06T13:45:58-07:00", "mg/dl", math.MaxFloat64),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueStringNotOneOf("mg/dl", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("mg/dl", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
 					}),
 				Entry("multiple",
 					NewTestKetone(nil, "unknown", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
-						testing.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
-						testing.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta()),
+						testData.ComposeError(service.ErrorValueStringNotOneOf("unknown", []string{"mmol/L", "mmol/l"}), "/units", NewMeta()),
+						testData.ComposeError(service.ErrorValueNotExists(), "/value", NewMeta()),
 					}),
 			)
 

--- a/data/types/bolus/bolus_suite_test.go
+++ b/data/types/bolus/bolus_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/bolus")
+	RunSpecs(t, "data/types/bolus")
 }

--- a/data/types/bolus/bolus_test.go
+++ b/data/types/bolus/bolus_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/bolus"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -110,7 +110,7 @@ var _ = Describe("Bolus", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestBolus(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 				Entry("does not parse sub type",
 					&map[string]interface{}{"subType": "dual/square"},
@@ -124,7 +124,7 @@ var _ = Describe("Bolus", func() {
 					&map[string]interface{}{"time": 0, "subType": 0},
 					NewTestBolus(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 			)
 
@@ -145,12 +145,12 @@ var _ = Describe("Bolus", func() {
 				Entry("missing time",
 					NewTestBolus(nil, "dual/square"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("dual/square")),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("dual/square")),
 					}),
 				Entry("missing sub type",
 					NewTestBolus("2016-09-06T13:45:58-07:00", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
+						testData.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
 					}),
 				Entry("specified sub type",
 					NewTestBolus("2016-09-06T13:45:58-07:00", "specified"),
@@ -158,8 +158,8 @@ var _ = Describe("Bolus", func() {
 				Entry("multiple",
 					NewTestBolus(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
-						testing.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
 					}),
 			)
 

--- a/data/types/bolus/combination/combination_suite_test.go
+++ b/data/types/bolus/combination/combination_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/bolus/combination")
+	RunSpecs(t, "data/types/bolus/combination")
 }

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/bolus"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "bolus"
 	rawObject["subType"] = "dual/square"
 	rawObject["normal"] = 7.6
@@ -45,28 +45,28 @@ func NewMeta() interface{} {
 
 var _ = Describe("Combination", func() {
 	Context("normal", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("does not exist", NewRawObject(), "normal", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta())},
 			),
 			Entry("is not a number", NewRawObject(), "normal", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/normal", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/normal", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit", NewRawObject(), "normal", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewRawObject(), "normal", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta())},
 			),
 			Entry("is zero without expectedNormal", NewRawObject(), "normal", 0.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/expectedNormal", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching lower limit", NewRawObject(), "normal", 0.01),
 			Entry("is within lower and upper limit", NewRawObject(), "normal", 14.5),
 			Entry("is at upper limit", NewRawObject(), "normal", 100.0),
@@ -75,19 +75,19 @@ var _ = Describe("Combination", func() {
 	})
 
 	Context("expectedNormal", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is not a number", NewExpectedNormalRawObject(), "expectedNormal", "not-a-number",
-				[]*service.Error{testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedNormal", NewMeta())},
 			),
 			Entry("is less than normal", NewExpectedNormalRawObject(), "expectedNormal", 7.5,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(7.5, 7.6, 100.0), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(7.5, 7.6, 100.0), "/expectedNormal", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewExpectedNormalRawObject(), "expectedNormal", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 7.6, 100.0), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 7.6, 100.0), "/expectedNormal", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching normal", NewExpectedNormalRawObject(), "expectedNormal", 9.71),
 			Entry("is at upper limit", NewExpectedNormalRawObject(), "expectedNormal", 100.0),
 			Entry("is without decimal", NewExpectedNormalRawObject(), "expectedNormal", 14),
@@ -95,40 +95,40 @@ var _ = Describe("Combination", func() {
 	})
 
 	Context("extended", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("does not exist", NewRawObject(), "extended", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta())},
 			),
 			Entry("is not a number", NewRawObject(), "extended", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/extended", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/extended", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit", NewRawObject(), "extended", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/extended", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewRawObject(), "extended", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/extended", NewMeta())},
 			),
 			Entry("is zero without expectedExtended", NewRawObject(), "extended", 0.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta())},
 			),
 			Entry("does not exist with expected normal", NewExpectedNormalRawObject(), "extended", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta())},
 			),
 			Entry("is not a number with expected normal", NewExpectedNormalRawObject(), "extended", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/extended", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/extended", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta()),
 				},
 			),
 			Entry("is non-zero with expected normal", NewExpectedNormalRawObject(), "extended", 1.2,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotEqualTo(1.2, 0.0), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotEqualTo(1.2, 0.0), "/extended", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching lower limit", NewRawObject(), "extended", 0.01),
 			Entry("is within lower and upper limit", NewRawObject(), "extended", 14.5),
 			Entry("is at upper limit", NewRawObject(), "extended", 100.0),
@@ -137,37 +137,37 @@ var _ = Describe("Combination", func() {
 	})
 
 	Context("expectedExtended", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is not a number", NewExpectedExtendedRawObject(), "expectedExtended", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedExtended", NewMeta()),
-					testing.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedExtended", NewMeta()),
+					testData.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta()),
 				},
 			),
 			Entry("is less than extended", NewExpectedExtendedRawObject(), "expectedExtended", 9.6,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(9.6, 9.7, 100.0), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(9.6, 9.7, 100.0), "/expectedExtended", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewExpectedExtendedRawObject(), "expectedExtended", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 9.7, 100.0), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 9.7, 100.0), "/expectedExtended", NewMeta())},
 			),
 			Entry("does not exist with expected normal", NewExpectedNormalRawObject(), "expectedExtended", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta())},
 			),
 			Entry("is not a number with expected normal", NewExpectedNormalRawObject(), "expectedExtended", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedExtended", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedExtended", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit with expected normal", NewExpectedNormalRawObject(), "expectedExtended", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/expectedExtended", NewMeta())},
 			),
 			Entry("is greater than upper limit with expected normal", NewExpectedNormalRawObject(), "expectedExtended", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedExtended", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching extended", NewExpectedExtendedRawObject(), "expectedExtended", 9.71),
 			Entry("is at upper limit", NewExpectedExtendedRawObject(), "expectedExtended", 100.0),
 			Entry("is without decimal", NewExpectedExtendedRawObject(), "expectedExtended", 14),
@@ -175,37 +175,37 @@ var _ = Describe("Combination", func() {
 	})
 
 	Context("duration", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("does not exist", NewRawObject(), "duration", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta())},
 			),
 			Entry("is not a number", NewRawObject(), "duration", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/duration", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/duration", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit", NewRawObject(), "duration", -1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/duration", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewRawObject(), "duration", 86400001,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/duration", NewMeta())},
 			),
 			Entry("does not exist", NewExpectedNormalRawObject(), "duration", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta())},
 			),
 			Entry("is not a number", NewExpectedNormalRawObject(), "duration", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/duration", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/duration", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 				},
 			),
 			Entry("is non-zero with expected normal", NewExpectedNormalRawObject(), "duration", 1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotEqualTo(1, 0), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotEqualTo(1, 0), "/duration", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is at lower limit", NewRawObject(), "duration", 0),
 			Entry("is within lower and upper limit", NewRawObject(), "duration", 14400000),
 			Entry("is at upper limit", NewRawObject(), "duration", 86400000),
@@ -213,40 +213,40 @@ var _ = Describe("Combination", func() {
 	})
 
 	Context("expectedDuration", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("exists when expectedExtended does not exist", NewExpectedExtendedRawObject(), "expectedExtended", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta())},
 			),
 			Entry("is not a number", NewExpectedExtendedRawObject(), "expectedDuration", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/expectedDuration", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta()),
 				},
 			),
 			Entry("is less than duration", NewExpectedExtendedRawObject(), "expectedDuration", 12599999,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(12599999, 12600000, 86400000), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(12599999, 12600000, 86400000), "/expectedDuration", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewExpectedExtendedRawObject(), "expectedDuration", 86400001,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 12600000, 86400000), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 12600000, 86400000), "/expectedDuration", NewMeta())},
 			),
 			Entry("does not exist with expected normal", NewExpectedNormalRawObject(), "expectedDuration", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta())},
 			),
 			Entry("is not a number with expected normal", NewExpectedNormalRawObject(), "expectedDuration", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/expectedDuration", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit with expected normal", NewExpectedNormalRawObject(), "expectedDuration", -1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/expectedDuration", NewMeta())},
 			),
 			Entry("is greater than upper limit with expected normal", NewExpectedNormalRawObject(), "expectedDuration", 86400001,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/expectedDuration", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching duration", NewExpectedExtendedRawObject(), "expectedDuration", 12600001),
 			Entry("is at upper limit", NewExpectedExtendedRawObject(), "expectedDuration", 86400000),
 		)

--- a/data/types/bolus/extended/extended_suite_test.go
+++ b/data/types/bolus/extended/extended_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/bolus/extended")
+	RunSpecs(t, "data/types/bolus/extended")
 }

--- a/data/types/bolus/extended/extended_test.go
+++ b/data/types/bolus/extended/extended_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/bolus"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "bolus"
 	rawObject["subType"] = "square"
 	rawObject["extended"] = 7.6
@@ -34,28 +34,28 @@ func NewMeta() interface{} {
 
 var _ = Describe("Extended", func() {
 	Context("extended", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("does not exist", NewRawObject(), "extended", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta())},
 			),
 			Entry("is not a number", NewRawObject(), "extended", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/extended", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/extended", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/extended", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit", NewRawObject(), "extended", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/extended", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewRawObject(), "extended", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/extended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/extended", NewMeta())},
 			),
 			Entry("is zero without expectedExtended", NewRawObject(), "extended", 0.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/expectedExtended", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching lower limit", NewRawObject(), "extended", 0.01),
 			Entry("is within lower and upper limit", NewRawObject(), "extended", 14.5),
 			Entry("is at upper limit", NewRawObject(), "extended", 100.0),
@@ -64,22 +64,22 @@ var _ = Describe("Extended", func() {
 	})
 
 	Context("expectedExtended", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is not a number", NewExpectedRawObject(), "expectedExtended", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedExtended", NewMeta()),
-					testing.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedExtended", NewMeta()),
+					testData.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta()),
 				},
 			),
 			Entry("is less than extended", NewExpectedRawObject(), "expectedExtended", 7.5,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(7.5, 7.6, 100.0), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(7.5, 7.6, 100.0), "/expectedExtended", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewExpectedRawObject(), "expectedExtended", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 7.6, 100.0), "/expectedExtended", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 7.6, 100.0), "/expectedExtended", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching extended", NewExpectedRawObject(), "expectedExtended", 7.61),
 			Entry("is at upper limit", NewExpectedRawObject(), "expectedExtended", 100.0),
 			Entry("is without decimal", NewExpectedRawObject(), "expectedExtended", 14),
@@ -87,25 +87,25 @@ var _ = Describe("Extended", func() {
 	})
 
 	Context("duration", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("does not exist", NewRawObject(), "duration", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta())},
 			),
 			Entry("is not a number", NewRawObject(), "duration", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/duration", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/duration", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/duration", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit", NewRawObject(), "duration", -1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/duration", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewRawObject(), "duration", 86400001,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/duration", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is at lower limit", NewRawObject(), "duration", 0),
 			Entry("is within lower and upper limit", NewRawObject(), "duration", 14400000),
 			Entry("is at upper limit", NewRawObject(), "duration", 86400000),
@@ -113,25 +113,25 @@ var _ = Describe("Extended", func() {
 	})
 
 	Context("expectedDuration", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("exists when expectedExtended does not exist", NewExpectedRawObject(), "expectedExtended", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueExists(), "/expectedDuration", NewMeta())},
 			),
 			Entry("is not a number", NewExpectedRawObject(), "expectedDuration", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/expectedDuration", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotInteger("not-a-number"), "/expectedDuration", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/expectedDuration", NewMeta()),
 				},
 			),
 			Entry("is less than duration", NewExpectedRawObject(), "expectedDuration", 12599999,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(12599999, 12600000, 86400000), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(12599999, 12600000, 86400000), "/expectedDuration", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewExpectedRawObject(), "expectedDuration", 86400001,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 12600000, 86400000), "/expectedDuration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 12600000, 86400000), "/expectedDuration", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching duration", NewExpectedRawObject(), "expectedDuration", 12600001),
 			Entry("is at upper limit", NewExpectedRawObject(), "expectedDuration", 86400000),
 		)

--- a/data/types/bolus/normal/normal_suite_test.go
+++ b/data/types/bolus/normal/normal_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/bolus/normal")
+	RunSpecs(t, "data/types/bolus/normal")
 }

--- a/data/types/bolus/normal/normal_test.go
+++ b/data/types/bolus/normal/normal_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/bolus"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "bolus"
 	rawObject["subType"] = "normal"
 	rawObject["normal"] = 7.6
@@ -32,28 +32,28 @@ func NewMeta() interface{} {
 
 var _ = Describe("Normal", func() {
 	Context("normal", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("does not exist", NewRawObject(), "normal", nil,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta())},
 			),
 			Entry("is not a number", NewRawObject(), "normal", "not-a-number",
 				[]*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/normal", NewMeta()),
-					testing.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta()),
+					testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/normal", NewMeta()),
+					testData.ComposeError(service.ErrorValueNotExists(), "/normal", NewMeta()),
 				},
 			),
 			Entry("is less than lower limit", NewRawObject(), "normal", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewRawObject(), "normal", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta())},
 			),
 			Entry("is zero without expectedNormal", NewRawObject(), "normal", 0.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/expectedNormal", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching lower limit", NewRawObject(), "normal", 0.01),
 			Entry("is within lower and upper limit", NewRawObject(), "normal", 14.5),
 			Entry("is at upper limit", NewRawObject(), "normal", 100.0),
@@ -62,19 +62,19 @@ var _ = Describe("Normal", func() {
 	})
 
 	Context("expectedNormal", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is not a number", NewExpectedRawObject(), "expectedNormal", "not-a-number",
-				[]*service.Error{testing.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorTypeNotFloat("not-a-number"), "/expectedNormal", NewMeta())},
 			),
 			Entry("is less than normal", NewExpectedRawObject(), "expectedNormal", 7.5,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(7.5, 7.6, 100.0), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(7.5, 7.6, 100.0), "/expectedNormal", NewMeta())},
 			),
 			Entry("is greater than upper limit", NewExpectedRawObject(), "expectedNormal", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 7.6, 100.0), "/expectedNormal", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 7.6, 100.0), "/expectedNormal", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is approaching normal", NewExpectedRawObject(), "expectedNormal", 7.61),
 			Entry("is at upper limit", NewExpectedRawObject(), "expectedNormal", 100.0),
 			Entry("is without decimal", NewExpectedRawObject(), "expectedNormal", 14),

--- a/data/types/calculator/calculator_suite_test.go
+++ b/data/types/calculator/calculator_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/calculator")
+	RunSpecs(t, "data/types/calculator")
 }

--- a/data/types/calculator/calculator_test.go
+++ b/data/types/calculator/calculator_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/normalizer"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/calculator"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObjectWithMmolL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "wizard"
 	rawObject["bgInput"] = 12.0
 	rawObject["carbInput"] = 120.0
@@ -40,7 +40,7 @@ func NewRawObjectWithMmoll() map[string]interface{} {
 }
 
 func NewRawObjectWithMgdL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "wizard"
 	rawObject["bgInput"] = 100
 	rawObject["carbInput"] = 120.0
@@ -70,7 +70,7 @@ func NewMeta() interface{} {
 }
 
 func NewEmbeddedBolus(datumType interface{}, subType interface{}, normal, extended float64, duration int) map[string]interface{} {
-	var rawBolus = testing.RawBaseObject()
+	var rawBolus = testData.RawBaseObject()
 
 	if datumType != nil {
 		rawBolus["type"] = datumType
@@ -93,46 +93,46 @@ func NewEmbeddedBolus(datumType interface{}, subType interface{}, normal, extend
 
 var _ = Describe("Calculator", func() {
 	Context("insulinOnBoard", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is negative", NewRawObjectWithMgdl(), "insulinOnBoard", -1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 250), "/insulinOnBoard", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 250), "/insulinOnBoard", NewMeta())},
 			),
 			Entry("is greater than 250", NewRawObjectWithMgdl(), "insulinOnBoard", 251,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(251, 0, 250), "/insulinOnBoard", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(251, 0, 250), "/insulinOnBoard", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is within bounds", NewRawObjectWithMgdl(), "insulinOnBoard", 99),
 		)
 	})
 
 	Context("insulinCarbRatio", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is negative", NewRawObjectWithMgdl(), "insulinCarbRatio", -1.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1.0, 0.0, 250.0), "/insulinCarbRatio", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1.0, 0.0, 250.0), "/insulinCarbRatio", NewMeta())},
 			),
 			Entry("is greater than 250.0", NewRawObjectWithMgdl(), "insulinCarbRatio", 251.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(251.0, 0.0, 250.0), "/insulinCarbRatio", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(251.0, 0.0, 250.0), "/insulinCarbRatio", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is within bounds", NewRawObjectWithMgdl(), "insulinCarbRatio", 99.0),
 		)
 	})
 
 	Context("units", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObjectWithMgdl(), "units", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
 			),
 			Entry("is not one of the predefined values", NewRawObjectWithMgdl(), "units", "wrong",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is mmol/L", NewRawObjectWithMmolL(), "units", "mmol/L"),
 			Entry("is mmol/l", NewRawObjectWithMmoll(), "units", "mmol/l"),
 			Entry("is mg/dL", NewRawObjectWithMgdL(), "units", "mg/dL"),
@@ -141,16 +141,16 @@ var _ = Describe("Calculator", func() {
 	})
 
 	Context("bgInput", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObjectWithMgdl(), "bgInput", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgInput", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgInput", NewMeta())},
 			),
 			Entry("is greater than 1000", NewRawObjectWithMgdl(), "bgInput", 1000.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgInput", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgInput", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObjectWithMgdl(), "bgInput", 0.0),
 			Entry("is above 0", NewRawObjectWithMgdl(), "bgInput", 0.1),
 			Entry("is below max", NewRawObjectWithMgdl(), "bgInput", glucose.MgdLUpperLimit),
@@ -159,16 +159,16 @@ var _ = Describe("Calculator", func() {
 	})
 
 	Context("insulinSensitivity", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObjectWithMgdL(), "insulinSensitivity", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity", NewMeta())},
 			),
 			Entry("is greater than 1000", NewRawObjectWithMgdL(), "insulinSensitivity", 1000.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObjectWithMgdL(), "insulinSensitivity", 0.0),
 			Entry("is above 0", NewRawObjectWithMgdL(), "insulinSensitivity", 0.1),
 			Entry("is below max mg/dl", NewRawObjectWithMgdL(), "insulinSensitivity", glucose.MgdLUpperLimit),
@@ -177,16 +177,16 @@ var _ = Describe("Calculator", func() {
 	})
 
 	Context("carbInput", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObjectWithMgdl(), "carbInput", -1.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1.0, 0.0, 1000.0), "/carbInput", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1.0, 0.0, 1000.0), "/carbInput", NewMeta())},
 			),
 			Entry("is greater than 1000", NewRawObjectWithMgdl(), "carbInput", 1001.0,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1001.0, 0.0, 1000.0), "/carbInput", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1001.0, 0.0, 1000.0), "/carbInput", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObjectWithMgdl(), "carbInput", 0.0),
 			Entry("is in range", NewRawObjectWithMgdl(), "carbInput", 250.0),
 			Entry("is below 1000", NewRawObjectWithMgdl(), "carbInput", 999.0),
@@ -194,22 +194,22 @@ var _ = Describe("Calculator", func() {
 	})
 
 	Context("bgTarget", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("has range less than 0", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": 100, "range": -1},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 100), "/bgTarget/range", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 100), "/bgTarget/range", NewMeta())},
 			),
 			Entry("has range greater than target", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": 100, "range": 101},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(101, 0, 100), "/bgTarget/range", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(101, 0, 100), "/bgTarget/range", NewMeta())},
 			),
 			Entry("has target less than 0", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": -0.1, "range": 10},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/target", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/target", NewMeta())},
 			),
 			Entry("has target greater than 1000", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": 1000.1, "range": 10},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/target", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/target", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("has range 0", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": 100, "range": 0}),
 			Entry("has target 0", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": 0.0, "range": 0}),
 			Entry("has range less or equal to target", NewRawObjectWithMgdL(), "bgTarget", map[string]interface{}{"target": 100, "range": 100}),
@@ -218,28 +218,28 @@ var _ = Describe("Calculator", func() {
 	})
 
 	Context("recommended", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("has net less than -100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": -101, "correction": -50, "carb": 50},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-101, -100, 100), "/recommended/net", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-101, -100, 100), "/recommended/net", NewMeta())},
 			),
 			Entry("has net greater than 100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 101, "correction": -50, "carb": 50},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(101, -100, 100), "/recommended/net", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(101, -100, 100), "/recommended/net", NewMeta())},
 			),
 			Entry("has correction less than -100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 50, "correction": -101, "carb": 50},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-101, -100, 100), "/recommended/correction", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-101, -100, 100), "/recommended/correction", NewMeta())},
 			),
 			Entry("has correction greater than 100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 50, "correction": 101, "carb": 50},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(101, -100, 100), "/recommended/correction", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(101, -100, 100), "/recommended/correction", NewMeta())},
 			),
 			Entry("has carb less than 0", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 50, "correction": -50, "carb": -1},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 100), "/recommended/carb", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 100), "/recommended/carb", NewMeta())},
 			),
 			Entry("has carb greater than 100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 50, "correction": -50, "carb": 101},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(101, 0, 100), "/recommended/carb", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(101, 0, 100), "/recommended/carb", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("has net more or equal -100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": -100, "correction": -50, "carb": 50}),
 			Entry("has net less or equal 100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 100, "correction": -50, "carb": 50}),
 			Entry("has correction more or equal -100", NewRawObjectWithMgdl(), "recommended", map[string]interface{}{"net": 10, "correction": -100, "carb": 50}),
@@ -250,21 +250,21 @@ var _ = Describe("Calculator", func() {
 	})
 
 	Context("bolus", func() {
-		DescribeTable("invalid when type", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when type", testData.ExpectFieldNotValid,
 			Entry("is missing", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus(nil, "normal", 52.1, 0.0, 0),
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/bolus/type", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/bolus/type", NewMeta())},
 			),
 			Entry("is not valid", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("invalid", "normal", 52.1, 0.0, 0),
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"bolus"}), "/bolus/type", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"bolus"}), "/bolus/type", NewMeta())},
 			),
 		)
 
-		DescribeTable("invalid when subType", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when subType", testData.ExpectFieldNotValid,
 			Entry("is missing", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", nil, 0.0, 52.1, 0),
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/bolus/subType", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/bolus/subType", NewMeta())},
 			),
 			Entry("is not valid", NewRawObjectWithMgdl(), "bolus", NewEmbeddedBolus("bolus", "invalid", 0.0, 52.1, 0),
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"dual/square", "normal", "square"}), "/bolus/subType", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"dual/square", "normal", "square"}), "/bolus/subType", NewMeta())},
 			),
 		)
 	})
@@ -324,7 +324,7 @@ var _ = Describe("Calculator", func() {
 
 		Context("bolus", func() {
 			DescribeTable("valid when embedded", func(rawObject map[string]interface{}, field string, val interface{}) {
-				calculatorDatum := testing.ParseAndNormalize(rawObject, field, val)
+				calculatorDatum := testData.ParseAndNormalize(rawObject, field, val)
 				calculatorBolus := calculatorDatum.(*calculator.Calculator)
 				Expect(calculatorBolus.BolusID).To(Not(BeNil()))
 			},

--- a/data/types/device/alarm/alarm_suite_test.go
+++ b/data/types/device/alarm/alarm_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device/alarm")
+	RunSpecs(t, "data/types/device/alarm")
 }

--- a/data/types/device/alarm/alarm_test.go
+++ b/data/types/device/alarm/alarm_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "alarm"
 	rawObject["alarmType"] = "other"
@@ -26,7 +26,7 @@ func NewMeta() interface{} {
 }
 
 func NewEmbeddedStatus(datumType interface{}, subType interface{}) map[string]interface{} {
-	var rawStatus = testing.RawBaseObject()
+	var rawStatus = testData.RawBaseObject()
 
 	if datumType != nil {
 		rawStatus["type"] = datumType
@@ -43,16 +43,16 @@ func NewEmbeddedStatus(datumType interface{}, subType interface{}) map[string]in
 
 var _ = Describe("Alarm", func() {
 	Context("alarmType", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "alarmType", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"low_insulin", "no_insulin", "low_power", "no_power", "occlusion", "no_delivery", "auto_off", "over_limit", "other"}), "/alarmType", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"low_insulin", "no_insulin", "low_power", "no_power", "occlusion", "no_delivery", "auto_off", "over_limit", "other"}), "/alarmType", NewMeta())},
 			),
 			Entry("is not one of the predefined types", NewRawObject(), "alarmType", "bad-robot",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("bad-robot", []string{"low_insulin", "no_insulin", "low_power", "no_power", "occlusion", "no_delivery", "auto_off", "over_limit", "other"}), "/alarmType", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("bad-robot", []string{"low_insulin", "no_insulin", "low_power", "no_power", "occlusion", "no_delivery", "auto_off", "over_limit", "other"}), "/alarmType", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is low_insulin type", NewRawObject(), "alarmType", "low_insulin"),
 			Entry("is low_power type", NewRawObject(), "alarmType", "low_power"),
 			Entry("is no_power type", NewRawObject(), "alarmType", "no_power"),
@@ -65,21 +65,21 @@ var _ = Describe("Alarm", func() {
 	})
 
 	Context("status", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("status is not an object", NewRawObject(), "status", "string",
-				[]*service.Error{testing.ComposeError(service.ErrorTypeNotObject("string"), "/status", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorTypeNotObject("string"), "/status", NewMeta())},
 			),
 			Entry("type is missing", NewRawObject(), "status", NewEmbeddedStatus(nil, "status"),
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/status/type", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/status/type", NewMeta())},
 			),
 			Entry("type is not valid", NewRawObject(), "status", NewEmbeddedStatus("invalid", "status"),
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"deviceEvent"}), "/status/type", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"deviceEvent"}), "/status/type", NewMeta())},
 			),
 			Entry("subType is missing", NewRawObject(), "status", NewEmbeddedStatus("deviceEvent", nil),
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotExists(), "/status/subType", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotExists(), "/status/subType", NewMeta())},
 			),
 			Entry("subType is not valid", NewRawObject(), "status", NewEmbeddedStatus("deviceEvent", "invalid"),
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"status"}), "/status/subType", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("invalid", []string{"status"}), "/status/subType", NewMeta())},
 			),
 		)
 	})

--- a/data/types/device/calibration/calibration_suite_test.go
+++ b/data/types/device/calibration/calibration_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device/calibration")
+	RunSpecs(t, "data/types/device/calibration")
 }

--- a/data/types/device/calibration/calibration_test.go
+++ b/data/types/device/calibration/calibration_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/normalizer"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
 	"github.com/tidepool-org/platform/data/types/device/calibration"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObjectMmolL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "calibration"
 	rawObject["units"] = glucose.MmolL
@@ -25,7 +25,7 @@ func NewRawObjectMmolL() map[string]interface{} {
 }
 
 func NewRawObjectMgdL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "calibration"
 	rawObject["units"] = glucose.MgdL
@@ -42,16 +42,16 @@ func NewMeta() interface{} {
 
 var _ = Describe("Calibration", func() {
 	Context("units", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObjectMmolL(), "units", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
 			),
 			Entry("is not one of the predefined values", NewRawObjectMmolL(), "units", "wrong",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is mmol/l", NewRawObjectMmolL(), "units", "mmol/l"),
 			Entry("is mmol/L", NewRawObjectMmolL(), "units", "mmol/L"),
 			Entry("is mg/dl", NewRawObjectMgdL(), "units", "mg/dl"),
@@ -60,16 +60,16 @@ var _ = Describe("Calibration", func() {
 	})
 
 	Context("value", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObjectMgdL(), "value", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
 			),
 			Entry("is greater than 1000", NewRawObjectMgdL(), "value", 1000.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/value", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObjectMgdL(), "value", 0.0),
 			Entry("is above 0", NewRawObjectMgdL(), "value", 0.1),
 			Entry("is below max", NewRawObjectMgdL(), "value", glucose.MgdLUpperLimit),

--- a/data/types/device/device_suite_test.go
+++ b/data/types/device/device_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device")
+	RunSpecs(t, "data/types/device")
 }

--- a/data/types/device/device_test.go
+++ b/data/types/device/device_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -110,7 +110,7 @@ var _ = Describe("Device", func() {
 					&map[string]interface{}{"time": 0},
 					NewTestDevice(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 				Entry("does not parse sub type",
 					&map[string]interface{}{"subType": "alarm"},
@@ -124,7 +124,7 @@ var _ = Describe("Device", func() {
 					&map[string]interface{}{"time": 0, "subType": 0},
 					NewTestDevice(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorTypeNotString(0), "/time", NewMeta("")),
 					}),
 			)
 
@@ -145,12 +145,12 @@ var _ = Describe("Device", func() {
 				Entry("missing time",
 					NewTestDevice(nil, "alarm"),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("alarm")),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("alarm")),
 					}),
 				Entry("missing sub type",
 					NewTestDevice("2016-09-06T13:45:58-07:00", nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
+						testData.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
 					}),
 				Entry("specified sub type",
 					NewTestDevice("2016-09-06T13:45:58-07:00", "specified"),
@@ -158,8 +158,8 @@ var _ = Describe("Device", func() {
 				Entry("multiple",
 					NewTestDevice(nil, nil),
 					[]*service.Error{
-						testing.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
-						testing.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
+						testData.ComposeError(service.ErrorValueNotExists(), "/time", NewMeta("")),
+						testData.ComposeError(service.ErrorValueEmpty(), "/subType", NewMeta("")),
 					}),
 			)
 

--- a/data/types/device/prime/prime_suite_test.go
+++ b/data/types/device/prime/prime_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device/prime")
+	RunSpecs(t, "data/types/device/prime")
 }

--- a/data/types/device/prime/prime_test.go
+++ b/data/types/device/prime/prime_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "prime"
 	rawObject["volume"] = 0.0
@@ -38,32 +38,32 @@ func NewMeta() interface{} {
 
 var _ = Describe("Prime", func() {
 	Context("primeTarget", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "primeTarget", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"cannula", "tubing"}), "/primeTarget", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"cannula", "tubing"}), "/primeTarget", NewMeta())},
 			),
 			Entry("is not one of the predefined types", NewRawObject(), "primeTarget", "bad",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("bad", []string{"cannula", "tubing"}), "/primeTarget", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("bad", []string{"cannula", "tubing"}), "/primeTarget", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is cannula type", NewRawObject(), "primeTarget", "cannula"),
 			Entry("is tubing type", NewRawObject(), "primeTarget", "tubing"),
 		)
 	})
 
 	Context("cannula volume", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObjectWithCannula(), "volume", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 3.0), "/volume", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 3.0), "/volume", NewMeta())},
 			),
 			Entry("is more than 3", NewRawObjectWithCannula(), "volume", 3.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(3.1, 0.0, 3.0), "/volume", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(3.1, 0.0, 3.0), "/volume", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObjectWithCannula(), "volume", 0.0),
 			Entry("is 3.0", NewRawObjectWithCannula(), "volume", 3.0),
 			Entry("is no decimal", NewRawObjectWithCannula(), "volume", 2),
@@ -71,16 +71,16 @@ var _ = Describe("Prime", func() {
 	})
 
 	Context("tubing volume", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObjectWithTubing(), "volume", -0.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/volume", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/volume", NewMeta())},
 			),
 			Entry("is more than 100", NewRawObjectWithTubing(), "volume", 100.1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/volume", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/volume", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObjectWithTubing(), "volume", 0.0),
 			Entry("is 100.0", NewRawObjectWithTubing(), "volume", 100.0),
 			Entry("is no decimal", NewRawObjectWithTubing(), "volume", 55),

--- a/data/types/device/reservoirchange/reservoirchange_suite_test.go
+++ b/data/types/device/reservoirchange/reservoirchange_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device/reservoirchange")
+	RunSpecs(t, "data/types/device/reservoirchange")
 }

--- a/data/types/device/reservoirchange/reservoirchange_test.go
+++ b/data/types/device/reservoirchange/reservoirchange_test.go
@@ -4,12 +4,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
-	"github.com/tidepool-org/platform/data/types/testing"
 )
 
 func NewRawStatusObject() map[string]interface{} {
-	rawStatusObject := testing.RawBaseObject()
+	rawStatusObject := testData.RawBaseObject()
 	rawStatusObject["type"] = "deviceEvent"
 	rawStatusObject["subType"] = "status"
 	rawStatusObject["status"] = "suspended"
@@ -18,7 +18,7 @@ func NewRawStatusObject() map[string]interface{} {
 }
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "reservoirChange"
 	rawObject["status"] = NewRawStatusObject()
@@ -35,7 +35,7 @@ func NewMeta() interface{} {
 
 var _ = Describe("Reservoirchange", func() {
 	Context("status", func() {
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is longer than one character", NewRawObject(), "status", NewRawStatusObject()),
 		)
 	})

--- a/data/types/device/status/status_suite_test.go
+++ b/data/types/device/status/status_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device/status")
+	RunSpecs(t, "data/types/device/status")
 }

--- a/data/types/device/status/status_test.go
+++ b/data/types/device/status/status_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "status"
 	rawObject["duration"] = 0
@@ -28,36 +28,36 @@ func NewMeta() interface{} {
 
 var _ = Describe("Status", func() {
 	Context("duration", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is less than 0", NewRawObject(), "duration", -1,
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/duration", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/duration", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 0", NewRawObject(), "duration", 0),
 			Entry("is max of 999999999999999999", NewRawObject(), "duration", 999999999999999999),
 		)
 	})
 
 	Context("status", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "status", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"resumed", "suspended"}), "/status", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"resumed", "suspended"}), "/status", NewMeta())},
 			),
 			Entry("is not one of the predefined types", NewRawObject(), "status", "bad",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("bad", []string{"resumed", "suspended"}), "/status", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("bad", []string{"resumed", "suspended"}), "/status", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is suspended type", NewRawObject(), "status", "resumed"),
 			Entry("is suspended type", NewRawObject(), "status", "suspended"),
 		)
 	})
 
 	Context("reason", func() {
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is manual", NewRawObject(), "reason", map[string]interface{}{"suspended": "manual"}),
 			Entry("is automatic", NewRawObject(), "reason", map[string]interface{}{"suspended": "automatic"}),
 		)

--- a/data/types/device/timechange/timechange_suite_test.go
+++ b/data/types/device/timechange/timechange_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/device/timechange")
+	RunSpecs(t, "data/types/device/timechange")
 }

--- a/data/types/device/timechange/timechange_test.go
+++ b/data/types/device/timechange/timechange_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/device"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "deviceEvent"
 	rawObject["subType"] = "timeChange"
 	rawObject["change"] = map[string]interface{}{
@@ -31,57 +31,57 @@ func NewMeta() interface{} {
 var _ = Describe("Timechange", func() {
 	Context("change", func() {
 		Context("from", func() {
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
+			DescribeTable("valid when", testData.ExpectFieldIsValid,
 				Entry("is non zulu time", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual"}),
 			)
 
-			DescribeTable("invalid when", testing.ExpectFieldNotValid,
+			DescribeTable("invalid when", testData.ExpectFieldNotValid,
 				Entry("is zulu time", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06Z", "to": "2016-05-04T07:21:31", "agent": "manual"},
-					[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("2016-05-04T08:18:06Z", "2006-01-02T15:04:05"), "/change/from", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("2016-05-04T08:18:06Z", "2006-01-02T15:04:05"), "/change/from", NewMeta())},
 				),
 				Entry("is empty time", NewRawObject(), "change",
 					map[string]interface{}{"from": "", "to": "2016-05-04T07:21:31", "agent": "manual"},
-					[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("", "2006-01-02T15:04:05"), "/change/from", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("", "2006-01-02T15:04:05"), "/change/from", NewMeta())},
 				),
 			)
 		})
 
 		Context("to", func() {
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
+			DescribeTable("valid when", testData.ExpectFieldIsValid,
 				Entry("is non zulu time", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual"}),
 			)
 
-			DescribeTable("invalid when", testing.ExpectFieldNotValid,
+			DescribeTable("invalid when", testData.ExpectFieldNotValid,
 				Entry("is zulu time", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31Z", "agent": "manual"},
-					[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("2016-05-04T07:21:31Z", "2006-01-02T15:04:05"), "/change/to", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("2016-05-04T07:21:31Z", "2006-01-02T15:04:05"), "/change/to", NewMeta())},
 				),
 				Entry("is empty time", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "", "agent": "manual"},
-					[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("", "2006-01-02T15:04:05"), "/change/to", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("", "2006-01-02T15:04:05"), "/change/to", NewMeta())},
 				),
 			)
 		})
 
 		Context("agent", func() {
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
+			DescribeTable("valid when", testData.ExpectFieldIsValid,
 				Entry("is manual", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "manual"}),
 				Entry("is automatic", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "automatic"}),
 			)
 
-			DescribeTable("invalid when", testing.ExpectFieldNotValid,
+			DescribeTable("invalid when", testData.ExpectFieldNotValid,
 				Entry("is empty", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": ""},
-					[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"manual", "automatic"}), "/change/agent", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"manual", "automatic"}), "/change/agent", NewMeta())},
 				),
 				Entry("is not predefined type", NewRawObject(), "change",
 					map[string]interface{}{"from": "2016-05-04T08:18:06", "to": "2016-05-04T07:21:31", "agent": "wrong"},
-					[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"manual", "automatic"}), "/change/agent", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("wrong", []string{"manual", "automatic"}), "/change/agent", NewMeta())},
 				),
 			)
 		})

--- a/data/types/settings/pump/blood_glucose_target_test.go
+++ b/data/types/settings/pump/blood_glucose_target_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/factory"
 	"github.com/tidepool-org/platform/data/parser"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/settings/pump"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/data/validator"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
@@ -64,15 +64,15 @@ var _ = Describe("BloodGlucoseTarget", func() {
 			NewTestBloodGlucoseTarget(120.0, 10.0, 110.0, 130.0, 3600), []*service.Error{}),
 		Entry("parses object that has multiple invalid fields", &map[string]interface{}{"target": "invalid", "range": "invalid", "low": "invalid", "high": "invalid", "start": "invalid"},
 			NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
-				testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/start", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
+				testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/start", nil),
 			}),
 		Entry("parses object that has additional fields", &map[string]interface{}{"target": 120.0, "range": 10.0, "low": 110.0, "high": 130.0, "start": 3600, "additional": 0.0},
 			NewTestBloodGlucoseTarget(120.0, 10.0, 110.0, 130.0, 3600), []*service.Error{
-				testing.ComposeError(parser.ErrorNotParsed(), "/additional", nil),
+				testData.ComposeError(parser.ErrorNotParsed(), "/additional", nil),
 			}),
 	)
 
@@ -117,11 +117,11 @@ var _ = Describe("BloodGlucoseTarget", func() {
 				NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil),
 				NewTestBloodGlucoseTarget(120.0, 10.0, 110.0, 130.0, 3600),
 			}, []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/target", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/range", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/low", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/high", nil),
-				testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/0/start", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/target", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/range", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/low", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/high", nil),
+				testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/0/start", nil),
 			}),
 		Entry("parses array that has more than one invalid",
 			&[]interface{}{
@@ -132,16 +132,16 @@ var _ = Describe("BloodGlucoseTarget", func() {
 				NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil),
 				NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil),
 			}, []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/target", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/range", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/low", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/high", nil),
-				testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/0/start", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/target", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/range", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/low", nil),
-				testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/high", nil),
-				testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/1/start", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/target", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/range", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/low", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/0/high", nil),
+				testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/0/start", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/target", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/range", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/low", nil),
+				testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/1/high", nil),
+				testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/1/start", nil),
 			}),
 		Entry("parses array that has more than one valid with additional field",
 			&[]interface{}{
@@ -152,7 +152,7 @@ var _ = Describe("BloodGlucoseTarget", func() {
 				NewTestBloodGlucoseTarget(120.0, 10.0, 110.0, 130.0, 3600),
 				NewTestBloodGlucoseTarget(121.0, 11.0, 111.0, 131.0, 3601),
 			}, []*service.Error{
-				testing.ComposeError(parser.ErrorNotParsed(), "/1/additional", nil),
+				testData.ComposeError(parser.ErrorNotParsed(), "/1/additional", nil),
 			}),
 	)
 
@@ -183,17 +183,17 @@ var _ = Describe("BloodGlucoseTarget", func() {
 			Entry("parses object that is empty", &map[string]interface{}{}, NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil), []*service.Error{}),
 			Entry("parses object that has valid start", &map[string]interface{}{"start": 3600}, NewTestBloodGlucoseTarget(nil, nil, nil, nil, 3600), []*service.Error{}),
 			Entry("parses object that has invalid start", &map[string]interface{}{"start": "invalid"}, NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil), []*service.Error{
-				testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/start", nil),
+				testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/start", nil),
 			}),
 			Entry("parses object that has multiple valid fields", &map[string]interface{}{"target": 120.0, "range": 10.0, "low": 110.0, "high": 130.0, "start": 3600},
 				NewTestBloodGlucoseTarget(120.0, 10.0, 110.0, 130.0, 3600), []*service.Error{}),
 			Entry("parses object that has multiple invalid fields", &map[string]interface{}{"target": "invalid", "range": "invalid", "low": "invalid", "high": "invalid", "start": "invalid"},
 				NewTestBloodGlucoseTarget(nil, nil, nil, nil, nil), []*service.Error{
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
-					testing.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
-					testing.ComposeError(service.ErrorTypeNotInteger("invalid"), "/start", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/target", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/range", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/low", nil),
+					testData.ComposeError(service.ErrorTypeNotFloat("invalid"), "/high", nil),
+					testData.ComposeError(service.ErrorTypeNotInteger("invalid"), "/start", nil),
 				}),
 		)
 
@@ -210,24 +210,24 @@ var _ = Describe("BloodGlucoseTarget", func() {
 			},
 			Entry("validates a target with units of mmol/L; target/range; all valid", NewTestBloodGlucoseTarget(6.6, 1.0, nil, nil, 3600), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; target/range; start missing", NewTestBloodGlucoseTarget(6.6, 1.0, nil, nil, nil), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotExists(), "/start", nil),
+				testData.ComposeError(service.ErrorValueNotExists(), "/start", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/range; start at lower", NewTestBloodGlucoseTarget(6.6, 1.0, nil, nil, 0), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; target/range; start at upper", NewTestBloodGlucoseTarget(6.6, 1.0, nil, nil, 8640000), "mmol/L", []*service.Error{}),
 			Entry("validates a target with units of mmol/L; target/range; start out of range (lower)", NewTestBloodGlucoseTarget(6.6, 1.0, nil, nil, -1), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/start", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/start", nil),
 			}),
 			Entry("validates a target with units of mmol/L; target/range; start out of range (upper)", NewTestBloodGlucoseTarget(6.6, 1.0, nil, nil, 86400001), "mmol/L", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/start", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/start", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; all valid", NewTestBloodGlucoseTarget(120.0, 10.0, nil, nil, 3600), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; target/range; start at lower", NewTestBloodGlucoseTarget(120.0, 10.0, nil, nil, 0), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; target/range; start at upper", NewTestBloodGlucoseTarget(120.0, 10.0, nil, nil, 86400000), "mg/dL", []*service.Error{}),
 			Entry("validates a target with units of mg/dL; target/range; start out of range (lower)", NewTestBloodGlucoseTarget(120.0, 10.0, nil, nil, -1), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/start", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/start", nil),
 			}),
 			Entry("validates a target with units of mg/dL; target/range; start out of range (upper)", NewTestBloodGlucoseTarget(120.0, 10.0, nil, nil, 86400001), "mg/dL", []*service.Error{
-				testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/start", nil),
+				testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/start", nil),
 			}),
 		)
 	})

--- a/data/types/settings/pump/pump_suite_test.go
+++ b/data/types/settings/pump/pump_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/settings/pump")
+	RunSpecs(t, "data/types/settings/pump")
 }

--- a/data/types/settings/pump/pump_test.go
+++ b/data/types/settings/pump/pump_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/data/context"
 	"github.com/tidepool-org/platform/data/normalizer"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/settings/pump"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObjectMmolL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "pumpSettings"
 	rawObject["activeSchedule"] = "standard"
 	rawObject["units"] = map[string]interface{}{
@@ -48,7 +48,7 @@ func NewRawObjectMmolL() map[string]interface{} {
 }
 
 func NewRawObjectMgdL() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "pumpSettings"
 	rawObject["activeSchedule"] = "standard"
 	rawObject["units"] = map[string]interface{}{
@@ -87,58 +87,58 @@ func NewMeta() interface{} {
 
 var _ = Describe("Settings", func() {
 	Context("activeSchedule", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObjectMmolL(), "activeSchedule", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/activeSchedule", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueEmpty(), "/activeSchedule", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is more than 1 characters", NewRawObjectMmolL(), "activeSchedule", "A"),
 			Entry("is freetext", NewRawObjectMgdL(), "activeSchedule", "standard"),
 		)
 	})
 
 	Context("units", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("has bg empty", NewRawObjectMgdL(), "units", map[string]interface{}{"carb": "grams", "bg": ""},
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units/bg", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units/bg", NewMeta())},
 			),
 			Entry("has bg not predefined type", NewRawObjectMmolL(), "units", map[string]interface{}{"carb": "grams", "bg": "na"},
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("na", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units/bg", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("na", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units/bg", NewMeta())},
 			),
 			Entry("has carb empty", NewRawObjectMmolL(), "units", map[string]interface{}{"carb": "", "bg": "mmol/L"},
-				[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/units/carb", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueEmpty(), "/units/carb", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("has carbs set and bg set as mmol/L", NewRawObjectMmolL(), "units", map[string]interface{}{"carb": "grams", "bg": "mmol/L"}),
 			Entry("has carbs set and bg set as mg/dL", NewRawObjectMgdL(), "units", map[string]interface{}{"carb": "grams", "bg": "mg/dL"}),
 		)
 	})
 
 	Context("carbRatio", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("has start negative", NewRawObjectMmolL(), "carbRatio",
 				[]interface{}{map[string]interface{}{"amount": 12.0, "start": -1}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/carbRatio/0/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/carbRatio/0/start", NewMeta())},
 			),
 			Entry("has start greater than 86400000", NewRawObjectMmolL(), "carbRatio",
 				[]interface{}{map[string]interface{}{"amount": 12.0, "start": 86400001}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/carbRatio/0/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/carbRatio/0/start", NewMeta())},
 			),
 			Entry("has amount negative", NewRawObjectMmolL(), "carbRatio",
 				[]interface{}{map[string]interface{}{"amount": -1.0, "start": 21600000}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1.0, 0.0, 250.0), "/carbRatio/0/amount", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1.0, 0.0, 250.0), "/carbRatio/0/amount", NewMeta())},
 			),
 			Entry("has amount greater than 250", NewRawObjectMmolL(), "carbRatio",
 				[]interface{}{map[string]interface{}{"amount": 251.0, "start": 21600000}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(251.0, 0.0, 250.0), "/carbRatio/0/amount", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(251.0, 0.0, 250.0), "/carbRatio/0/amount", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("has start and amount within bounds", NewRawObjectMmolL(), "carbRatio",
 				[]interface{}{map[string]interface{}{"amount": 12.0, "start": 0}},
 			),
@@ -165,25 +165,25 @@ var _ = Describe("Settings", func() {
 			"pattern b": []interface{}{},
 		}
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("has start and rate within bounds", NewRawObjectMgdL(), "basalSchedules", basalSchedules),
 			Entry("has an empty array", NewRawObjectMgdL(), "basalSchedules", map[string]interface{}{"empty": []interface{}{}}),
 		)
 
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("has start negative", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
 					"standard": []interface{}{
 						map[string]interface{}{"rate": 0.6, "start": -1},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/basalSchedules/standard/0/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/basalSchedules/standard/0/start", NewMeta())},
 			),
 			Entry("has start to large", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
 					"standard": []interface{}{
 						map[string]interface{}{"rate": 0.6, "start": 86400001},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/basalSchedules/standard/0/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/basalSchedules/standard/0/start", NewMeta())},
 			),
 			Entry("has nested start to large", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
@@ -191,21 +191,21 @@ var _ = Describe("Settings", func() {
 						map[string]interface{}{"rate": 0.6, "start": 5},
 						map[string]interface{}{"rate": 0.6, "start": 86400001},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/basalSchedules/standard/1/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/basalSchedules/standard/1/start", NewMeta())},
 			),
 			Entry("has start negative", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
 					"standard": []interface{}{
 						map[string]interface{}{"rate": -0.1, "start": 10800000},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/basalSchedules/standard/0/rate", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/basalSchedules/standard/0/rate", NewMeta())},
 			),
 			Entry("has start to large", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
 					"standard": []interface{}{
 						map[string]interface{}{"rate": 100.1, "start": 10800000},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/basalSchedules/standard/0/rate", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(100.1, 0.0, 100.0), "/basalSchedules/standard/0/rate", NewMeta())},
 			),
 			Entry("has nested rate to large", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
@@ -213,7 +213,7 @@ var _ = Describe("Settings", func() {
 						map[string]interface{}{"rate": 0.6, "start": 0},
 						map[string]interface{}{"rate": 125.1, "start": 10800000},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(125.1, 0.0, 100.0), "/basalSchedules/standard/1/rate", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(125.1, 0.0, 100.0), "/basalSchedules/standard/1/rate", NewMeta())},
 			),
 			Entry("has no defined name", NewRawObjectMgdL(), "basalSchedules",
 				map[string]interface{}{
@@ -221,32 +221,32 @@ var _ = Describe("Settings", func() {
 						map[string]interface{}{"rate": 0.6, "start": 0},
 						map[string]interface{}{"rate": 18.1, "start": 10800000},
 					}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/basalSchedules/", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueEmpty(), "/basalSchedules/", NewMeta())},
 			),
 		)
 	})
 
 	Context("insulinSensitivity", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("has start negative", NewRawObjectMmolL(), "insulinSensitivity",
 				[]interface{}{map[string]interface{}{"amount": 12.0, "start": -1}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/insulinSensitivity/0/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/insulinSensitivity/0/start", NewMeta())},
 			),
 			Entry("has start greater than 86400000", NewRawObjectMmolL(), "insulinSensitivity",
 				[]interface{}{map[string]interface{}{"amount": 12.0, "start": 86400001}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/insulinSensitivity/0/start", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/insulinSensitivity/0/start", NewMeta())},
 			),
 			Entry("has amount negative", NewRawObjectMgdL(), "insulinSensitivity",
 				[]interface{}{map[string]interface{}{"amount": -0.1, "start": 21600000}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity/0/amount", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity/0/amount", NewMeta())},
 			),
 			Entry("has amount greater than 1000.0", NewRawObjectMgdL(), "insulinSensitivity",
 				[]interface{}{map[string]interface{}{"amount": 1000.1, "start": 21600000}},
-				[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity/0/amount", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/insulinSensitivity/0/amount", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("has start and amount within bounds", NewRawObjectMmolL(), "insulinSensitivity",
 				[]interface{}{map[string]interface{}{"amount": 12.0, "start": 0}},
 			),
@@ -255,34 +255,34 @@ var _ = Describe("Settings", func() {
 
 	Context("bgTarget", func() {
 		Context("start, target, range", func() {
-			DescribeTable("invalid when", testing.ExpectFieldNotValid,
+			DescribeTable("invalid when", testData.ExpectFieldNotValid,
 				Entry("has start negative", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": -1, "target": 99.0, "range": 15}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/bgTarget/0/start", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/bgTarget/0/start", NewMeta())},
 				),
 				Entry("has start greater than 86400000", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 86400001, "target": 99.0, "range": 15}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/bgTarget/0/start", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/bgTarget/0/start", NewMeta())},
 				),
 				Entry("has target negative", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": -0.1, "range": 15}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
 				),
 				Entry("has target greater than 1000.0", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 1000.1, "range": 15}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
 				),
 				Entry("has range negative", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 99.0, "range": -1}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 99), "/bgTarget/0/range", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 99), "/bgTarget/0/range", NewMeta())},
 				),
 				Entry("has range greater than target", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 199.0, "range": 200}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(200, 0, 199), "/bgTarget/0/range", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(200, 0, 199), "/bgTarget/0/range", NewMeta())},
 				),
 			)
 
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
+			DescribeTable("valid when", testData.ExpectFieldIsValid,
 				Entry("is within bounds", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 99.9, "range": 10}},
 				),
@@ -291,34 +291,34 @@ var _ = Describe("Settings", func() {
 
 		Context("start, target, high", func() {
 
-			DescribeTable("invalid when", testing.ExpectFieldNotValid,
+			DescribeTable("invalid when", testData.ExpectFieldNotValid,
 				Entry("has start negative", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": -1, "target": 99.0, "high": 180.0}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/bgTarget/0/start", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-1, 0, 86400000), "/bgTarget/0/start", NewMeta())},
 				),
 				Entry("has start greater than 86400000", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 86400001, "target": 99.0, "high": 180.0}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/bgTarget/0/start", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(86400001, 0, 86400000), "/bgTarget/0/start", NewMeta())},
 				),
 				Entry("has target negative", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": -0.1, "high": 180.0}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(-0.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
 				),
 				Entry("has target greater than 1000.0", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 1000.1, "high": 180.0}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, glucose.MgdLLowerLimit, glucose.MgdLUpperLimit), "/bgTarget/0/target", NewMeta())},
 				),
 				Entry("has high less than target", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 90.0, "high": 80.0}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(80.0, 90.0, 1000.0), "/bgTarget/0/high", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(80.0, 90.0, 1000.0), "/bgTarget/0/high", NewMeta())},
 				),
 				Entry("has high greater than 1000.0", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 0.0, "high": 1000.1}},
-					[]*service.Error{testing.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, glucose.MgdLUpperLimit), "/bgTarget/0/high", NewMeta())},
+					[]*service.Error{testData.ComposeError(service.ErrorValueNotInRange(1000.1, 0.0, glucose.MgdLUpperLimit), "/bgTarget/0/high", NewMeta())},
 				),
 			)
 
-			DescribeTable("valid when", testing.ExpectFieldIsValid,
+			DescribeTable("valid when", testData.ExpectFieldIsValid,
 				Entry("is within bounds", NewRawObjectMgdL(), "bgTarget",
 					[]interface{}{map[string]interface{}{"start": 21600000, "target": 99.9, "high": 180.0}},
 				),

--- a/data/types/upload/upload.go
+++ b/data/types/upload/upload.go
@@ -48,7 +48,6 @@ func (u *Upload) Init() {
 
 	u.State = "open"
 	u.DataState = "open" // TODO: Deprecated DataState (after data migration)
-	u.Deduplicator = nil
 	u.ByUser = ""
 
 	u.ComputerTime = nil

--- a/data/types/upload/upload_suite_test.go
+++ b/data/types/upload/upload_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types/base/upload")
+	RunSpecs(t, "data/types/upload")
 }

--- a/data/types/upload/upload_test.go
+++ b/data/types/upload/upload_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types"
-	"github.com/tidepool-org/platform/data/types/testing"
 	"github.com/tidepool-org/platform/service"
 )
 
 func NewRawObject() map[string]interface{} {
-	rawObject := testing.RawBaseObject()
+	rawObject := testData.RawBaseObject()
 	rawObject["type"] = "upload"
 	rawObject["version"] = "123456"
 	rawObject["computerTime"] = "2014-06-11T06:00:00.000"
@@ -31,35 +31,35 @@ func NewMeta() interface{} {
 
 var _ = Describe("Upload", func() {
 	Context("version", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "version", "",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(0, 5), "/version", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(0, 5), "/version", NewMeta())},
 			),
 			Entry("is less than 6 characters", NewRawObject(), "version", "aaaaa",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(5, 5), "/version", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(5, 5), "/version", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 6 characters", NewRawObject(), "version", "aaaaaa"),
 			Entry("is more than 6 characters", NewRawObject(), "version", "aaaaaabb"),
 		)
 	})
 
 	Context("deviceTags", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty array", NewRawObject(), "deviceTags", []string{},
-				[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/deviceTags", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueEmpty(), "/deviceTags", NewMeta())},
 			),
 			Entry("is not one of the allowed types", NewRawObject(), "deviceTags", []string{"not-valid"},
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("not-valid", []string{"insulin-pump", "cgm", "bgm"}), "/deviceTags/0", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("not-valid", []string{"insulin-pump", "cgm", "bgm"}), "/deviceTags/0", NewMeta())},
 			),
 			Entry("is not one of the allowed types", NewRawObject(), "deviceTags", []string{"bgm", "cgm", "not-valid"},
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("not-valid", []string{"insulin-pump", "cgm", "bgm"}), "/deviceTags/2", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("not-valid", []string{"insulin-pump", "cgm", "bgm"}), "/deviceTags/2", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is insulin-pump", NewRawObject(), "deviceTags", []string{"insulin-pump"}),
 			Entry("is cgm", NewRawObject(), "deviceTags", []string{"cgm"}),
 			Entry("is bgm", NewRawObject(), "deviceTags", []string{"bgm"}),
@@ -68,94 +68,94 @@ var _ = Describe("Upload", func() {
 	})
 
 	Context("deviceManufacturers", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty array", NewRawObject(), "deviceManufacturers", []string{},
-				[]*service.Error{testing.ComposeError(service.ErrorValueEmpty(), "/deviceManufacturers", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueEmpty(), "/deviceManufacturers", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is one item", NewRawObject(), "deviceManufacturers", []string{"insulin-pump-people"}),
 			Entry("is multiple items", NewRawObject(), "deviceManufacturers", []string{"bgm-people", "cgm-people"}),
 		)
 	})
 
 	Context("computerTime", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "computerTime", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("", "2006-01-02T15:04:05"), "/computerTime", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("", "2006-01-02T15:04:05"), "/computerTime", NewMeta())},
 			),
 			Entry("is zulu time", NewRawObject(), "computerTime", "2013-05-04T03:58:44.584Z",
-				[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("2013-05-04T03:58:44.584Z", "2006-01-02T15:04:05"), "/computerTime", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("2013-05-04T03:58:44.584Z", "2006-01-02T15:04:05"), "/computerTime", NewMeta())},
 			),
 			Entry("is offset time", NewRawObject(), "computerTime", "2013-05-04T03:58:44-08:00",
-				[]*service.Error{testing.ComposeError(service.ErrorValueTimeNotValid("2013-05-04T03:58:44-08:00", "2006-01-02T15:04:05"), "/computerTime", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueTimeNotValid("2013-05-04T03:58:44-08:00", "2006-01-02T15:04:05"), "/computerTime", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is non-zulu time", NewRawObject(), "computerTime", "2013-05-04T03:58:44.584"),
 		)
 	})
 
 	Context("deviceModel", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "deviceModel", "",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(0, 1), "/deviceModel", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(0, 1), "/deviceModel", NewMeta())},
 			),
 			Entry("is 1 character", NewRawObject(), "deviceModel", "x",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(1, 1), "/deviceModel", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(1, 1), "/deviceModel", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 2 characters", NewRawObject(), "deviceModel", "xx"),
 			Entry("is more than 2 characters", NewRawObject(), "deviceModel", "model-x"),
 		)
 	})
 
 	Context("deviceSerialNumber", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "deviceSerialNumber", "",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(0, 1), "/deviceSerialNumber", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(0, 1), "/deviceSerialNumber", NewMeta())},
 			),
 			Entry("is 1 character", NewRawObject(), "deviceSerialNumber", "x",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(1, 1), "/deviceSerialNumber", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(1, 1), "/deviceSerialNumber", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is 2 characters", NewRawObject(), "deviceSerialNumber", "xx"),
 			Entry("is more than 2 characters", NewRawObject(), "deviceSerialNumber", "model-x"),
 		)
 	})
 
 	Context("timezone", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "timezone", "",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(0, 1), "/timezone", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(0, 1), "/timezone", NewMeta())},
 			),
 			Entry("is only one character", NewRawObject(), "timezone", "a",
-				[]*service.Error{testing.ComposeError(service.ErrorLengthNotGreaterThan(1, 1), "/timezone", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorLengthNotGreaterThan(1, 1), "/timezone", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is set", NewRawObject(), "timezone", "US/Central"),
 		)
 	})
 
 	Context("timeProcessing", func() {
-		DescribeTable("invalid when", testing.ExpectFieldNotValid,
+		DescribeTable("invalid when", testData.ExpectFieldNotValid,
 			Entry("is empty", NewRawObject(), "timeProcessing", "",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("", []string{"across-the-board-timezone", "utc-bootstrapping", "none"}), "/timeProcessing", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("", []string{"across-the-board-timezone", "utc-bootstrapping", "none"}), "/timeProcessing", NewMeta())},
 			),
 			Entry("is not of predefined type", NewRawObject(), "timeProcessing", "invalid-time-processing",
-				[]*service.Error{testing.ComposeError(service.ErrorValueStringNotOneOf("invalid-time-processing", []string{"across-the-board-timezone", "utc-bootstrapping", "none"}), "/timeProcessing", NewMeta())},
+				[]*service.Error{testData.ComposeError(service.ErrorValueStringNotOneOf("invalid-time-processing", []string{"across-the-board-timezone", "utc-bootstrapping", "none"}), "/timeProcessing", NewMeta())},
 			),
 		)
 
-		DescribeTable("valid when", testing.ExpectFieldIsValid,
+		DescribeTable("valid when", testData.ExpectFieldIsValid,
 			Entry("is none", NewRawObject(), "timeProcessing", "none"),
 			Entry("is utc-bootstrapping", NewRawObject(), "timeProcessing", "utc-bootstrapping"),
 			Entry("is across-the-board-timezone", NewRawObject(), "timeProcessing", "across-the-board-timezone"),

--- a/dataservices/service/api/v1/datasets_data_create.go
+++ b/dataservices/service/api/v1/datasets_data_create.go
@@ -63,9 +63,9 @@ func DatasetsDataCreate(serviceContext service.Context) {
 		return
 	}
 
-	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicator(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
+	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewRegisteredDeduplicatorForDataset(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
 	if err != nil {
-		serviceContext.RespondWithInternalServerFailure("No duplicator found matching dataset", err)
+		serviceContext.RespondWithInternalServerFailure("Unable to create registered deduplicator for dataset", err)
 		return
 	}
 
@@ -126,8 +126,8 @@ func DatasetsDataCreate(serviceContext service.Context) {
 		datum.SetDatasetID(dataset.UploadID)
 	}
 
-	if err = deduplicator.AddDataToDataset(datumArray); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to add data to dataset", err)
+	if err = deduplicator.AddDatasetData(datumArray); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to add dataset data", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/datasets_delete_test.go
+++ b/dataservices/service/api/v1/datasets_delete_test.go
@@ -1,15 +1,16 @@
 package v1_test
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"errors"
 	"net/http"
 
 	"github.com/tidepool-org/platform/app"
+	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/upload"
 	"github.com/tidepool-org/platform/dataservices/service/api/v1"
 	"github.com/tidepool-org/platform/service"
@@ -35,6 +36,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{false}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{authenticatedUserID}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"root": client.Permission{}}, nil}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: nil}}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{nil}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{nil}
 		})
@@ -43,6 +45,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -54,6 +57,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -66,6 +70,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -78,6 +83,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -89,6 +95,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(nil) }).To(Panic())
@@ -101,6 +108,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
@@ -113,6 +121,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -125,6 +134,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -136,6 +146,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -149,6 +160,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -162,6 +174,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -173,6 +186,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("panics if authentication details is missing", func() {
 			context.AuthenticationDetailsImpl = nil
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
@@ -182,6 +196,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("panics if user services client is missing", func() {
 			context.UserServicesClientImpl = nil
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
@@ -191,6 +206,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if user services client get user permissions returns unauthorized error", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{nil, client.NewUnauthorizedError()}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -203,6 +219,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("responds with error if user services client get user permissions returns any other error", func() {
 			err := errors.New("other")
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{nil, err}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -214,6 +231,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if user services client get user permissions does not return needed permissions", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"view": client.Permission{}}, nil}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -225,6 +243,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if user services client get user permissions returns upload permissions, but not user who uploaded", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"upload": client.Permission{}}, nil}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -234,6 +253,60 @@ var _ = Describe("DatasetsDelete", func() {
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
 
+		It("panics if data deduplicator factory is missing", func() {
+			context.DataDeduplicatorFactoryImpl = nil
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if data deduplicator factory is registered with dataset returns an error", func() {
+			err := errors.New("other")
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: err}}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to check if registered with dataset", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if data deduplicator factory new registered deduplicator for data returns an error", func() {
+			err := errors.New("other")
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+			context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: nil, Error: err}}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
+			Expect(context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetInputs).To(Equal([]testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{{Logger: context.LoggerImpl, DataStoreSession: context.DataStoreSessionImpl, Dataset: targetUpload}}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to create registered deduplicator for dataset", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if deduplicator delete dataset returns an error", func() {
+			deduplicatorImpl := testData.NewDeduplicator()
+			err := errors.New("other")
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+			context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: deduplicatorImpl, Error: nil}}
+			deduplicatorImpl.DeleteDatasetOutputs = []error{err}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
+			Expect(context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetInputs).To(Equal([]testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{{Logger: context.LoggerImpl, DataStoreSession: context.DataStoreSessionImpl, Dataset: targetUpload}}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to delete dataset", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+			Expect(deduplicatorImpl.UnusedOutputsCount()).To(Equal(0))
+		})
+
 		It("responds with error if data store session delete dataset returns an error", func() {
 			err := errors.New("other")
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{err}
@@ -241,6 +314,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to delete dataset", []interface{}{err}}}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -251,6 +325,7 @@ var _ = Describe("DatasetsDelete", func() {
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -259,6 +334,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{errors.New("other")}
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))

--- a/dataservices/service/api/v1/datasets_update.go
+++ b/dataservices/service/api/v1/datasets_update.go
@@ -64,14 +64,14 @@ func DatasetsUpdate(serviceContext service.Context) {
 		return
 	}
 
-	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicator(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
+	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewRegisteredDeduplicatorForDataset(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
 	if err != nil {
-		serviceContext.RespondWithInternalServerFailure("No duplicator found matching dataset", err)
+		serviceContext.RespondWithInternalServerFailure("Unable to create registered deduplicator for dataset", err)
 		return
 	}
 
-	if err = deduplicator.FinalizeDataset(); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to finalize dataset", err)
+	if err = deduplicator.DeduplicateDataset(); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to deduplicate dataset", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/users_datasets_create.go
+++ b/dataservices/service/api/v1/users_datasets_create.go
@@ -117,14 +117,14 @@ func UsersDatasetsCreate(serviceContext service.Context) {
 		return
 	}
 
-	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicator(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
+	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicatorForDataset(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
 	if err != nil {
-		serviceContext.RespondWithInternalServerFailure("No duplicator found matching dataset", err)
+		serviceContext.RespondWithInternalServerFailure("Unable to create deduplicator for dataset", err)
 		return
 	}
 
-	if err = deduplicator.InitializeDataset(); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to initialize dataset", err)
+	if err = deduplicator.RegisterDataset(); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to register dataset with deduplicator", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
+	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	dataStore "github.com/tidepool-org/platform/data/store"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
 	"github.com/tidepool-org/platform/log"
@@ -174,6 +175,7 @@ type TestContext struct {
 	RespondWithStatusAndDataInputs         []RespondWithStatusAndDataInput
 	MetricServicesClientImpl               *TestMetricServicesClient
 	UserServicesClientImpl                 *TestUserServicesClient
+	DataDeduplicatorFactoryImpl            *testDataDeduplicator.Factory
 	DataStoreSessionImpl                   *testDataStore.Session
 	TaskStoreSessionImpl                   *TestTaskStoreSession
 	AuthenticationDetailsImpl              *TestAuthenticationDetails
@@ -188,11 +190,12 @@ func NewTestContext() *TestContext {
 			},
 			PathParams: map[string]string{},
 		},
-		MetricServicesClientImpl:  &TestMetricServicesClient{},
-		UserServicesClientImpl:    &TestUserServicesClient{},
-		DataStoreSessionImpl:      testDataStore.NewSession(),
-		TaskStoreSessionImpl:      &TestTaskStoreSession{},
-		AuthenticationDetailsImpl: &TestAuthenticationDetails{},
+		MetricServicesClientImpl:    &TestMetricServicesClient{},
+		UserServicesClientImpl:      &TestUserServicesClient{},
+		DataDeduplicatorFactoryImpl: testDataDeduplicator.NewFactory(),
+		DataStoreSessionImpl:        testDataStore.NewSession(),
+		TaskStoreSessionImpl:        &TestTaskStoreSession{},
+		AuthenticationDetailsImpl:   &TestAuthenticationDetails{},
 	}
 }
 
@@ -237,7 +240,7 @@ func (t *TestContext) DataFactory() data.Factory {
 }
 
 func (t *TestContext) DataDeduplicatorFactory() deduplicator.Factory {
-	panic("Unexpected invocation of DataDeduplicatorFactory on TestContext")
+	return t.DataDeduplicatorFactoryImpl
 }
 
 func (t *TestContext) DataStoreSession() dataStore.Session {
@@ -259,6 +262,7 @@ func (t *TestContext) SetAuthenticationDetails(authenticationDetails userservice
 func (t *TestContext) ValidateTest() bool {
 	return (t.MetricServicesClientImpl == nil || t.MetricServicesClientImpl.ValidateTest()) &&
 		(t.UserServicesClientImpl == nil || t.UserServicesClientImpl.ValidateTest()) &&
+		(t.DataDeduplicatorFactoryImpl == nil || t.DataDeduplicatorFactoryImpl.UnusedOutputsCount() == 0) &&
 		(t.DataStoreSessionImpl == nil || t.DataStoreSessionImpl.UnusedOutputsCount() == 0) &&
 		(t.TaskStoreSessionImpl == nil || t.TaskStoreSessionImpl.ValidateTest()) &&
 		(t.AuthenticationDetailsImpl == nil || t.AuthenticationDetailsImpl.ValidateTest())

--- a/dataservices/service/service/standard.go
+++ b/dataservices/service/service/standard.go
@@ -174,18 +174,18 @@ func (s *Standard) initializeDataDeduplicatorFactory() error {
 		return app.ExtError(err, "service", "unable to create truncate data deduplicator factory")
 	}
 
-	s.Logger().Debug("Creating hash data deduplicator factory")
+	s.Logger().Debug("Creating hash-deactivate-old data deduplicator factory")
 
-	hashDeduplicatorFactory, err := deduplicator.NewHashFactory()
+	hashDeactivateOldDeduplicatorFactory, err := deduplicator.NewHashDeactivateOldFactory()
 	if err != nil {
-		return app.ExtError(err, "service", "unable to create hash data deduplicator factory")
+		return app.ExtError(err, "service", "unable to create hash-deactivate-old data deduplicator factory")
 	}
 
 	s.Logger().Debug("Creating data deduplicator factory")
 
 	factories := []deduplicator.Factory{
 		truncateDeduplicatorFactory,
-		hashDeduplicatorFactory,
+		hashDeactivateOldDeduplicatorFactory,
 	}
 
 	dataDeduplicatorFactory, err := deduplicator.NewDelegateFactory(factories)

--- a/test/mongo/mongo.go
+++ b/test/mongo/mongo.go
@@ -1,12 +1,13 @@
 package mongo
 
 import (
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
 	"fmt"
 	"math/rand"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	mgo "gopkg.in/mgo.v2"
 )
 


### PR DESCRIPTION
@jh-bate Move legacy testing package into data/type package. Required explicitly naming usage of the data/deduplicator/test package as testDataDeduplicator (to be consistent with other test package use).
