### PR TITLE
New deduplicators; add common base deduplicator; new vs existing deduplicators

### DIFF
--- a/.govetignore
+++ b/.govetignore
@@ -1,4 +1,7 @@
 app/error_test.go:21: no formatting directive in Errorf call
+data/deduplicator.go:49: no formatting directive in Errorf call
+data/deduplicator/base.go:151: no formatting directive in Errorf call
+data/deduplicator/delegate.go:99: no formatting directive in Errorf call
 store/mongo/mongo.go:93: no formatting directive in Errorf call
 userservices/client/standard.go:238: no formatting directive in Errorf call
 userservices/client/standard.go:312: no formatting directive in Errorf call

--- a/data/data_suite_test.go
+++ b/data/data_suite_test.go
@@ -1,4 +1,4 @@
-package types_test
+package data_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/types")
+	RunSpecs(t, "data")
 }

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -10,13 +10,45 @@ package data
  * [x] Full test coverage
  */
 
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+)
+
 type Deduplicator interface {
-	InitializeDataset() error
-	AddDataToDataset(datasetData []Datum) error
-	FinalizeDataset() error
+	Name() string
+
+	RegisterDataset() error
+
+	AddDatasetData(datasetData []Datum) error
+	DeduplicateDataset() error
+
+	DeleteDataset() error
 }
 
 type DeduplicatorDescriptor struct {
 	Name string `bson:"name,omitempty"`
 	Hash string `bson:"hash,omitempty"`
+}
+
+func NewDeduplicatorDescriptor() *DeduplicatorDescriptor {
+	return &DeduplicatorDescriptor{}
+}
+
+func (d *DeduplicatorDescriptor) IsRegisteredWithAnyDeduplicator() bool {
+	return d.Name != ""
+}
+
+func (d *DeduplicatorDescriptor) IsRegisteredWithNamedDeduplicator(name string) bool {
+	return d.Name == name
+}
+
+func (d *DeduplicatorDescriptor) RegisterWithNamedDeduplicator(name string) error {
+	if d.Name != "" {
+		return app.Errorf("data", "deduplicator descriptor already registered with %s", strconv.Quote(d.Name))
+	}
+
+	d.Name = name
+	return nil
 }

--- a/data/deduplicator/after_deactivate_old.go
+++ b/data/deduplicator/after_deactivate_old.go
@@ -1,0 +1,114 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type afterDeactivateOldFactory struct {
+	*BaseFactory
+}
+
+type afterDeactivateOldDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _AfterDeactivateOldDeduplicatorName = "after-deactivate-old"
+
+var _AfterDeactivateOldExpectedDeviceManufacturers = []string{"UNUSED"}
+
+func NewAfterDeactivateOldFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_AfterDeactivateOldDeduplicatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &afterDeactivateOldFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (a *afterDeactivateOldFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := a.BaseFactory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	if dataset.DeviceID == nil {
+		return false, nil
+	}
+	if *dataset.DeviceID == "" {
+		return false, nil
+	}
+	if dataset.DeviceManufacturers == nil {
+		return false, nil
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _AfterDeactivateOldExpectedDeviceManufacturers) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (a *afterDeactivateOldFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(a.name, logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataset.DeviceID == nil {
+		return nil, app.Error("deduplicator", "dataset device id is missing")
+	}
+	if *dataset.DeviceID == "" {
+		return nil, app.Error("deduplicator", "dataset device id is empty")
+	}
+	if dataset.DeviceManufacturers == nil {
+		return nil, app.Error("deduplicator", "dataset device manufacturers is missing")
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _AfterDeactivateOldExpectedDeviceManufacturers) {
+		return nil, app.Error("deduplicator", "dataset device manufacturers does not contain expected device manufacturers")
+	}
+
+	return &afterDeactivateOldDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (a *afterDeactivateOldDeduplicator) DeduplicateDataset() error {
+	afterTime, err := a.dataStoreSession.FindEarliestDatasetDataTime(a.dataset)
+	if err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to get earliest data in dataset with id %s", strconv.Quote(a.dataset.UploadID))
+	}
+
+	// TODO: Technically, ActivateDatasetData could succeed, but DeactivateOtherDatasetDataAfterTime fail. This would
+	// result in duplicate (and possible incorrect) data. Is there a way to resolve this? Would be nice to have transactions.
+
+	if err = a.BaseDeduplicator.DeduplicateDataset(); err != nil {
+		return err
+	}
+
+	if afterTime != "" {
+		if err = a.dataStoreSession.DeactivateOtherDatasetDataAfterTime(a.dataset, afterTime); err != nil {
+			return app.ExtErrorf(err, "deduplicator", "unable to remove all other data except dataset with id %s", strconv.Quote(a.dataset.UploadID))
+		}
+	}
+
+	return nil
+}

--- a/data/deduplicator/base.go
+++ b/data/deduplicator/base.go
@@ -1,0 +1,196 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type BaseFactory struct {
+	Factory
+	name string
+}
+
+type BaseDeduplicator struct {
+	name             string
+	logger           log.Logger
+	dataStoreSession store.Session
+	dataset          *upload.Upload
+}
+
+func NewBaseFactory(name string) (*BaseFactory, error) {
+	if name == "" {
+		return nil, app.Error("deduplicator", "name is missing")
+	}
+
+	factory := &BaseFactory{
+		name: name,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (b *BaseFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if dataset == nil {
+		return false, app.Error("deduplicator", "dataset is missing")
+	}
+
+	if dataset.UploadID == "" {
+		return false, nil
+	}
+	if dataset.UserID == "" {
+		return false, nil
+	}
+	if dataset.GroupID == "" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (b *BaseFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	return NewBaseDeduplicator(b.name, logger, dataStoreSession, dataset)
+}
+
+func (b *BaseFactory) IsRegisteredWithDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := b.Factory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	deduplicatorDescriptor := dataset.DeduplicatorDescriptor()
+	if deduplicatorDescriptor == nil {
+		return false, nil
+	}
+	if !deduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(b.name) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (b *BaseFactory) NewRegisteredDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	deduplicator, err := b.Factory.NewDeduplicatorForDataset(logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	deduplicatorDescriptor := dataset.DeduplicatorDescriptor()
+	if deduplicatorDescriptor == nil {
+		return nil, app.Error("deduplicator", "dataset deduplicator descriptor is missing")
+	}
+	if !deduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(b.name) {
+		return nil, app.Error("deduplicator", "dataset deduplicator descriptor is not registered with expected deduplicator")
+	}
+
+	return deduplicator, nil
+}
+
+func NewBaseDeduplicator(name string, logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (*BaseDeduplicator, error) {
+	if name == "" {
+		return nil, app.Error("deduplicator", "name is missing")
+	}
+	if logger == nil {
+		return nil, app.Error("deduplicator", "logger is missing")
+	}
+	if dataStoreSession == nil {
+		return nil, app.Error("deduplicator", "data store session is missing")
+	}
+	if dataset == nil {
+		return nil, app.Error("deduplicator", "dataset is missing")
+	}
+	if dataset.UploadID == "" {
+		return nil, app.Error("deduplicator", "dataset id is missing")
+	}
+	if dataset.UserID == "" {
+		return nil, app.Error("deduplicator", "dataset user id is missing")
+	}
+	if dataset.GroupID == "" {
+		return nil, app.Error("deduplicator", "dataset group id is missing")
+	}
+
+	logger = logger.WithFields(log.Fields{
+		"deduplicatorName": name,
+		"datasetId":        dataset.UploadID,
+	})
+
+	return &BaseDeduplicator{
+		name:             name,
+		logger:           logger,
+		dataStoreSession: dataStoreSession,
+		dataset:          dataset,
+	}, nil
+}
+
+func (b *BaseDeduplicator) Name() string {
+	return b.name
+}
+
+func (b *BaseDeduplicator) RegisterDataset() error {
+	b.logger.Debug("RegisterDataset")
+
+	deduplicatorDescriptor := b.dataset.DeduplicatorDescriptor()
+
+	if deduplicatorDescriptor == nil {
+		deduplicatorDescriptor = data.NewDeduplicatorDescriptor()
+	} else if deduplicatorDescriptor.IsRegisteredWithAnyDeduplicator() {
+		return app.Errorf("deduplicator", "already registered dataset with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+	deduplicatorDescriptor.RegisterWithNamedDeduplicator(b.name)
+
+	b.dataset.SetDeduplicatorDescriptor(deduplicatorDescriptor)
+
+	if err := b.dataStoreSession.UpdateDataset(b.dataset); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to update dataset with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}
+
+func (b *BaseDeduplicator) AddDatasetData(datasetData []data.Datum) error {
+	b.logger.WithField("datasetDataLength", len(datasetData)).Debug("AddDatasetData")
+
+	if len(datasetData) == 0 {
+		return nil
+	}
+
+	if err := b.dataStoreSession.CreateDatasetData(b.dataset, datasetData); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to create dataset data with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}
+
+func (b *BaseDeduplicator) DeduplicateDataset() error {
+	b.logger.Debug("DeduplicateDataset")
+
+	if err := b.dataStoreSession.ActivateDatasetData(b.dataset); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to activate dataset data with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}
+
+func (b *BaseDeduplicator) DeleteDataset() error {
+	b.logger.Debug("DeleteDataset")
+
+	if err := b.dataStoreSession.DeleteDataset(b.dataset); err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to delete dataset with id %s", strconv.Quote(b.dataset.UploadID))
+	}
+
+	return nil
+}

--- a/data/deduplicator/base_test.go
+++ b/data/deduplicator/base_test.go
@@ -1,0 +1,494 @@
+package deduplicator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+	"fmt"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/deduplicator"
+	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+var _ = Describe("Base", func() {
+	var testName string
+
+	BeforeEach(func() {
+		testName = app.NewID()
+	})
+
+	Context("BaseFactory", func() {
+		Context("NewBaseFactory", func() {
+			It("returns an error if the name is missing", func() {
+				testFactory, err := deduplicator.NewBaseFactory("")
+				Expect(err).To(MatchError("deduplicator: name is missing"))
+				Expect(testFactory).To(BeNil())
+			})
+
+			It("returns a new factory", func() {
+				testFactory, err := deduplicator.NewBaseFactory(testName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testFactory).ToNot(BeNil())
+				Expect(testFactory.Factory).ToNot(BeNil())
+			})
+		})
+
+		Context("with a new factory", func() {
+			var testFactory *deduplicator.BaseFactory
+			var testDataset *upload.Upload
+
+			BeforeEach(func() {
+				var err error
+				testFactory, err = deduplicator.NewBaseFactory(testName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testFactory).ToNot(BeNil())
+				testDataset = upload.Init()
+				Expect(testDataset).ToNot(BeNil())
+				testDataset.UserID = app.NewID()
+				testDataset.GroupID = app.NewID()
+			})
+
+			Context("CanDeduplicateDataset", func() {
+				It("returns an error if the dataset is missing", func() {
+					can, err := testFactory.CanDeduplicateDataset(nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(can).To(BeFalse())
+				})
+
+				It("returns false if the dataset id is missing", func() {
+					testDataset.UploadID = ""
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+				})
+
+				It("returns false if the dataset user id is missing", func() {
+					testDataset.UserID = ""
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+				})
+
+				It("returns false if the dataset group id is missing", func() {
+					testDataset.GroupID = ""
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+				})
+
+				It("returns true if successful", func() {
+					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+				})
+			})
+
+			Context("with logger and data store session", func() {
+				var testLogger log.Logger
+				var testDataStoreSession *testDataStore.Session
+
+				BeforeEach(func() {
+					testLogger = log.NewNull()
+					Expect(testLogger).ToNot(BeNil())
+					testDataStoreSession = testDataStore.NewSession()
+					Expect(testDataStoreSession).ToNot(BeNil())
+				})
+
+				AfterEach(func() {
+					Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				})
+
+				Context("NewDeduplicatorForDataset", func() {
+					It("returns an error if the logger is missing", func() {
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: logger is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the data store session is missing", func() {
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, nil, testDataset)
+						Expect(err).To(MatchError("deduplicator: data store session is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset is missing", func() {
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+						Expect(err).To(MatchError("deduplicator: dataset is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset id is missing", func() {
+						testDataset.UploadID = ""
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset user id is missing", func() {
+						testDataset.UserID = ""
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns an error if the dataset group id is missing", func() {
+						testDataset.GroupID = ""
+						testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+						Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+						Expect(testDeduplicator).To(BeNil())
+					})
+
+					It("returns a new deduplicator upon success", func() {
+						Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+					})
+				})
+			})
+
+			Context("with registered dataset", func() {
+				BeforeEach(func() {
+					testDataset.Deduplicator = data.NewDeduplicatorDescriptor()
+					testDataset.Deduplicator.RegisterWithNamedDeduplicator(testName)
+				})
+
+				Context("IsRegisteredWithDataset", func() {
+					It("returns an error if the dataset is missing", func() {
+						can, err := testFactory.IsRegisteredWithDataset(nil)
+						Expect(err).To(MatchError("deduplicator: dataset is missing"))
+						Expect(can).To(BeFalse())
+					})
+
+					It("returns false if the dataset id is missing", func() {
+						testDataset.UploadID = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the dataset user id is missing", func() {
+						testDataset.UserID = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the dataset group id is missing", func() {
+						testDataset.GroupID = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if there is no deduplicator descriptor", func() {
+						testDataset.Deduplicator = nil
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the deduplicator descriptor name is missing", func() {
+						testDataset.Deduplicator.Name = ""
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns false if the deduplicator descriptor name does not match", func() {
+						testDataset.Deduplicator.Name = app.NewID()
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					})
+
+					It("returns true if successful", func() {
+						Expect(testFactory.IsRegisteredWithDataset(testDataset)).To(BeTrue())
+					})
+				})
+
+				Context("with logger and data store session", func() {
+					var testLogger log.Logger
+					var testDataStoreSession *testDataStore.Session
+
+					BeforeEach(func() {
+						testLogger = log.NewNull()
+						Expect(testLogger).ToNot(BeNil())
+						testDataStoreSession = testDataStore.NewSession()
+						Expect(testDataStoreSession).ToNot(BeNil())
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+					})
+
+					Context("NewRegisteredDeduplicatorForDataset", func() {
+						It("returns an error if the logger is missing", func() {
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: logger is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the data store session is missing", func() {
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, nil, testDataset)
+							Expect(err).To(MatchError("deduplicator: data store session is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset is missing", func() {
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+							Expect(err).To(MatchError("deduplicator: dataset is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset id is missing", func() {
+							testDataset.UploadID = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset user id is missing", func() {
+							testDataset.UserID = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the dataset group id is missing", func() {
+							testDataset.GroupID = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if there is no deduplicator descriptor", func() {
+							testDataset.Deduplicator = nil
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset deduplicator descriptor is missing"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the deduplicator descriptor name is missing", func() {
+							testDataset.Deduplicator.Name = ""
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset deduplicator descriptor is not registered with expected deduplicator"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns an error if the deduplicator descriptor name does not match", func() {
+							testDataset.Deduplicator.Name = app.NewID()
+							testDeduplicator, err := testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+							Expect(err).To(MatchError("deduplicator: dataset deduplicator descriptor is not registered with expected deduplicator"))
+							Expect(testDeduplicator).To(BeNil())
+						})
+
+						It("returns a new deduplicator upon success", func() {
+							Expect(testFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+						})
+					})
+				})
+			})
+		})
+	})
+
+	Context("BaseDeduplicator", func() {
+		var testLogger log.Logger
+		var testDataStoreSession *testDataStore.Session
+		var testDataset *upload.Upload
+
+		BeforeEach(func() {
+			testLogger = log.NewNull()
+			Expect(testLogger).ToNot(BeNil())
+			testDataStoreSession = testDataStore.NewSession()
+			Expect(testDataStoreSession).ToNot(BeNil())
+			testDataset = upload.Init()
+			Expect(testDataset).ToNot(BeNil())
+			testDataset.UserID = app.NewID()
+			testDataset.GroupID = app.NewID()
+		})
+
+		AfterEach(func() {
+			Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+		})
+
+		Context("NewBaseDeduplicator", func() {
+			It("returns an error if the name is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator("", testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: name is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the logger is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, nil, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: logger is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the data store session is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, nil, testDataset)
+				Expect(err).To(MatchError("deduplicator: data store session is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, nil)
+				Expect(err).To(MatchError("deduplicator: dataset is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset id is missing", func() {
+				testDataset.UploadID = ""
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset user id is missing", func() {
+				testDataset.UserID = ""
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the dataset group id is missing", func() {
+				testDataset.GroupID = ""
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("successfully returns a new deduplicator", func() {
+				Expect(deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+			})
+		})
+
+		Context("with a new deduplicator", func() {
+			var testDeduplicator data.Deduplicator
+
+			BeforeEach(func() {
+				var err error
+				testDeduplicator, err = deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testDeduplicator).ToNot(BeNil())
+			})
+
+			Context("Name", func() {
+				It("returns the name", func() {
+					Expect(testDeduplicator.Name()).To(Equal(testName))
+				})
+			})
+
+			Context("RegisterDataset", func() {
+				It("returns an error if a deduplicator already registered dataset", func() {
+					testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: "test"})
+					err := testDeduplicator.RegisterDataset()
+					Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: already registered dataset with id "%s"`, testDataset.UploadID)))
+				})
+
+				Context("with updating dataset", func() {
+					BeforeEach(func() {
+						testDataStoreSession.UpdateDatasetOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
+					})
+
+					It("returns an error if there is an error with UpdateDataset", func() {
+						testDataStoreSession.UpdateDatasetOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.RegisterDataset()
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to update dataset with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.RegisterDataset()).To(Succeed())
+						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName}))
+					})
+
+					It("returns successfully even if there is a deduplicator description just without a name", func() {
+						testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Hash: "test"})
+						Expect(testDeduplicator.RegisterDataset()).To(Succeed())
+						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName, Hash: "test"}))
+					})
+				})
+			})
+
+			Context("AddDatasetData", func() {
+				var testDataData []*testData.Datum
+				var testDatasetData []data.Datum
+
+				BeforeEach(func() {
+					testDataData = []*testData.Datum{}
+					testDatasetData = []data.Datum{}
+					for i := 0; i < 3; i++ {
+						testDatum := testData.NewDatum()
+						testDataData = append(testDataData, testDatum)
+						testDatasetData = append(testDatasetData, testDatum)
+					}
+				})
+
+				AfterEach(func() {
+					for _, testDataDatum := range testDataData {
+						Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+					}
+				})
+
+				It("returns successfully if the data is missing", func() {
+					Expect(testDeduplicator.AddDatasetData(nil)).To(Succeed())
+				})
+
+				It("returns successfully if the data is empty", func() {
+					Expect(testDeduplicator.AddDatasetData([]data.Datum{})).To(Succeed())
+				})
+
+				Context("with creating dataset data", func() {
+					BeforeEach(func() {
+						testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{Dataset: testDataset, DatasetData: testDatasetData}))
+					})
+
+					It("returns an error if there is an error with CreateDatasetData", func() {
+						testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to create dataset data with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+					})
+				})
+			})
+
+			Context("DeduplicateDataset", func() {
+				Context("with activating dataset data", func() {
+					BeforeEach(func() {
+						testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
+					})
+
+					It("returns an error if there is an error with ActivateDatasetData", func() {
+						testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.DeduplicateDataset()
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to activate dataset data with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.DeduplicateDataset()).To(Succeed())
+					})
+				})
+			})
+
+			Context("DeleteDataset", func() {
+				Context("with deleting dataset", func() {
+					BeforeEach(func() {
+						testDataStoreSession.DeleteDatasetOutputs = []error{nil}
+					})
+
+					AfterEach(func() {
+						Expect(testDataStoreSession.DeleteDatasetInputs).To(ConsistOf(testDataset))
+					})
+
+					It("returns an error if there is an error with DeleteDataset", func() {
+						testDataStoreSession.DeleteDatasetOutputs = []error{errors.New("test error")}
+						err := testDeduplicator.DeleteDataset()
+						Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to delete dataset with id "%s"; test error`, testDataset.UploadID)))
+					})
+
+					It("returns successfully if there is no error", func() {
+						Expect(testDeduplicator.DeleteDataset()).To(Succeed())
+					})
+				})
+			})
+		})
+	})
+})

--- a/data/deduplicator/delegate_test.go
+++ b/data/deduplicator/delegate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"errors"
 
+	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
 	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
@@ -15,7 +16,7 @@ import (
 )
 
 var _ = Describe("Delegate", func() {
-	Context("NewFactory", func() {
+	Context("NewDelegateFactory", func() {
 		It("returns an error if factories is nil", func() {
 			testFactory, err := deduplicator.NewDelegateFactory(nil)
 			Expect(err).To(MatchError("deduplicator: factories is missing"))
@@ -37,7 +38,7 @@ var _ = Describe("Delegate", func() {
 		})
 	})
 
-	Context("with a new factory", func() {
+	Context("with a new delegate factory", func() {
 		var testFirstFactory *testDataDeduplicator.Factory
 		var testSecondFactory *testDataDeduplicator.Factory
 		var testDelegateFactory deduplicator.Factory
@@ -46,9 +47,7 @@ var _ = Describe("Delegate", func() {
 		BeforeEach(func() {
 			var err error
 			testFirstFactory = testDataDeduplicator.NewFactory()
-			testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			testSecondFactory = testDataDeduplicator.NewFactory()
-			testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			testDelegateFactory, err = deduplicator.NewDelegateFactory([]deduplicator.Factory{testFirstFactory, testSecondFactory})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testDelegateFactory).ToNot(BeNil())
@@ -61,128 +60,289 @@ var _ = Describe("Delegate", func() {
 			Expect(testFirstFactory.UnusedOutputsCount()).To(Equal(0))
 		})
 
-		Context("CanDeduplicateDataset", func() {
-			It("returns an error if the dataset is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				can, err := testDelegateFactory.CanDeduplicateDataset(nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(can).To(BeFalse())
+		Context("with unregistered dataset", func() {
+			BeforeEach(func() {
+				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
+				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: nil}}
 			})
 
-			It("returns an error if any contained factory returns an error", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
-				can, err := testDelegateFactory.CanDeduplicateDataset(testDataset)
-				Expect(err).To(MatchError("test error"))
-				Expect(can).To(BeFalse())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+			Context("CanDeduplicateDataset", func() {
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					can, err := testDelegateFactory.CanDeduplicateDataset(nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(can).To(BeFalse())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
+					can, err := testDelegateFactory.CanDeduplicateDataset(testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(can).To(BeFalse())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("return false if no factory can deduplicate the dataset", func() {
+					Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory can deduplicate the dataset", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(BeEmpty())
+				})
 			})
 
-			It("return false if no factory can deduplicate the dataset", func() {
-				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+			Context("NewDeduplicatorForDataset", func() {
+				var testLogger log.Logger
+				var testDataStoreSession *testDataStore.Session
 
-			It("returns true if any contained factory can deduplicate the dataset", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				BeforeEach(func() {
+					testLogger = log.NewNull()
+					Expect(testLogger).ToNot(BeNil())
+					testDataStoreSession = testDataStore.NewSession()
+					Expect(testDataStoreSession).ToNot(BeNil())
+				})
 
-			It("returns true if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				Expect(testDelegateFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(BeEmpty())
+				AfterEach(func() {
+					Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				})
+
+				It("returns an error if the logger is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: logger is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data store session is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, nil, testDataset)
+					Expect(err).To(MatchError("deduplicator: data store session is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns an error if no factory can deduplicate the dataset", func() {
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: deduplicator not found"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory can deduplicate the dataset", func() {
+					secondDeduplicator := testData.NewDeduplicator()
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testSecondFactory.NewDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewDeduplicatorForDatasetOutput{{Deduplicator: secondDeduplicator, Error: nil}}
+					Expect(testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
+					firstDeduplicator := testData.NewDeduplicator()
+					testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testFirstFactory.NewDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewDeduplicatorForDatasetOutput{{Deduplicator: firstDeduplicator, Error: nil}}
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
+					Expect(testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testFirstFactory.NewDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
+
+				It("returns an error if any contained factory can deduplicate the dataset, but returns an error when creating", func() {
+					testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
+					testSecondFactory.NewDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewDeduplicatorForDatasetOutput{{Deduplicator: nil, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.NewDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
 			})
 		})
 
-		Context("NewDeduplicator", func() {
-			var testLogger log.Logger
-			var testDataStoreSession *testDataStore.Session
-
+		Context("with registered dataset", func() {
 			BeforeEach(func() {
-				testLogger = log.NewNull()
-				testDataStoreSession = testDataStore.NewSession()
+				testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: nil}}
+				testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: nil}}
+				testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: "test"})
 			})
 
-			AfterEach(func() {
-				Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+			Context("IsRegisteredWithDataset", func() {
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					can, err := testDelegateFactory.IsRegisteredWithDataset(nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(can).To(BeFalse())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: errors.New("test error")}}
+					can, err := testDelegateFactory.IsRegisteredWithDataset(testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(can).To(BeFalse())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("return false if no factory is registered with the dataset", func() {
+					Expect(testDelegateFactory.IsRegisteredWithDataset(testDataset)).To(BeFalse())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory is registered with the dataset", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					Expect(testDelegateFactory.IsRegisteredWithDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns true if any contained factory is registered with the dataset even if a later factory returns an error", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					Expect(testDelegateFactory.IsRegisteredWithDataset(testDataset)).To(BeTrue())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(BeEmpty())
+				})
 			})
 
-			It("returns an error if the logger is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(nil, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("deduplicator: logger is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
+			Context("NewRegisteredDeduplicatorForDataset", func() {
+				var testLogger log.Logger
+				var testDataStoreSession *testDataStore.Session
 
-			It("returns an error if the data store session is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, nil, testDataset)
-				Expect(err).To(MatchError("deduplicator: data store session is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
+				BeforeEach(func() {
+					testLogger = log.NewNull()
+					testDataStoreSession = testDataStore.NewSession()
+					Expect(testDataStoreSession).ToNot(BeNil())
+				})
 
-			It("returns an error if the dataset is missing", func() {
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
+				AfterEach(func() {
+					Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				})
 
-			It("returns an error if any contained factory returns an error", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: false, Error: errors.New("test error")}}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("test error"))
-				Expect(deduplicator).To(BeNil())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				It("returns an error if the logger is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: logger is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns an error if no factory can deduplicate the dataset", func() {
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("deduplicator: deduplicator not found"))
-				Expect(deduplicator).To(BeNil())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				It("returns an error if the data store session is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, nil, testDataset)
+					Expect(err).To(MatchError("deduplicator: data store session is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns a deduplicator if any contained factory can deduplicate the dataset", func() {
-				secondDeduplicator := testData.NewDeduplicator()
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: secondDeduplicator, Error: nil}}
-				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-			})
+				It("returns an error if the dataset is missing", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns a deduplicator if any contained factory can deduplicate the dataset even if a later factory returns an error", func() {
-				firstDeduplicator := testData.NewDeduplicator()
-				testFirstFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testFirstFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: firstDeduplicator, Error: nil}}
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{}
-				Expect(testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testFirstFactory.NewDeduplicatorInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
-			})
+				It("returns an error if the dataset is not registered with a deduplicator", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDataset.SetDeduplicatorDescriptor(nil)
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset not registered with deduplicator"))
+					Expect(testDeduplicator).To(BeNil())
+				})
 
-			It("returns an error if any contained factory can deduplicate the dataset, but returns an error when creating", func() {
-				testSecondFactory.CanDeduplicateDatasetOutputs = []testDataDeduplicator.CanDeduplicateDatasetOutput{{Can: true, Error: nil}}
-				testSecondFactory.NewDeduplicatorOutputs = []testDataDeduplicator.NewDeduplicatorOutput{{Deduplicator: nil, Error: errors.New("test error")}}
-				deduplicator, err := testDelegateFactory.NewDeduplicator(testLogger, testDataStoreSession, testDataset)
-				Expect(err).To(MatchError("test error"))
-				Expect(deduplicator).To(BeNil())
-				Expect(testFirstFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.CanDeduplicateDatasetInputs).To(ConsistOf(testDataset))
-				Expect(testSecondFactory.NewDeduplicatorInputs).To(ConsistOf(testDataDeduplicator.NewDeduplicatorInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				It("returns an error if the dataset is not registered with a deduplicator with a name", func() {
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{})
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset not registered with deduplicator"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if any contained factory returns an error", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns an error if no factory is registered with the dataset", func() {
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: deduplicator not found"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory is registered with the dataset", func() {
+					secondDeduplicator := testData.NewDeduplicator()
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testSecondFactory.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: secondDeduplicator, Error: nil}}
+					Expect(testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(secondDeduplicator))
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+				})
+
+				It("returns a deduplicator if any contained factory is registered with the dataset even if a later factory returns an error", func() {
+					firstDeduplicator := testData.NewDeduplicator()
+					testFirstFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testFirstFactory.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: firstDeduplicator, Error: nil}}
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
+					Expect(testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).To(Equal(firstDeduplicator))
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testFirstFactory.NewRegisteredDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
+
+				It("returns an error if any contained factory is registered with the dataset, but returns an error when creating", func() {
+					testSecondFactory.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+					testSecondFactory.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: nil, Error: errors.New("test error")}}
+					testDeduplicator, err := testDelegateFactory.NewRegisteredDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("test error"))
+					Expect(testDeduplicator).To(BeNil())
+					Expect(testFirstFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.IsRegisteredWithDatasetInputs).To(ConsistOf(testDataset))
+					Expect(testSecondFactory.NewRegisteredDeduplicatorForDatasetInputs).To(ConsistOf(testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{Logger: testLogger, DataStoreSession: testDataStoreSession, Dataset: testDataset}))
+				})
 			})
 		})
 	})

--- a/data/deduplicator/factory.go
+++ b/data/deduplicator/factory.go
@@ -19,5 +19,8 @@ import (
 
 type Factory interface {
 	CanDeduplicateDataset(dataset *upload.Upload) (bool, error)
-	NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
+	NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
+
+	IsRegisteredWithDataset(dataset *upload.Upload) (bool, error)
+	NewRegisteredDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error)
 }

--- a/data/deduplicator/hash.go
+++ b/data/deduplicator/hash.go
@@ -1,154 +1,58 @@
 package deduplicator
 
 /* CHECKLIST
- * [ ] Uses interfaces as appropriate
- * [ ] Private package variables use underscore prefix
- * [ ] All parameters validated
- * [ ] All errors handled
- * [ ] Reviewed for concurrency safety
- * [ ] Code complete
- * [ ] Full test coverage
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
  */
 
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"strconv"
 	"strings"
 
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
-	"github.com/tidepool-org/platform/data/store"
-	"github.com/tidepool-org/platform/data/types/upload"
-	"github.com/tidepool-org/platform/log"
 )
 
-type HashFactory struct{}
+const _HashIdentityFieldsSeparator = "|"
 
-type HashDeduplicator struct {
-	logger           log.Logger
-	dataStoreSession store.Session
-	dataset          *upload.Upload
-}
-
-const HashDeduplicatorName = "hash"
-const HashIdentityFieldsSeparator = "|"
-
-func NewHashFactory() (*HashFactory, error) {
-	return &HashFactory{}, nil
-}
-
-func (h *HashFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
-	if dataset == nil {
-		return false, app.Error("deduplicator", "dataset is missing")
-	}
-
-	if dataset.Deduplicator != nil {
-		return dataset.Deduplicator.Name == HashDeduplicatorName, nil
-	}
-
-	if dataset.UploadID == "" || dataset.UserID == "" || dataset.GroupID == "" {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-func (h *HashFactory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
-	if logger == nil {
-		return nil, app.Error("deduplicator", "logger is missing")
-	}
-	if dataStoreSession == nil {
-		return nil, app.Error("deduplicator", "data store session is missing")
-	}
-	if dataset == nil {
-		return nil, app.Error("deduplicator", "dataset is missing")
-	}
-	if dataset.UploadID == "" {
-		return nil, app.Error("deduplicator", "dataset id is missing")
-	}
-	if dataset.UserID == "" {
-		return nil, app.Error("deduplicator", "dataset user id is missing")
-	}
-	if dataset.GroupID == "" {
-		return nil, app.Error("deduplicator", "dataset group id is missing")
-	}
-
-	return &HashDeduplicator{
-		logger:           logger,
-		dataStoreSession: dataStoreSession,
-		dataset:          dataset,
-	}, nil
-}
-
-func (h *HashDeduplicator) InitializeDataset() error {
-	h.dataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: HashDeduplicatorName})
-
-	if err := h.dataStoreSession.UpdateDataset(h.dataset); err != nil {
-		return app.ExtError(err, "deduplicator", "unable to initialize dataset")
-	}
-
-	return nil
-}
-
-func (h *HashDeduplicator) AddDataToDataset(datasetData []data.Datum) error {
-	if datasetData == nil {
-		return app.Error("deduplicator", "dataset data is missing")
-	}
-
+func AssignDatasetDataIdentityHashes(datasetData []data.Datum) ([]string, error) {
 	if len(datasetData) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	hashes := []string{}
 	for _, datasetDatum := range datasetData {
 		fields, err := datasetDatum.IdentityFields()
 		if err != nil {
-			return app.ExtError(err, "deduplicator", "unable to gather identity fields for datum")
+			return nil, app.ExtError(err, "deduplicator", "unable to gather identity fields for datum")
 		}
 
-		hash, err := generateIdentityHash(fields)
+		hash, err := GenerateIdentityHash(fields)
 		if err != nil {
-			return app.ExtError(err, "deduplicator", "unable to generate identity hash for datum")
+			return nil, app.ExtError(err, "deduplicator", "unable to generate identity hash for datum")
 		}
 
-		datasetDatum.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: HashDeduplicatorName, Hash: hash})
+		deduplicatorDescriptor := datasetDatum.DeduplicatorDescriptor()
+		if deduplicatorDescriptor == nil {
+			deduplicatorDescriptor = data.NewDeduplicatorDescriptor()
+		}
+		deduplicatorDescriptor.Hash = hash
+
+		datasetDatum.SetDeduplicatorDescriptor(deduplicatorDescriptor)
 
 		hashes = append(hashes, hash)
 	}
 
-	hashes, err := h.dataStoreSession.FindDatasetDataDeduplicatorHashes(h.dataset.UserID, hashes)
-	if err != nil {
-		return app.ExtError(err, "deduplicator", "unable to find existing identity hashes")
-	}
-
-	uniqueDatasetData := []data.Datum{}
-	for _, datasetDatum := range datasetData {
-		if !app.StringsContainsString(hashes, datasetDatum.DeduplicatorDescriptor().Hash) {
-			uniqueDatasetData = append(uniqueDatasetData, datasetDatum)
-		}
-	}
-
-	if len(uniqueDatasetData) == 0 {
-		return nil
-	}
-
-	if err = h.dataStoreSession.CreateDatasetData(h.dataset, uniqueDatasetData); err != nil {
-		return app.ExtError(err, "deduplicator", "unable to add data to dataset")
-	}
-
-	return nil
+	return hashes, nil
 }
 
-func (h *HashDeduplicator) FinalizeDataset() error {
-	if err := h.dataStoreSession.ActivateDatasetData(h.dataset); err != nil {
-		return app.ExtErrorf(err, "deduplicator", "unable to activate data in dataset with id %s", strconv.Quote(h.dataset.UploadID))
-	}
-
-	return nil
-}
-
-func generateIdentityHash(identityFields []string) (string, error) {
+func GenerateIdentityHash(identityFields []string) (string, error) {
 	if len(identityFields) == 0 {
 		return "", app.Error("deduplicator", "identity fields are missing")
 	}
@@ -159,7 +63,7 @@ func generateIdentityHash(identityFields []string) (string, error) {
 		}
 	}
 
-	identityString := strings.Join(identityFields, HashIdentityFieldsSeparator)
+	identityString := strings.Join(identityFields, _HashIdentityFieldsSeparator)
 	identitySum := sha256.Sum256([]byte(identityString))
 	identityHash := base64.StdEncoding.EncodeToString(identitySum[:])
 

--- a/data/deduplicator/hash_deactivate_old.go
+++ b/data/deduplicator/hash_deactivate_old.go
@@ -1,0 +1,142 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"strconv"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type hashDeactivateOldFactory struct {
+	*BaseFactory
+}
+
+type hashDeactivateOldDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _HashDeactivateOldDeduplicatorName = "hash-deactivate-old"
+
+var _HashDeactivateOldExpectedDeviceManufacturers = []string{"Medtronic"}
+
+func NewHashDeactivateOldFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_HashDeactivateOldDeduplicatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &hashDeactivateOldFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (h *hashDeactivateOldFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := h.BaseFactory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	if dataset.DeviceID == nil {
+		return false, nil
+	}
+	if *dataset.DeviceID == "" {
+		return false, nil
+	}
+	if dataset.DeviceManufacturers == nil {
+		return false, nil
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDeactivateOldExpectedDeviceManufacturers) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (h *hashDeactivateOldFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(h.name, logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataset.DeviceID == nil {
+		return nil, app.Error("deduplicator", "dataset device id is missing")
+	}
+	if *dataset.DeviceID == "" {
+		return nil, app.Error("deduplicator", "dataset device id is empty")
+	}
+	if dataset.DeviceManufacturers == nil {
+		return nil, app.Error("deduplicator", "dataset device manufacturers is missing")
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDeactivateOldExpectedDeviceManufacturers) {
+		return nil, app.Error("deduplicator", "dataset device manufacturers does not contain expected device manufacturers")
+	}
+
+	return &hashDeactivateOldDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (h *hashDeactivateOldDeduplicator) AddDatasetData(datasetData []data.Datum) error {
+	hashes, err := AssignDatasetDataIdentityHashes(datasetData)
+	if err != nil {
+		return err
+	} else if len(hashes) == 0 {
+		return nil
+	}
+
+	return h.BaseDeduplicator.AddDatasetData(datasetData)
+}
+
+func (h *hashDeactivateOldDeduplicator) DeduplicateDataset() error {
+	if err := h.setPreviousDatasetDataActiveUsingHashes(false); err != nil {
+		return err
+	}
+
+	return h.BaseDeduplicator.DeduplicateDataset()
+}
+
+func (h *hashDeactivateOldDeduplicator) DeleteDataset() error {
+	if err := h.setPreviousDatasetDataActiveUsingHashes(true); err != nil {
+		return err
+	}
+
+	return h.BaseDeduplicator.DeleteDataset()
+}
+
+func (h *hashDeactivateOldDeduplicator) setPreviousDatasetDataActiveUsingHashes(active bool) error {
+	previousDataset, err := h.dataStoreSession.FindPreviousActiveDatasetForDevice(h.dataset)
+	if err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to find previous dataset from dataset with id %s", strconv.Quote(h.dataset.UploadID))
+	} else if previousDataset == nil {
+		return nil
+	}
+
+	var hashes []string
+	hashes, err = h.dataStoreSession.GetDatasetDataDeduplicatorHashes(h.dataset, active)
+	if err != nil {
+		return app.ExtErrorf(err, "deduplicator", "unable to get dataset data deduplicator hashes from dataset with id %s", strconv.Quote(h.dataset.UploadID))
+	}
+
+	if len(hashes) > 0 {
+		if err = h.dataStoreSession.SetDatasetDataActiveUsingHashes(previousDataset, hashes, active); err != nil {
+			return app.ExtErrorf(err, "deduplicator", "unable to set dataset data active using hashes from dataset with id %s", strconv.Quote(previousDataset.UploadID))
+		}
+	}
+
+	return nil
+}

--- a/data/deduplicator/hash_deactivate_old_test.go
+++ b/data/deduplicator/hash_deactivate_old_test.go
@@ -1,0 +1,501 @@
+package deduplicator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+	"fmt"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/deduplicator"
+	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+var _ = Describe("HashDeactivateOld", func() {
+	Context("NewHashDeactivateOldFactory", func() {
+		It("returns a new factory", func() {
+			Expect(deduplicator.NewHashDeactivateOldFactory()).ToNot(BeNil())
+		})
+	})
+
+	Context("with a new factory", func() {
+		var testFactory deduplicator.Factory
+		var testUploadID string
+		var testUserID string
+		var testDataset *upload.Upload
+
+		BeforeEach(func() {
+			var err error
+			testFactory, err = deduplicator.NewHashDeactivateOldFactory()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testFactory).ToNot(BeNil())
+			testUploadID = app.NewID()
+			testUserID = app.NewID()
+			testDataset = upload.Init()
+			Expect(testDataset).ToNot(BeNil())
+			testDataset.UploadID = testUploadID
+			testDataset.UserID = testUserID
+			testDataset.GroupID = app.NewID()
+			testDataset.DeviceID = app.StringAsPointer(app.NewID())
+			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Medtronic"})
+		})
+
+		Context("CanDeduplicateDataset", func() {
+			It("returns an error if the dataset is missing", func() {
+				can, err := testFactory.CanDeduplicateDataset(nil)
+				Expect(err).To(MatchError("deduplicator: dataset is missing"))
+				Expect(can).To(BeFalse())
+			})
+
+			It("returns false if the dataset id is missing", func() {
+				testDataset.UploadID = ""
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the dataset user id is missing", func() {
+				testDataset.UserID = ""
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the dataset group id is missing", func() {
+				testDataset.GroupID = ""
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device id is missing", func() {
+				testDataset.DeviceID = nil
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device id is empty", func() {
+				testDataset.DeviceID = app.StringAsPointer("")
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device manufacturers is missing", func() {
+				testDataset.DeviceManufacturers = nil
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device manufacturers is empty", func() {
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{})
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns false if the device manufacturers does not contain expected device manufacturer", func() {
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Cobra"})
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
+			})
+
+			It("returns true if the device id and expected device manufacturer are specified", func() {
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+			})
+
+			It("returns true if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Medtronic", "Cobra"})
+				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
+			})
+		})
+
+		Context("with logger and data store session", func() {
+			var testLogger log.Logger
+			var testDataStoreSession *testDataStore.Session
+
+			BeforeEach(func() {
+				testLogger = log.NewNull()
+				Expect(testLogger).ToNot(BeNil())
+				testDataStoreSession = testDataStore.NewSession()
+				Expect(testDataStoreSession).ToNot(BeNil())
+			})
+
+			AfterEach(func() {
+				Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+			})
+
+			Context("NewDeduplicatorForDataset", func() {
+				It("returns an error if the logger is missing", func() {
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(nil, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: logger is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data store session is missing", func() {
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, nil, testDataset)
+					Expect(err).To(MatchError("deduplicator: data store session is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset is missing", func() {
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, nil)
+					Expect(err).To(MatchError("deduplicator: dataset is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset id is missing", func() {
+					testDataset.UploadID = ""
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset user id is missing", func() {
+					testDataset.UserID = ""
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset group id is missing", func() {
+					testDataset.GroupID = ""
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset device id is missing", func() {
+					testDataset.DeviceID = nil
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device id is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the dataset device id is empty", func() {
+					testDataset.DeviceID = app.StringAsPointer("")
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device id is empty"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the device manufacturers is missing", func() {
+					testDataset.DeviceManufacturers = nil
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device manufacturers is missing"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the device manufacturers is empty", func() {
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{})
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device manufacturers does not contain expected device manufacturers"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns an error if the device manufacturers does not contain expected device manufacturer", func() {
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Cobra"})
+					testDeduplicator, err := testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).To(MatchError("deduplicator: dataset device manufacturers does not contain expected device manufacturers"))
+					Expect(testDeduplicator).To(BeNil())
+				})
+
+				It("returns a new deduplicator upon success", func() {
+					Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+				})
+
+				It("returns a new deduplicator upon success if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Medtronic", "Cobra"})
+					Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+				})
+			})
+
+			Context("with a new deduplicator", func() {
+				var testDeduplicator data.Deduplicator
+				var testDataData []*testData.Datum
+				var testDatasetData []data.Datum
+
+				BeforeEach(func() {
+					var err error
+					testDeduplicator, err = testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testDeduplicator).ToNot(BeNil())
+					testDataData = []*testData.Datum{}
+					testDatasetData = []data.Datum{}
+					for i := 0; i < 3; i++ {
+						testDatum := testData.NewDatum()
+						testDataData = append(testDataData, testDatum)
+						testDatasetData = append(testDatasetData, testDatum)
+					}
+				})
+
+				AfterEach(func() {
+					for _, testDataDatum := range testDataData {
+						Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+					}
+				})
+
+				Context("AddDatasetData", func() {
+					It("returns successfully if the data is nil", func() {
+						Expect(testDeduplicator.AddDatasetData(nil)).To(Succeed())
+					})
+
+					It("returns successfully if there is no data", func() {
+						Expect(testDeduplicator.AddDatasetData([]data.Datum{})).To(Succeed())
+					})
+
+					It("returns an error if any datum returns an error getting identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
+					})
+
+					It("returns an error if any datum returns no identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns any empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
+					})
+
+					Context("with identity fields", func() {
+						BeforeEach(func() {
+							testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "0"}, Error: nil}}
+							testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "1"}, Error: nil}}
+							testDataData[2].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "2"}, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(testDataData[0].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg="}))
+							Expect(testDataData[1].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8="}))
+							Expect(testDataData[2].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78="}))
+						})
+
+						Context("with creating dataset data", func() {
+							BeforeEach(func() {
+								testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{
+									Dataset:     testDataset,
+									DatasetData: testDatasetData,
+								}))
+							})
+
+							It("returns an error if there is an error with CreateDatasetDataInput", func() {
+								testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
+								err := testDeduplicator.AddDatasetData(testDatasetData)
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to create dataset data with id "%s"; test error`, testDataset.UploadID)))
+							})
+
+							It("returns successfully if there is no error", func() {
+								Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+							})
+						})
+					})
+				})
+
+				Context("DeduplicateDataset", func() {
+					AssertWithCreatingDatasetData := func() {
+						Context("with creating dataset data", func() {
+							BeforeEach(func() {
+								testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
+							})
+
+							It("returns an error if there is an error with CreateDatasetData", func() {
+								testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
+								err := testDeduplicator.DeduplicateDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to activate dataset data with id "%s"; test error`, testUploadID)))
+							})
+
+							It("returns successfully if there is no error", func() {
+								Expect(testDeduplicator.DeduplicateDataset()).To(Succeed())
+							})
+						})
+					}
+
+					Context("with finding previous active dataset for device", func() {
+						var testPreviousDataset *upload.Upload
+
+						BeforeEach(func() {
+							testPreviousDataset = upload.Init()
+							Expect(testPreviousDataset).ToNot(BeNil())
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: testPreviousDataset, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(testDataStoreSession.FindPreviousActiveDatasetForDeviceInputs).To(Equal([]*upload.Upload{testDataset}))
+						})
+
+						It("returns an error if there is an error with FindPreviousActiveDatasetForDevice", func() {
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: errors.New("test error")}}
+							err := testDeduplicator.DeduplicateDataset()
+							Expect(err).To(MatchError(`deduplicator: unable to find previous dataset from dataset with id "` + testUploadID + `"; test error`))
+						})
+
+						Context("without previous dataset", func() {
+							BeforeEach(func() {
+								testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: nil}}
+							})
+
+							AssertWithCreatingDatasetData()
+						})
+
+						Context("with getting dataset data deduplicator hashes", func() {
+							var testHashes []string
+
+							BeforeEach(func() {
+								testHashes = []string{app.NewID(), app.NewID(), app.NewID()}
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: testHashes, Error: nil}}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.GetDatasetDataDeduplicatorHashesInputs).To(Equal([]testDataStore.GetDatasetDataDeduplicatorHashesInput{{Dataset: testDataset, Active: false}}))
+							})
+
+							It("returns an error if there is an error with GetDatasetDataDeduplicatorHashes", func() {
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: errors.New("test error")}}
+								err := testDeduplicator.DeduplicateDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to get dataset data deduplicator hashes from dataset with id "%s"; test error`, testUploadID)))
+							})
+
+							Context("without dataset data deduplicator hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: nil}}
+								})
+
+								AssertWithCreatingDatasetData()
+							})
+
+							Context("with set dataset data active using hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(testDataStoreSession.SetDatasetDataActiveUsingHashesInputs).To(Equal([]testDataStore.SetDatasetDataActiveUsingHashesInput{{Dataset: testPreviousDataset, Hashes: testHashes, Active: false}}))
+								})
+
+								It("returns an error if there is an error with SetDatasetDataActiveUsingHashes", func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{errors.New("test error")}
+									err := testDeduplicator.DeduplicateDataset()
+									Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to set dataset data active using hashes from dataset with id "%s"; test error`, testPreviousDataset.UploadID)))
+								})
+
+								AssertWithCreatingDatasetData()
+							})
+						})
+					})
+				})
+
+				Context("DeleteDataset", func() {
+					AssertWithDeletingDataset := func() {
+						Context("with deleting dataset", func() {
+							BeforeEach(func() {
+								testDataStoreSession.DeleteDatasetOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.DeleteDatasetInputs).To(ConsistOf(testDataset))
+							})
+
+							It("returns an error if there is an error with DeleteDataset", func() {
+								testDataStoreSession.DeleteDatasetOutputs = []error{errors.New("test error")}
+								err := testDeduplicator.DeleteDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to delete dataset with id "%s"; test error`, testUploadID)))
+							})
+
+							It("returns successfully if there is no error", func() {
+								Expect(testDeduplicator.DeleteDataset()).To(Succeed())
+							})
+						})
+					}
+
+					Context("with finding previous active dataset for device", func() {
+						var testPreviousDataset *upload.Upload
+
+						BeforeEach(func() {
+							testPreviousDataset = upload.Init()
+							Expect(testPreviousDataset).ToNot(BeNil())
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: testPreviousDataset, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(testDataStoreSession.FindPreviousActiveDatasetForDeviceInputs).To(Equal([]*upload.Upload{testDataset}))
+						})
+
+						It("returns an error if there is an error with FindPreviousActiveDatasetForDevice", func() {
+							testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: errors.New("test error")}}
+							err := testDeduplicator.DeleteDataset()
+							Expect(err).To(MatchError(`deduplicator: unable to find previous dataset from dataset with id "` + testUploadID + `"; test error`))
+						})
+
+						Context("without previous dataset", func() {
+							BeforeEach(func() {
+								testDataStoreSession.FindPreviousActiveDatasetForDeviceOutputs = []testDataStore.FindPreviousActiveDatasetForDeviceOutput{{Dataset: nil, Error: nil}}
+							})
+
+							AssertWithDeletingDataset()
+						})
+
+						Context("with getting dataset data deduplicator hashes", func() {
+							var testHashes []string
+
+							BeforeEach(func() {
+								testHashes = []string{app.NewID(), app.NewID(), app.NewID()}
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: testHashes, Error: nil}}
+							})
+
+							AfterEach(func() {
+								Expect(testDataStoreSession.GetDatasetDataDeduplicatorHashesInputs).To(Equal([]testDataStore.GetDatasetDataDeduplicatorHashesInput{{Dataset: testDataset, Active: true}}))
+							})
+
+							It("returns an error if there is an error with GetDatasetDataDeduplicatorHashes", func() {
+								testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: errors.New("test error")}}
+								err := testDeduplicator.DeleteDataset()
+								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to get dataset data deduplicator hashes from dataset with id "%s"; test error`, testUploadID)))
+							})
+
+							Context("without dataset data deduplicator hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.GetDatasetDataDeduplicatorHashesOutputs = []testDataStore.GetDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: nil}}
+								})
+
+								AssertWithDeletingDataset()
+							})
+
+							Context("with set dataset data active using hashes", func() {
+								BeforeEach(func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(testDataStoreSession.SetDatasetDataActiveUsingHashesInputs).To(Equal([]testDataStore.SetDatasetDataActiveUsingHashesInput{{Dataset: testPreviousDataset, Hashes: testHashes, Active: true}}))
+								})
+
+								It("returns an error if there is an error with SetDatasetDataActiveUsingHashes", func() {
+									testDataStoreSession.SetDatasetDataActiveUsingHashesOutputs = []error{errors.New("test error")}
+									err := testDeduplicator.DeleteDataset()
+									Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to set dataset data active using hashes from dataset with id "%s"; test error`, testPreviousDataset.UploadID)))
+								})
+
+								AssertWithDeletingDataset()
+							})
+						})
+					})
+				})
+			})
+		})
+	})
+})

--- a/data/deduplicator/hash_drop_new.go
+++ b/data/deduplicator/hash_drop_new.go
@@ -1,0 +1,113 @@
+package deduplicator
+
+/* CHECKLIST
+ * [x] Uses interfaces as appropriate
+ * [x] Private package variables use underscore prefix
+ * [x] All parameters validated
+ * [x] All errors handled
+ * [x] Reviewed for concurrency safety
+ * [x] Code complete
+ * [x] Full test coverage
+ */
+
+import (
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
+)
+
+type hashDropNewFactory struct {
+	*BaseFactory
+}
+
+type hashDropNewDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _HashDropNewDeduplicatorName = "hash-drop-new"
+
+var _HashDropNewExpectedDeviceManufacturers = []string{"UNUSED"}
+
+func NewHashDropNewFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_HashDropNewDeduplicatorName)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &hashDropNewFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (h *hashDropNewFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
+	if can, err := h.BaseFactory.CanDeduplicateDataset(dataset); err != nil || !can {
+		return can, err
+	}
+
+	if dataset.DeviceID == nil {
+		return false, nil
+	}
+	if *dataset.DeviceID == "" {
+		return false, nil
+	}
+	if dataset.DeviceManufacturers == nil {
+		return false, nil
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDropNewExpectedDeviceManufacturers) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (h *hashDropNewFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(h.name, logger, dataStoreSession, dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataset.DeviceID == nil {
+		return nil, app.Error("deduplicator", "dataset device id is missing")
+	}
+	if *dataset.DeviceID == "" {
+		return nil, app.Error("deduplicator", "dataset device id is empty")
+	}
+	if dataset.DeviceManufacturers == nil {
+		return nil, app.Error("deduplicator", "dataset device manufacturers is missing")
+	}
+	if !app.StringsContainsAnyStrings(*dataset.DeviceManufacturers, _HashDropNewExpectedDeviceManufacturers) {
+		return nil, app.Error("deduplicator", "dataset device manufacturers does not contain expected device manufacturers")
+	}
+
+	return &hashDropNewDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (h *hashDropNewDeduplicator) AddDatasetData(datasetData []data.Datum) error {
+	hashes, err := AssignDatasetDataIdentityHashes(datasetData)
+	if err != nil {
+		return err
+	} else if len(hashes) == 0 {
+		return nil
+	}
+
+	hashes, err = h.dataStoreSession.FindAllDatasetDataDeduplicatorHashesForDevice(h.dataset.UserID, *h.dataset.DeviceID, hashes)
+	if err != nil {
+		return app.ExtError(err, "deduplicator", "unable to find all dataset data deduplicator hashes for device")
+	}
+
+	uniqueDatasetData := []data.Datum{}
+	for _, datasetDatum := range datasetData {
+		if !app.StringsContainsString(hashes, datasetDatum.DeduplicatorDescriptor().Hash) {
+			uniqueDatasetData = append(uniqueDatasetData, datasetDatum)
+		}
+	}
+
+	return h.BaseDeduplicator.AddDatasetData(uniqueDatasetData)
+}

--- a/data/deduplicator/hash_drop_new_test.go
+++ b/data/deduplicator/hash_drop_new_test.go
@@ -11,32 +11,37 @@ import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/upload"
 	"github.com/tidepool-org/platform/log"
 )
 
-var _ = Describe("Truncate", func() {
-	Context("NewTruncateFactory", func() {
+var _ = Describe("HashDropNew", func() {
+	Context("NewHashDropNewFactory", func() {
 		It("returns a new factory", func() {
-			Expect(deduplicator.NewTruncateFactory()).ToNot(BeNil())
+			Expect(deduplicator.NewHashDropNewFactory()).ToNot(BeNil())
 		})
 	})
 
 	Context("with a new factory", func() {
 		var testFactory deduplicator.Factory
+		var testUserID string
+		var testDeviceID string
 		var testDataset *upload.Upload
 
 		BeforeEach(func() {
 			var err error
-			testFactory, err = deduplicator.NewTruncateFactory()
+			testFactory, err = deduplicator.NewHashDropNewFactory()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testFactory).ToNot(BeNil())
+			testUserID = app.NewID()
+			testDeviceID = app.NewID()
 			testDataset = upload.Init()
 			Expect(testDataset).ToNot(BeNil())
-			testDataset.UserID = app.NewID()
+			testDataset.UserID = testUserID
 			testDataset.GroupID = app.NewID()
-			testDataset.DeviceID = app.StringAsPointer(app.NewID())
-			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Animas"})
+			testDataset.DeviceID = app.StringAsPointer(testDeviceID)
+			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"UNUSED"})
 		})
 
 		Context("CanDeduplicateDataset", func() {
@@ -91,7 +96,7 @@ var _ = Describe("Truncate", func() {
 			})
 
 			It("returns true if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
-				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Animas", "Cobra"})
+				testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "UNUSED", "Cobra"})
 				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
 			})
 		})
@@ -191,7 +196,7 @@ var _ = Describe("Truncate", func() {
 				})
 
 				It("returns a new deduplicator upon success if the device id and expected device manufacturer are specified with multiple device manufacturers", func() {
-					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "Animas", "Cobra"})
+					testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Ant", "Zebra", "UNUSED", "Cobra"})
 					Expect(testFactory.NewDeduplicatorForDataset(testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
 				})
 			})
@@ -206,39 +211,139 @@ var _ = Describe("Truncate", func() {
 					Expect(testDeduplicator).ToNot(BeNil())
 				})
 
-				Context("DeduplicateDataset", func() {
-					Context("with activating dataset data", func() {
+				Context("AddDatasetData", func() {
+					var testDataData []*testData.Datum
+					var testDatasetData []data.Datum
+
+					BeforeEach(func() {
+						testDataData = []*testData.Datum{}
+						testDatasetData = []data.Datum{}
+						for i := 0; i < 3; i++ {
+							testDatum := testData.NewDatum()
+							testDataData = append(testDataData, testDatum)
+							testDatasetData = append(testDatasetData, testDatum)
+						}
+					})
+
+					AfterEach(func() {
+						for _, testDataDatum := range testDataData {
+							Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+						}
+					})
+
+					It("returns successfully if the data is nil", func() {
+						Expect(testDeduplicator.AddDatasetData(nil)).To(Succeed())
+					})
+
+					It("returns successfully if there is no data", func() {
+						Expect(testDeduplicator.AddDatasetData([]data.Datum{})).To(Succeed())
+					})
+
+					It("returns an error if any datum returns an error getting identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
+					})
+
+					It("returns an error if any datum returns no identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+					})
+
+					It("returns an error if any datum returns any empty identity fields", func() {
+						testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+						testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
+						err := testDeduplicator.AddDatasetData(testDatasetData)
+						Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
+					})
+
+					Context("with identity fields", func() {
 						BeforeEach(func() {
-							testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
+							testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "0"}, Error: nil}}
+							testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "1"}, Error: nil}}
+							testDataData[2].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "2"}, Error: nil}}
 						})
 
 						AfterEach(func() {
-							Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
+							Expect(testDataData[0].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg="}))
+							Expect(testDataData[1].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8="}))
+							Expect(testDataData[2].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78="}))
 						})
 
-						It("returns an error if there is an error with ActivateDatasetData", func() {
-							testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
-							err := testDeduplicator.DeduplicateDataset()
-							Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to activate dataset data with id "%s"; test error`, testDataset.UploadID)))
-						})
-
-						Context("with deleting other dataset data", func() {
+						Context("with finding all dataset data deduplicator hashes for device", func() {
 							BeforeEach(func() {
-								testDataStoreSession.DeleteOtherDatasetDataOutputs = []error{nil}
+								testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = []testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceOutput{{
+									Hashes: []string{
+										"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+									},
+									Error: nil,
+								}}
 							})
 
 							AfterEach(func() {
-								Expect(testDataStoreSession.DeleteOtherDatasetDataInputs).To(ConsistOf(testDataset))
+								Expect(testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceInputs).To(Equal([]testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceInput{{
+									UserID:   testUserID,
+									DeviceID: testDeviceID,
+									Hashes: []string{
+										"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
+										"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+										"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
+									},
+								}}))
 							})
 
-							It("returns an error if there is an error with DeleteOtherDatasetData", func() {
-								testDataStoreSession.DeleteOtherDatasetDataOutputs = []error{errors.New("test error")}
-								err := testDeduplicator.DeduplicateDataset()
-								Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to remove all other data except dataset with id "%s"; test error`, testDataset.UploadID)))
+							It("returns an error if finding all dataset data deduplicator hashes for device returns an error", func() {
+								testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = []testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceOutput{{Hashes: nil, Error: errors.New("test error")}}
+								err := testDeduplicator.AddDatasetData(testDatasetData)
+								Expect(err).To(MatchError("deduplicator: unable to find all dataset data deduplicator hashes for device; test error"))
 							})
 
-							It("returns successfully if there is no error", func() {
-								Expect(testDeduplicator.DeduplicateDataset()).To(Succeed())
+							It("returns success if finding all dataset data deduplicator hashes for device returns all hashes", func() {
+								testDataStoreSession.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = []testDataStore.FindAllDatasetDataDeduplicatorHashesForDeviceOutput{{
+									Hashes: []string{
+										"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
+										"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+										"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
+									},
+									Error: nil,
+								}}
+								Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+							})
+
+							Context("with creating dataset data", func() {
+								BeforeEach(func() {
+									testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{
+										Dataset: testDataset,
+										DatasetData: []data.Datum{
+											testDataData[0],
+											testDataData[2],
+										},
+									}))
+								})
+
+								It("returns an error if there is an error with CreateDatasetDataInput", func() {
+									testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
+									err := testDeduplicator.AddDatasetData(testDatasetData)
+									Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: unable to create dataset data with id "%s"; test error`, testDataset.UploadID)))
+								})
+
+								It("returns successfully if there is no error", func() {
+									Expect(testDeduplicator.AddDatasetData(testDatasetData)).To(Succeed())
+								})
 							})
 						})
 					})

--- a/data/deduplicator/hash_test.go
+++ b/data/deduplicator/hash_test.go
@@ -1,339 +1,138 @@
 package deduplicator_test
 
 import (
-	"errors"
-	"strconv"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"errors"
 
 	"github.com/tidepool-org/platform/app"
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
-	testDataStore "github.com/tidepool-org/platform/data/store/test"
 	testData "github.com/tidepool-org/platform/data/test"
-	"github.com/tidepool-org/platform/data/types/upload"
-	"github.com/tidepool-org/platform/log"
 )
 
 var _ = Describe("Hash", func() {
-	Context("NewFactory", func() {
-		It("returns a new factory", func() {
-			Expect(deduplicator.NewHashFactory()).ToNot(BeNil())
-		})
-	})
-
-	Context("with a new factory", func() {
-		var testFactory deduplicator.Factory
-		var userID string
-		var testDataset *upload.Upload
+	Context("AssignDatasetDataIdentityHashes", func() {
+		var testDataData []*testData.Datum
+		var testDatasetData []data.Datum
 
 		BeforeEach(func() {
-			var err error
-			testFactory, err = deduplicator.NewHashFactory()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(testFactory).ToNot(BeNil())
-			userID = app.NewID()
-			testDataset = upload.Init()
-			Expect(testDataset).ToNot(BeNil())
-			testDataset.UserID = userID
-			testDataset.GroupID = app.NewID()
-			testDataset.DeviceID = app.StringAsPointer(app.NewID())
-			testDataset.DeviceManufacturers = app.StringArrayAsPointer([]string{"Medtronic"})
+			testDataData = []*testData.Datum{}
+			testDatasetData = []data.Datum{}
+			for i := 0; i < 3; i++ {
+				testDatum := testData.NewDatum()
+				testDataData = append(testDataData, testDatum)
+				testDatasetData = append(testDatasetData, testDatum)
+			}
 		})
 
-		Context("CanDeduplicateDataset", func() {
-			It("returns an error if the dataset is missing", func() {
-				can, err := testFactory.CanDeduplicateDataset(nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(can).To(BeFalse())
-			})
-
-			Context("with deduplicator", func() {
-				BeforeEach(func() {
-					testDataset.Deduplicator = &data.DeduplicatorDescriptor{Name: "hash"}
-				})
-
-				It("returns false if the deduplicator name is empty", func() {
-					testDataset.Deduplicator.Name = ""
-					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-				})
-
-				It("returns false if the deduplicator name does not match", func() {
-					testDataset.Deduplicator.Name = "not-hash"
-					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-				})
-
-				It("returns true if the deduplicator name does match", func() {
-					Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-				})
-			})
-
-			It("returns false if the dataset id is missing", func() {
-				testDataset.UploadID = ""
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-			})
-
-			It("returns false if the user id is missing", func() {
-				testDataset.UserID = ""
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-			})
-
-			It("returns false if the group id is missing", func() {
-				testDataset.GroupID = ""
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeFalse())
-			})
-
-			It("returns true if dataset id, user id, and group id are specified", func() {
-				Expect(testFactory.CanDeduplicateDataset(testDataset)).To(BeTrue())
-			})
+		AfterEach(func() {
+			for _, testDataDatum := range testDataData {
+				Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
+			}
 		})
 
-		Context("NewDeduplicator", func() {
-			It("returns an error if the logger is missing", func() {
-				testDeduplicator, err := testFactory.NewDeduplicator(nil, testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: logger is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the data store session is missing", func() {
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), nil, testDataset)
-				Expect(err).To(MatchError("deduplicator: data store session is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset is missing", func() {
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), nil)
-				Expect(err).To(MatchError("deduplicator: dataset is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset id is missing", func() {
-				testDataset.UploadID = ""
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: dataset id is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset user id is missing", func() {
-				testDataset.UserID = ""
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns an error if the dataset group id is missing", func() {
-				testDataset.GroupID = ""
-				testDeduplicator, err := testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)
-				Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
-				Expect(testDeduplicator).To(BeNil())
-			})
-
-			It("returns a new deduplicator upon success", func() {
-				Expect(testFactory.NewDeduplicator(log.NewNull(), testDataStore.NewSession(), testDataset)).ToNot(BeNil())
-			})
+		It("returns successfully if the data is nil", func() {
+			Expect(deduplicator.AssignDatasetDataIdentityHashes(nil)).To(BeNil())
 		})
 
-		Context("with a new deduplicator", func() {
-			var testDataStoreSession *testDataStore.Session
-			var testDeduplicator data.Deduplicator
+		It("returns successfully if there is no data", func() {
+			Expect(deduplicator.AssignDatasetDataIdentityHashes([]data.Datum{})).To(BeNil())
+		})
 
+		It("returns an error if any datum returns an error getting identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
+			Expect(hashes).To(BeNil())
+		})
+
+		It("returns an error if any datum returns no identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+			Expect(hashes).To(BeNil())
+		})
+
+		It("returns an error if any datum returns empty identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
+			Expect(hashes).To(BeNil())
+		})
+
+		It("returns an error if any datum returns any empty identity fields", func() {
+			testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
+			testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
+			hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+			Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
+			Expect(hashes).To(BeNil())
+		})
+
+		Context("with identity fields", func() {
 			BeforeEach(func() {
-				var err error
-				testDataStoreSession = testDataStore.NewSession()
-				testDeduplicator, err = testFactory.NewDeduplicator(log.NewNull(), testDataStoreSession, testDataset)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(testDeduplicator).ToNot(BeNil())
+				testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "0"}, Error: nil}}
+				testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "1"}, Error: nil}}
+				testDataData[2].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", "2"}, Error: nil}}
 			})
 
 			AfterEach(func() {
-				Expect(testDataStoreSession.UnusedOutputsCount()).To(Equal(0))
+				Expect(testDataData[0].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg="}))
+				Expect(testDataData[1].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8="}))
+				Expect(testDataData[2].DeduplicatorDescriptorValue).To(Equal(&data.DeduplicatorDescriptor{Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78="}))
 			})
 
-			Context("InitializeDataset", func() {
-				It("returns an error if there is an error", func() {
-					testDataStoreSession.UpdateDatasetOutputs = []error{errors.New("test error")}
-					err := testDeduplicator.InitializeDataset()
-					Expect(err).To(MatchError("deduplicator: unable to initialize dataset; test error"))
-					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
-				})
-
-				It("returns successfully if there is no error", func() {
-					testDataStoreSession.UpdateDatasetOutputs = []error{nil}
-					Expect(testDeduplicator.InitializeDataset()).To(Succeed())
-					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
-				})
-
-				It("sets the dataset deduplicator if there is no error", func() {
-					testDataStoreSession.UpdateDatasetOutputs = []error{nil}
-					Expect(testDeduplicator.InitializeDataset()).To(Succeed())
-					Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: "hash"}))
-					Expect(testDataStoreSession.UpdateDatasetInputs).To(ConsistOf(testDataset))
-				})
+			It("returns successfully", func() {
+				hashes, err := deduplicator.AssignDatasetDataIdentityHashes(testDatasetData)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hashes).To(Equal([]string{
+					"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
+					"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
+					"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
+				}))
 			})
+		})
+	})
 
-			Context("AddDataToDataset", func() {
-				var testDataData []*testData.Datum
-				var testDatasetData []data.Datum
+	Context("GenerateIdentityHash", func() {
+		It("returns an error if identity fields is missing", func() {
+			hash, err := deduplicator.GenerateIdentityHash(nil)
+			Expect(err).To(MatchError("deduplicator: identity fields are missing"))
+			Expect(hash).To(Equal(""))
+		})
 
-				BeforeEach(func() {
-					testDataData = []*testData.Datum{}
-					testDatasetData = []data.Datum{}
-					for i := 0; i < 3; i++ {
-						testDatum := testData.NewDatum()
-						testDataData = append(testDataData, testDatum)
-						testDatasetData = append(testDatasetData, testDatum)
-					}
-				})
+		It("returns an error if identity fields is empty", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{})
+			Expect(err).To(MatchError("deduplicator: identity fields are missing"))
+			Expect(hash).To(Equal(""))
+		})
 
-				AfterEach(func() {
-					for _, testDataDatum := range testDataData {
-						Expect(testDataDatum.UnusedOutputsCount()).To(Equal(0))
-					}
-				})
+		It("returns an error if an identity fields empty", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"alpha", "", "charlie"})
+			Expect(err).To(MatchError("deduplicator: identity field is empty"))
+			Expect(hash).To(Equal(""))
+		})
 
-				It("returns an error if the dataset is missing", func() {
-					err := testDeduplicator.AddDataToDataset(nil)
-					Expect(err).To(MatchError("deduplicator: dataset data is missing"))
-				})
+		It("successfully returns a hash with one identity field", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"zero"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal("+RlOc/npRZ40UOoQoXnN93qvppW+7NO5NEqY0RFiIkM="))
+		})
 
-				It("returns successfully if there is no data", func() {
-					Expect(testDeduplicator.AddDataToDataset([]data.Datum{})).To(Succeed())
-				})
+		It("successfully returns a hash with three identity fields", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"alpha", "bravo", "charlie"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal("dO3wei6LXqnM+oEql2hguPTmyM0+QnmIZPyxzlvL2xY="))
+		})
 
-				It("returns an error if any datum returns an error getting identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to gather identity fields for datum; test error"))
-				})
-
-				It("returns an error if any datum returns no identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
-				})
-
-				It("returns an error if any datum returns empty identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity fields are missing"))
-				})
-
-				It("returns an error if any datum returns any empty identity fields", func() {
-					testDataData[0].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), app.NewID()}, Error: nil}}
-					testDataData[1].IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{app.NewID(), ""}, Error: nil}}
-					err := testDeduplicator.AddDataToDataset(testDatasetData)
-					Expect(err).To(MatchError("deduplicator: unable to generate identity hash for datum; deduplicator: identity field is empty"))
-				})
-
-				Context("with identity fields", func() {
-					BeforeEach(func() {
-						for index, testDataDatum := range testDataData {
-							testDataDatum.IdentityFieldsOutputs = []testData.IdentityFieldsOutput{{IdentityFields: []string{"test", strconv.Itoa(index)}, Error: nil}}
-						}
-						testDataStoreSession.FindDatasetDataDeduplicatorHashesOutputs = []testDataStore.FindDatasetDataDeduplicatorHashesOutput{{
-							Hashes: []string{
-								"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-							},
-							Error: nil,
-						}}
-					})
-
-					AfterEach(func() {
-						for _, testDataDatum := range testDataData {
-							Expect(testDataDatum.SetDeduplicatorDescriptorInputs).To(HaveLen(1))
-							Expect(testDataDatum.SetDeduplicatorDescriptorInputs[0].Name).To(Equal("hash"))
-							Expect(testDataDatum.SetDeduplicatorDescriptorInputs[0].Hash).ToNot(BeEmpty())
-						}
-						Expect(testDataStoreSession.FindDatasetDataDeduplicatorHashesInputs).To(Equal([]testDataStore.FindDatasetDataDeduplicatorHashesInput{{
-							UserID: userID,
-							Hashes: []string{
-								"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-								"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
-								"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
-							},
-						}}))
-					})
-
-					It("returns an error if finding deduplicator hashes returns an error", func() {
-						testDataStoreSession.FindDatasetDataDeduplicatorHashesOutputs = []testDataStore.FindDatasetDataDeduplicatorHashesOutput{{Hashes: nil, Error: errors.New("test error")}}
-						err := testDeduplicator.AddDataToDataset(testDatasetData)
-						Expect(err).To(MatchError("deduplicator: unable to find existing identity hashes; test error"))
-					})
-
-					Context("with deduplicator descriptor", func() {
-						BeforeEach(func() {
-							testDataData[0].DeduplicatorDescriptorOutputs = []*data.DeduplicatorDescriptor{{
-								Name: "hash",
-								Hash: "GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-							}}
-							testDataData[1].DeduplicatorDescriptorOutputs = []*data.DeduplicatorDescriptor{{
-								Name: "hash",
-								Hash: "+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
-							}}
-							testDataData[2].DeduplicatorDescriptorOutputs = []*data.DeduplicatorDescriptor{{
-								Name: "hash",
-								Hash: "dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
-							}}
-						})
-
-						It("returns success if finding deduplicator hashes returns all hashes", func() {
-							testDataStoreSession.FindDatasetDataDeduplicatorHashesOutputs = []testDataStore.FindDatasetDataDeduplicatorHashesOutput{{
-								Hashes: []string{
-									"GRp47M02cMlAzSn7oJTQ2LC9eb1Qd6mIPO1U8GeuoYg=",
-									"+cywqM0rcj9REPt87Vfx2U+j9m57cB0XW2kmNZm5Ao8=",
-									"dCPMoOxFVMbPvMkXMbyKeff8QmdBPu8hr/BVeHJhz78=",
-								},
-								Error: nil,
-							}}
-							Expect(testDeduplicator.AddDataToDataset(testDatasetData)).To(Succeed())
-						})
-
-						Context("with creating dataset data", func() {
-							AfterEach(func() {
-								Expect(testDataStoreSession.CreateDatasetDataInputs).To(ConsistOf(testDataStore.CreateDatasetDataInput{
-									Dataset: testDataset,
-									DatasetData: []data.Datum{
-										testDataData[1],
-										testDataData[2],
-									},
-								}))
-							})
-
-							It("returns an error if there is an error with CreateDatasetDataInput", func() {
-								testDataStoreSession.CreateDatasetDataOutputs = []error{errors.New("test error")}
-								err := testDeduplicator.AddDataToDataset(testDatasetData)
-								Expect(err).To(MatchError("deduplicator: unable to add data to dataset; test error"))
-							})
-
-							It("returns successfully if there is no error", func() {
-								testDataStoreSession.CreateDatasetDataOutputs = []error{nil}
-								Expect(testDeduplicator.AddDataToDataset(testDatasetData)).To(Succeed())
-							})
-						})
-					})
-				})
-			})
-
-			Context("FinalizeDataset", func() {
-				It("returns an error if there is an error on activate", func() {
-					uploadID := app.NewID()
-					testDataset.UploadID = uploadID
-					testDataStoreSession.ActivateDatasetDataOutputs = []error{errors.New("test error")}
-					err := testDeduplicator.FinalizeDataset()
-					Expect(err).To(MatchError(`deduplicator: unable to activate data in dataset with id "` + uploadID + `"; test error`))
-					Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
-				})
-
-				It("returns successfully if there is no error", func() {
-					testDataStoreSession.ActivateDatasetDataOutputs = []error{nil}
-					Expect(testDeduplicator.FinalizeDataset()).To(Succeed())
-					Expect(testDataStoreSession.ActivateDatasetDataInputs).To(ConsistOf(testDataset))
-				})
-			})
+		It("successfully returns a hash with five identity fields", func() {
+			hash, err := deduplicator.GenerateIdentityHash([]string{"one", "two", "three", "four", "five"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(Equal("8HUIFZUXmOuySpngHvl+fJECoeELTiCRxwNxxgDzmVQ="))
 		})
 	})
 })

--- a/data/deduplicator/test/factory.go
+++ b/data/deduplicator/test/factory.go
@@ -13,25 +13,47 @@ type CanDeduplicateDatasetOutput struct {
 	Error error
 }
 
-type NewDeduplicatorInput struct {
+type NewDeduplicatorForDatasetInput struct {
 	Logger           log.Logger
 	DataStoreSession store.Session
 	Dataset          *upload.Upload
 }
 
-type NewDeduplicatorOutput struct {
+type NewDeduplicatorForDatasetOutput struct {
+	Deduplicator data.Deduplicator
+	Error        error
+}
+
+type IsRegisteredWithDatasetOutput struct {
+	Is    bool
+	Error error
+}
+
+type NewRegisteredDeduplicatorForDatasetInput struct {
+	Logger           log.Logger
+	DataStoreSession store.Session
+	Dataset          *upload.Upload
+}
+
+type NewRegisteredDeduplicatorForDatasetOutput struct {
 	Deduplicator data.Deduplicator
 	Error        error
 }
 
 type Factory struct {
-	ID                               string
-	CanDeduplicateDatasetInvocations int
-	CanDeduplicateDatasetInputs      []*upload.Upload
-	CanDeduplicateDatasetOutputs     []CanDeduplicateDatasetOutput
-	NewDeduplicatoInvocations        int
-	NewDeduplicatorInputs            []NewDeduplicatorInput
-	NewDeduplicatorOutputs           []NewDeduplicatorOutput
+	ID                                             string
+	CanDeduplicateDatasetInvocations               int
+	CanDeduplicateDatasetInputs                    []*upload.Upload
+	CanDeduplicateDatasetOutputs                   []CanDeduplicateDatasetOutput
+	NewDeduplicatorForDatasetInvocations           int
+	NewDeduplicatorForDatasetInputs                []NewDeduplicatorForDatasetInput
+	NewDeduplicatorForDatasetOutputs               []NewDeduplicatorForDatasetOutput
+	IsRegisteredWithDatasetInvocations             int
+	IsRegisteredWithDatasetInputs                  []*upload.Upload
+	IsRegisteredWithDatasetOutputs                 []IsRegisteredWithDatasetOutput
+	NewRegisteredDeduplicatorForDatasetInvocations int
+	NewRegisteredDeduplicatorForDatasetInputs      []NewRegisteredDeduplicatorForDatasetInput
+	NewRegisteredDeduplicatorForDatasetOutputs     []NewRegisteredDeduplicatorForDatasetOutput
 }
 
 func NewFactory() *Factory {
@@ -54,21 +76,51 @@ func (f *Factory) CanDeduplicateDataset(dataset *upload.Upload) (bool, error) {
 	return output.Can, output.Error
 }
 
-func (f *Factory) NewDeduplicator(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
-	f.NewDeduplicatoInvocations++
+func (f *Factory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	f.NewDeduplicatorForDatasetInvocations++
 
-	f.NewDeduplicatorInputs = append(f.NewDeduplicatorInputs, NewDeduplicatorInput{logger, dataStoreSession, dataset})
+	f.NewDeduplicatorForDatasetInputs = append(f.NewDeduplicatorForDatasetInputs, NewDeduplicatorForDatasetInput{logger, dataStoreSession, dataset})
 
-	if len(f.NewDeduplicatorOutputs) == 0 {
-		panic("Unexpected invocation of NewDeduplicator on Factory")
+	if len(f.NewDeduplicatorForDatasetOutputs) == 0 {
+		panic("Unexpected invocation of NewDeduplicatorForDataset on Factory")
 	}
 
-	output := f.NewDeduplicatorOutputs[0]
-	f.NewDeduplicatorOutputs = f.NewDeduplicatorOutputs[1:]
+	output := f.NewDeduplicatorForDatasetOutputs[0]
+	f.NewDeduplicatorForDatasetOutputs = f.NewDeduplicatorForDatasetOutputs[1:]
+	return output.Deduplicator, output.Error
+}
+
+func (f *Factory) IsRegisteredWithDataset(dataset *upload.Upload) (bool, error) {
+	f.IsRegisteredWithDatasetInvocations++
+
+	f.IsRegisteredWithDatasetInputs = append(f.IsRegisteredWithDatasetInputs, dataset)
+
+	if len(f.IsRegisteredWithDatasetOutputs) == 0 {
+		panic("Unexpected invocation of IsRegisteredWithDataset on Factory")
+	}
+
+	output := f.IsRegisteredWithDatasetOutputs[0]
+	f.IsRegisteredWithDatasetOutputs = f.IsRegisteredWithDatasetOutputs[1:]
+	return output.Is, output.Error
+}
+
+func (f *Factory) NewRegisteredDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
+	f.NewRegisteredDeduplicatorForDatasetInvocations++
+
+	f.NewRegisteredDeduplicatorForDatasetInputs = append(f.NewRegisteredDeduplicatorForDatasetInputs, NewRegisteredDeduplicatorForDatasetInput{logger, dataStoreSession, dataset})
+
+	if len(f.NewRegisteredDeduplicatorForDatasetOutputs) == 0 {
+		panic("Unexpected invocation of NewRegisteredDeduplicatorForDataset on Factory")
+	}
+
+	output := f.NewRegisteredDeduplicatorForDatasetOutputs[0]
+	f.NewRegisteredDeduplicatorForDatasetOutputs = f.NewRegisteredDeduplicatorForDatasetOutputs[1:]
 	return output.Deduplicator, output.Error
 }
 
 func (f *Factory) UnusedOutputsCount() int {
 	return len(f.CanDeduplicateDatasetOutputs) +
-		len(f.NewDeduplicatorOutputs)
+		len(f.NewDeduplicatorForDatasetOutputs) +
+		len(f.IsRegisteredWithDatasetOutputs) +
+		len(f.NewRegisteredDeduplicatorForDatasetOutputs)
 }

--- a/data/deduplicator_test.go
+++ b/data/deduplicator_test.go
@@ -1,0 +1,73 @@
+package data_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"fmt"
+
+	"github.com/tidepool-org/platform/app"
+	"github.com/tidepool-org/platform/data"
+)
+
+var _ = Describe("Delegate", func() {
+	Context("DeduplicatorDescriptor", func() {
+		Context("NewDeduplicatorDescriptor", func() {
+			It("returns a new deduplicator descriptor", func() {
+				Expect(data.NewDeduplicatorDescriptor()).ToNot(BeNil())
+			})
+		})
+
+		Context("with a new deduplicator descriptor", func() {
+			var testDeduplicatorDescriptor *data.DeduplicatorDescriptor
+			var testName string
+
+			BeforeEach(func() {
+				testDeduplicatorDescriptor = data.NewDeduplicatorDescriptor()
+				Expect(testDeduplicatorDescriptor).ToNot(BeNil())
+				testName = app.NewID()
+				testDeduplicatorDescriptor.Name = testName
+			})
+
+			Context("IsRegisteredWithAnyDeduplicator", func() {
+				It("returns false if the deduplicator descriptor name is missing", func() {
+					testDeduplicatorDescriptor.Name = ""
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithAnyDeduplicator()).To(BeFalse())
+				})
+
+				It("returns true if the deduplicator descriptor name is present", func() {
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithAnyDeduplicator()).To(BeTrue())
+				})
+			})
+
+			Context("IsRegisteredWithNamedDeduplicator", func() {
+				It("returns false if the deduplicator descriptor name is missing", func() {
+					testDeduplicatorDescriptor.Name = ""
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(testName)).To(BeFalse())
+				})
+
+				It("returns true if the deduplicator descriptor name is present, but does not match", func() {
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(app.NewID())).To(BeFalse())
+				})
+
+				It("returns true if the deduplicator descriptor name is present and matches", func() {
+					Expect(testDeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator(testName)).To(BeTrue())
+				})
+			})
+
+			Context("RegisterWithNamedDeduplicator", func() {
+				It("returns error if the deduplicator descriptor already has a name", func() {
+					err := testDeduplicatorDescriptor.RegisterWithNamedDeduplicator(app.NewID())
+					Expect(err).To(MatchError(fmt.Sprintf(`data: deduplicator descriptor already registered with "%s"`, testName)))
+				})
+
+				It("returns successfully if the deduplicator descriptor does not already have a name", func() {
+					testDeduplicatorDescriptor.Name = ""
+					err := testDeduplicatorDescriptor.RegisterWithNamedDeduplicator(testName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(testDeduplicatorDescriptor.Name).To(Equal(testName))
+				})
+			})
+		})
+	})
+})

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -29,12 +29,17 @@ type Session interface {
 
 	GetDatasetsForUserByID(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
 	GetDatasetByID(datasetID string) (*upload.Upload, error)
+	FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error)
 	CreateDataset(dataset *upload.Upload) error
 	UpdateDataset(dataset *upload.Upload) error
 	DeleteDataset(dataset *upload.Upload) error
-	FindDatasetDataDeduplicatorHashes(userID string, queryHashes []string) ([]string, error)
+	GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error)
+	FindAllDatasetDataDeduplicatorHashesForDevice(userID string, deviceID string, queryHashes []string) ([]string, error)
 	CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error
+	FindEarliestDatasetDataTime(dataset *upload.Upload) (string, error)
 	ActivateDatasetData(dataset *upload.Upload) error
+	SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error
+	DeactivateOtherDatasetDataAfterTime(dataset *upload.Upload, time string) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
 	DestroyDataForUserByID(userID string) error
 }

--- a/data/store/test/session.go
+++ b/data/store/test/session.go
@@ -24,12 +24,28 @@ type GetDatasetByIDOutput struct {
 	Error   error
 }
 
-type FindDatasetDataDeduplicatorHashesInput struct {
-	UserID string
-	Hashes []string
+type FindPreviousActiveDatasetForDeviceOutput struct {
+	Dataset *upload.Upload
+	Error   error
 }
 
-type FindDatasetDataDeduplicatorHashesOutput struct {
+type GetDatasetDataDeduplicatorHashesInput struct {
+	Dataset *upload.Upload
+	Active  bool
+}
+
+type GetDatasetDataDeduplicatorHashesOutput struct {
+	Hashes []string
+	Error  error
+}
+
+type FindAllDatasetDataDeduplicatorHashesForDeviceInput struct {
+	UserID   string
+	DeviceID string
+	Hashes   []string
+}
+
+type FindAllDatasetDataDeduplicatorHashesForDeviceOutput struct {
 	Hashes []string
 	Error  error
 }
@@ -39,43 +55,74 @@ type CreateDatasetDataInput struct {
 	DatasetData []data.Datum
 }
 
+type FindEarliestDatasetDataTimeOutput struct {
+	Time  string
+	Error error
+}
+
+type SetDatasetDataActiveUsingHashesInput struct {
+	Dataset *upload.Upload
+	Hashes  []string
+	Active  bool
+}
+
+type DeactivateOtherDatasetDataAfterTimeInput struct {
+	Dataset *upload.Upload
+	Time    string
+}
+
 type Session struct {
-	ID                                           string
-	IsClosedInvocations                          int
-	IsClosedOutputs                              []bool
-	CloseInvocations                             int
-	SetAgentInvocations                          int
-	SetAgentInputs                               []commonStore.Agent
-	GetDatasetsForUserByIDInvocations            int
-	GetDatasetsForUserByIDInputs                 []GetDatasetsForUserByIDInput
-	GetDatasetsForUserByIDOutputs                []GetDatasetsForUserByIDOutput
-	GetDatasetByIDInvocations                    int
-	GetDatasetByIDInputs                         []string
-	GetDatasetByIDOutputs                        []GetDatasetByIDOutput
-	CreateDatasetInvocations                     int
-	CreateDatasetInputs                          []*upload.Upload
-	CreateDatasetOutputs                         []error
-	UpdateDatasetInvocations                     int
-	UpdateDatasetInputs                          []*upload.Upload
-	UpdateDatasetOutputs                         []error
-	DeleteDatasetInvocations                     int
-	DeleteDatasetInputs                          []*upload.Upload
-	DeleteDatasetOutputs                         []error
-	FindDatasetDataDeduplicatorHashesInvocations int
-	FindDatasetDataDeduplicatorHashesInputs      []FindDatasetDataDeduplicatorHashesInput
-	FindDatasetDataDeduplicatorHashesOutputs     []FindDatasetDataDeduplicatorHashesOutput
-	CreateDatasetDataInvocations                 int
-	CreateDatasetDataInputs                      []CreateDatasetDataInput
-	CreateDatasetDataOutputs                     []error
-	ActivateDatasetDataInvocations               int
-	ActivateDatasetDataInputs                    []*upload.Upload
-	ActivateDatasetDataOutputs                   []error
-	DeleteOtherDatasetDataInvocations            int
-	DeleteOtherDatasetDataInputs                 []*upload.Upload
-	DeleteOtherDatasetDataOutputs                []error
-	DestroyDataForUserByIDInvocations            int
-	DestroyDataForUserByIDInputs                 []string
-	DestroyDataForUserByIDOutputs                []error
+	ID                                                       string
+	IsClosedInvocations                                      int
+	IsClosedOutputs                                          []bool
+	CloseInvocations                                         int
+	SetAgentInvocations                                      int
+	SetAgentInputs                                           []commonStore.Agent
+	GetDatasetsForUserByIDInvocations                        int
+	GetDatasetsForUserByIDInputs                             []GetDatasetsForUserByIDInput
+	GetDatasetsForUserByIDOutputs                            []GetDatasetsForUserByIDOutput
+	GetDatasetByIDInvocations                                int
+	GetDatasetByIDInputs                                     []string
+	GetDatasetByIDOutputs                                    []GetDatasetByIDOutput
+	FindPreviousActiveDatasetForDeviceInvocations            int
+	FindPreviousActiveDatasetForDeviceInputs                 []*upload.Upload
+	FindPreviousActiveDatasetForDeviceOutputs                []FindPreviousActiveDatasetForDeviceOutput
+	CreateDatasetInvocations                                 int
+	CreateDatasetInputs                                      []*upload.Upload
+	CreateDatasetOutputs                                     []error
+	UpdateDatasetInvocations                                 int
+	UpdateDatasetInputs                                      []*upload.Upload
+	UpdateDatasetOutputs                                     []error
+	DeleteDatasetInvocations                                 int
+	DeleteDatasetInputs                                      []*upload.Upload
+	DeleteDatasetOutputs                                     []error
+	GetDatasetDataDeduplicatorHashesInvocations              int
+	GetDatasetDataDeduplicatorHashesInputs                   []GetDatasetDataDeduplicatorHashesInput
+	GetDatasetDataDeduplicatorHashesOutputs                  []GetDatasetDataDeduplicatorHashesOutput
+	FindAllDatasetDataDeduplicatorHashesForDeviceInvocations int
+	FindAllDatasetDataDeduplicatorHashesForDeviceInputs      []FindAllDatasetDataDeduplicatorHashesForDeviceInput
+	FindAllDatasetDataDeduplicatorHashesForDeviceOutputs     []FindAllDatasetDataDeduplicatorHashesForDeviceOutput
+	CreateDatasetDataInvocations                             int
+	CreateDatasetDataInputs                                  []CreateDatasetDataInput
+	CreateDatasetDataOutputs                                 []error
+	FindEarliestDatasetDataTimeInvocations                   int
+	FindEarliestDatasetDataTimeInputs                        []*upload.Upload
+	FindEarliestDatasetDataTimeOutputs                       []FindEarliestDatasetDataTimeOutput
+	ActivateDatasetDataInvocations                           int
+	ActivateDatasetDataInputs                                []*upload.Upload
+	ActivateDatasetDataOutputs                               []error
+	SetDatasetDataActiveUsingHashesInvocations               int
+	SetDatasetDataActiveUsingHashesInputs                    []SetDatasetDataActiveUsingHashesInput
+	SetDatasetDataActiveUsingHashesOutputs                   []error
+	DeactivateOtherDatasetDataAfterTimeInvocations           int
+	DeactivateOtherDatasetDataAfterTimeInputs                []DeactivateOtherDatasetDataAfterTimeInput
+	DeactivateOtherDatasetDataAfterTimeOutputs               []error
+	DeleteOtherDatasetDataInvocations                        int
+	DeleteOtherDatasetDataInputs                             []*upload.Upload
+	DeleteOtherDatasetDataOutputs                            []error
+	DestroyDataForUserByIDInvocations                        int
+	DestroyDataForUserByIDInputs                             []string
+	DestroyDataForUserByIDOutputs                            []error
 }
 
 func NewSession() *Session {
@@ -134,6 +181,20 @@ func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	return output.Dataset, output.Error
 }
 
+func (s *Session) FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error) {
+	s.FindPreviousActiveDatasetForDeviceInvocations++
+
+	s.FindPreviousActiveDatasetForDeviceInputs = append(s.FindPreviousActiveDatasetForDeviceInputs, dataset)
+
+	if len(s.FindPreviousActiveDatasetForDeviceOutputs) == 0 {
+		panic("Unexpected invocation of FindPreviousActiveDatasetForDevice on Session")
+	}
+
+	output := s.FindPreviousActiveDatasetForDeviceOutputs[0]
+	s.FindPreviousActiveDatasetForDeviceOutputs = s.FindPreviousActiveDatasetForDeviceOutputs[1:]
+	return output.Dataset, output.Error
+}
+
 func (s *Session) CreateDataset(dataset *upload.Upload) error {
 	s.CreateDatasetInvocations++
 
@@ -176,17 +237,31 @@ func (s *Session) DeleteDataset(dataset *upload.Upload) error {
 	return output
 }
 
-func (s *Session) FindDatasetDataDeduplicatorHashes(userID string, queryHashes []string) ([]string, error) {
-	s.FindDatasetDataDeduplicatorHashesInvocations++
+func (s *Session) GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error) {
+	s.GetDatasetDataDeduplicatorHashesInvocations++
 
-	s.FindDatasetDataDeduplicatorHashesInputs = append(s.FindDatasetDataDeduplicatorHashesInputs, FindDatasetDataDeduplicatorHashesInput{userID, queryHashes})
+	s.GetDatasetDataDeduplicatorHashesInputs = append(s.GetDatasetDataDeduplicatorHashesInputs, GetDatasetDataDeduplicatorHashesInput{dataset, active})
 
-	if len(s.FindDatasetDataDeduplicatorHashesOutputs) == 0 {
-		panic("Unexpected invocation of FindDatasetDataDeduplicatorHashes on Session")
+	if len(s.GetDatasetDataDeduplicatorHashesOutputs) == 0 {
+		panic("Unexpected invocation of GetDatasetDataDeduplicatorHashes on Session")
 	}
 
-	output := s.FindDatasetDataDeduplicatorHashesOutputs[0]
-	s.FindDatasetDataDeduplicatorHashesOutputs = s.FindDatasetDataDeduplicatorHashesOutputs[1:]
+	output := s.GetDatasetDataDeduplicatorHashesOutputs[0]
+	s.GetDatasetDataDeduplicatorHashesOutputs = s.GetDatasetDataDeduplicatorHashesOutputs[1:]
+	return output.Hashes, output.Error
+}
+
+func (s *Session) FindAllDatasetDataDeduplicatorHashesForDevice(userID string, deviceID string, queryHashes []string) ([]string, error) {
+	s.FindAllDatasetDataDeduplicatorHashesForDeviceInvocations++
+
+	s.FindAllDatasetDataDeduplicatorHashesForDeviceInputs = append(s.FindAllDatasetDataDeduplicatorHashesForDeviceInputs, FindAllDatasetDataDeduplicatorHashesForDeviceInput{userID, deviceID, queryHashes})
+
+	if len(s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs) == 0 {
+		panic("Unexpected invocation of FindAllDatasetDataDeduplicatorHashesForDevice on Session")
+	}
+
+	output := s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs[0]
+	s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs = s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs[1:]
 	return output.Hashes, output.Error
 }
 
@@ -204,6 +279,20 @@ func (s *Session) CreateDatasetData(dataset *upload.Upload, datasetData []data.D
 	return output
 }
 
+func (s *Session) FindEarliestDatasetDataTime(dataset *upload.Upload) (string, error) {
+	s.FindEarliestDatasetDataTimeInvocations++
+
+	s.FindEarliestDatasetDataTimeInputs = append(s.FindEarliestDatasetDataTimeInputs, dataset)
+
+	if len(s.FindEarliestDatasetDataTimeOutputs) == 0 {
+		panic("Unexpected invocation of FindEarliestDatasetDataTime on Session")
+	}
+
+	output := s.FindEarliestDatasetDataTimeOutputs[0]
+	s.FindEarliestDatasetDataTimeOutputs = s.FindEarliestDatasetDataTimeOutputs[1:]
+	return output.Time, output.Error
+}
+
 func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 	s.ActivateDatasetDataInvocations++
 
@@ -215,6 +304,34 @@ func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 
 	output := s.ActivateDatasetDataOutputs[0]
 	s.ActivateDatasetDataOutputs = s.ActivateDatasetDataOutputs[1:]
+	return output
+}
+
+func (s *Session) SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error {
+	s.SetDatasetDataActiveUsingHashesInvocations++
+
+	s.SetDatasetDataActiveUsingHashesInputs = append(s.SetDatasetDataActiveUsingHashesInputs, SetDatasetDataActiveUsingHashesInput{dataset, queryHashes, active})
+
+	if len(s.SetDatasetDataActiveUsingHashesOutputs) == 0 {
+		panic("Unexpected invocation of SetDatasetDataActiveUsingHashes on Session")
+	}
+
+	output := s.SetDatasetDataActiveUsingHashesOutputs[0]
+	s.SetDatasetDataActiveUsingHashesOutputs = s.SetDatasetDataActiveUsingHashesOutputs[1:]
+	return output
+}
+
+func (s *Session) DeactivateOtherDatasetDataAfterTime(dataset *upload.Upload, time string) error {
+	s.DeactivateOtherDatasetDataAfterTimeInvocations++
+
+	s.DeactivateOtherDatasetDataAfterTimeInputs = append(s.DeactivateOtherDatasetDataAfterTimeInputs, DeactivateOtherDatasetDataAfterTimeInput{dataset, time})
+
+	if len(s.DeactivateOtherDatasetDataAfterTimeOutputs) == 0 {
+		panic("Unexpected invocation of DeactivateOtherDatasetDataAfterTime on Session")
+	}
+
+	output := s.DeactivateOtherDatasetDataAfterTimeOutputs[0]
+	s.DeactivateOtherDatasetDataAfterTimeOutputs = s.DeactivateOtherDatasetDataAfterTimeOutputs[1:]
 	return output
 }
 
@@ -250,11 +367,17 @@ func (s *Session) UnusedOutputsCount() int {
 	return len(s.IsClosedOutputs) +
 		len(s.GetDatasetsForUserByIDOutputs) +
 		len(s.GetDatasetByIDOutputs) +
+		len(s.FindPreviousActiveDatasetForDeviceOutputs) +
 		len(s.CreateDatasetOutputs) +
 		len(s.UpdateDatasetOutputs) +
 		len(s.DeleteDatasetOutputs) +
+		len(s.GetDatasetDataDeduplicatorHashesOutputs) +
+		len(s.FindAllDatasetDataDeduplicatorHashesForDeviceOutputs) +
 		len(s.CreateDatasetDataOutputs) +
+		len(s.FindEarliestDatasetDataTimeOutputs) +
 		len(s.ActivateDatasetDataOutputs) +
+		len(s.SetDatasetDataActiveUsingHashesOutputs) +
+		len(s.DeactivateOtherDatasetDataAfterTimeOutputs) +
 		len(s.DeleteOtherDatasetDataOutputs) +
 		len(s.DestroyDataForUserByIDOutputs)
 }

--- a/data/test/datum.go
+++ b/data/test/datum.go
@@ -46,10 +46,9 @@ type Datum struct {
 	SetDeletedTimeInputs                 []string
 	SetDeletedUserIDInvocations          int
 	SetDeletedUserIDInputs               []string
+	DeduplicatorDescriptorValue          *data.DeduplicatorDescriptor
 	DeduplicatorDescriptorInvocations    int
-	DeduplicatorDescriptorOutputs        []*data.DeduplicatorDescriptor
 	SetDeduplicatorDescriptorInvocations int
-	SetDeduplicatorDescriptorInputs      []*data.DeduplicatorDescriptor
 }
 
 func NewDatum() *Datum {
@@ -66,7 +65,7 @@ func (d *Datum) Meta() interface{} {
 	d.MetaInvocations++
 
 	if len(d.MetaOutputs) == 0 {
-		panic("Unexpected invocation of Meta on Session")
+		panic("Unexpected invocation of Meta on Datum")
 	}
 
 	output := d.MetaOutputs[0]
@@ -80,7 +79,7 @@ func (d *Datum) Parse(parser data.ObjectParser) error {
 	d.ParseInputs = append(d.ParseInputs, parser)
 
 	if len(d.ParseOutputs) == 0 {
-		panic("Unexpected invocation of Parse on Session")
+		panic("Unexpected invocation of Parse on Datum")
 	}
 
 	output := d.ParseOutputs[0]
@@ -94,7 +93,7 @@ func (d *Datum) Validate(validator data.Validator) error {
 	d.ValidateInputs = append(d.ValidateInputs, validator)
 
 	if len(d.ValidateOutputs) == 0 {
-		panic("Unexpected invocation of Validate on Session")
+		panic("Unexpected invocation of Validate on Datum")
 	}
 
 	output := d.ValidateOutputs[0]
@@ -108,7 +107,7 @@ func (d *Datum) Normalize(normalizer data.Normalizer) error {
 	d.NormalizeInputs = append(d.NormalizeInputs, normalizer)
 
 	if len(d.NormalizeOutputs) == 0 {
-		panic("Unexpected invocation of Normalize on Session")
+		panic("Unexpected invocation of Normalize on Datum")
 	}
 
 	output := d.NormalizeOutputs[0]
@@ -120,7 +119,7 @@ func (d *Datum) IdentityFields() ([]string, error) {
 	d.IdentityFieldsInvocations++
 
 	if len(d.IdentityFieldsOutputs) == 0 {
-		panic("Unexpected invocation of IdentityFields on Session")
+		panic("Unexpected invocation of IdentityFields on Datum")
 	}
 
 	output := d.IdentityFieldsOutputs[0]
@@ -191,19 +190,13 @@ func (d *Datum) SetDeletedUserID(deletedUserID string) {
 func (d *Datum) DeduplicatorDescriptor() *data.DeduplicatorDescriptor {
 	d.DeduplicatorDescriptorInvocations++
 
-	if len(d.DeduplicatorDescriptorOutputs) == 0 {
-		panic("Unexpected invocation of DeduplicatorDescriptor on Session")
-	}
-
-	output := d.DeduplicatorDescriptorOutputs[0]
-	d.DeduplicatorDescriptorOutputs = d.DeduplicatorDescriptorOutputs[1:]
-	return output
+	return d.DeduplicatorDescriptorValue
 }
 
 func (d *Datum) SetDeduplicatorDescriptor(deduplicatorDescriptor *data.DeduplicatorDescriptor) {
 	d.SetDeduplicatorDescriptorInvocations++
 
-	d.SetDeduplicatorDescriptorInputs = append(d.SetDeduplicatorDescriptorInputs, deduplicatorDescriptor)
+	d.DeduplicatorDescriptorValue = deduplicatorDescriptor
 }
 
 func (d *Datum) UnusedOutputsCount() int {
@@ -211,6 +204,5 @@ func (d *Datum) UnusedOutputsCount() int {
 		len(d.ParseOutputs) +
 		len(d.ValidateOutputs) +
 		len(d.NormalizeOutputs) +
-		len(d.IdentityFieldsOutputs) +
-		len(d.DeduplicatorDescriptorOutputs)
+		len(d.IdentityFieldsOutputs)
 }

--- a/data/test/deduplicator.go
+++ b/data/test/deduplicator.go
@@ -6,14 +6,18 @@ import (
 )
 
 type Deduplicator struct {
-	ID                           string
-	InitializeDatasetInvocations int
-	InitializeDatasetOutputs     []error
-	AddDataToDatasetInvocations  int
-	AddDataToDatasetInputs       [][]data.Datum
-	AddDataToDatasetOutputs      []error
-	FinalizeDatasetInvocations   int
-	FinalizeDatasetOutputs       []error
+	ID                            string
+	NameInvocations               int
+	NameOutputs                   []string
+	RegisterDatasetInvocations    int
+	RegisterDatasetOutputs        []error
+	AddDatasetDataInvocations     int
+	AddDatasetDataInputs          [][]data.Datum
+	AddDatasetDataOutputs         []error
+	DeduplicateDatasetInvocations int
+	DeduplicateDatasetOutputs     []error
+	DeleteDatasetInvocations      int
+	DeleteDatasetOutputs          []error
 }
 
 func NewDeduplicator() *Deduplicator {
@@ -22,46 +26,72 @@ func NewDeduplicator() *Deduplicator {
 	}
 }
 
-func (d *Deduplicator) InitializeDataset() error {
-	d.InitializeDatasetInvocations++
+func (d *Deduplicator) Name() string {
+	d.NameInvocations++
 
-	if len(d.InitializeDatasetOutputs) == 0 {
-		panic("Unexpected invocation of InitializeDataset on Deduplicator")
+	if len(d.NameOutputs) == 0 {
+		panic("Unexpected invocation of Name on Deduplicator")
 	}
 
-	output := d.InitializeDatasetOutputs[0]
-	d.InitializeDatasetOutputs = d.InitializeDatasetOutputs[1:]
+	output := d.NameOutputs[0]
+	d.NameOutputs = d.NameOutputs[1:]
 	return output
 }
 
-func (d *Deduplicator) AddDataToDataset(datasetData []data.Datum) error {
-	d.AddDataToDatasetInvocations++
+func (d *Deduplicator) RegisterDataset() error {
+	d.RegisterDatasetInvocations++
 
-	d.AddDataToDatasetInputs = append(d.AddDataToDatasetInputs, datasetData)
-
-	if len(d.AddDataToDatasetOutputs) == 0 {
-		panic("Unexpected invocation of AddDataToDataset on Deduplicator")
+	if len(d.RegisterDatasetOutputs) == 0 {
+		panic("Unexpected invocation of RegisterDataset on Deduplicator")
 	}
 
-	output := d.AddDataToDatasetOutputs[0]
-	d.AddDataToDatasetOutputs = d.AddDataToDatasetOutputs[1:]
+	output := d.RegisterDatasetOutputs[0]
+	d.RegisterDatasetOutputs = d.RegisterDatasetOutputs[1:]
 	return output
 }
 
-func (d *Deduplicator) FinalizeDataset() error {
-	d.FinalizeDatasetInvocations++
+func (d *Deduplicator) AddDatasetData(datasetData []data.Datum) error {
+	d.AddDatasetDataInvocations++
 
-	if len(d.FinalizeDatasetOutputs) == 0 {
-		panic("Unexpected invocation of FinalizeDataset on Deduplicator")
+	d.AddDatasetDataInputs = append(d.AddDatasetDataInputs, datasetData)
+
+	if len(d.AddDatasetDataOutputs) == 0 {
+		panic("Unexpected invocation of AddDatasetData on Deduplicator")
 	}
 
-	output := d.FinalizeDatasetOutputs[0]
-	d.FinalizeDatasetOutputs = d.FinalizeDatasetOutputs[1:]
+	output := d.AddDatasetDataOutputs[0]
+	d.AddDatasetDataOutputs = d.AddDatasetDataOutputs[1:]
+	return output
+}
+
+func (d *Deduplicator) DeduplicateDataset() error {
+	d.DeduplicateDatasetInvocations++
+
+	if len(d.DeduplicateDatasetOutputs) == 0 {
+		panic("Unexpected invocation of DeduplicateDataset on Deduplicator")
+	}
+
+	output := d.DeduplicateDatasetOutputs[0]
+	d.DeduplicateDatasetOutputs = d.DeduplicateDatasetOutputs[1:]
+	return output
+}
+
+func (d *Deduplicator) DeleteDataset() error {
+	d.DeleteDatasetInvocations++
+
+	if len(d.DeleteDatasetOutputs) == 0 {
+		panic("Unexpected invocation of DeleteDataset on Deduplicator")
+	}
+
+	output := d.DeleteDatasetOutputs[0]
+	d.DeleteDatasetOutputs = d.DeleteDatasetOutputs[1:]
 	return output
 }
 
 func (d *Deduplicator) UnusedOutputsCount() int {
-	return len(d.InitializeDatasetOutputs) +
-		len(d.AddDataToDatasetOutputs) +
-		len(d.FinalizeDatasetOutputs)
+	return len(d.NameOutputs) +
+		len(d.RegisterDatasetOutputs) +
+		len(d.AddDatasetDataOutputs) +
+		len(d.DeduplicateDatasetOutputs) +
+		len(d.DeleteDatasetOutputs)
 }

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -54,6 +54,7 @@ func (b *Base) Init() {
 	b.Active = false
 	b.CreatedTime = ""
 	b.CreatedUserID = ""
+	b.Deduplicator = nil
 	b.DeletedTime = ""
 	b.DeletedUserID = ""
 	b.GroupID = ""

--- a/data/types/upload/upload.go
+++ b/data/types/upload/upload.go
@@ -48,7 +48,6 @@ func (u *Upload) Init() {
 
 	u.State = "open"
 	u.DataState = "open" // TODO: Deprecated DataState (after data migration)
-	u.Deduplicator = nil
 	u.ByUser = ""
 
 	u.ComputerTime = nil

--- a/dataservices/service/api/v1/datasets_data_create.go
+++ b/dataservices/service/api/v1/datasets_data_create.go
@@ -63,9 +63,9 @@ func DatasetsDataCreate(serviceContext service.Context) {
 		return
 	}
 
-	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicator(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
+	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewRegisteredDeduplicatorForDataset(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
 	if err != nil {
-		serviceContext.RespondWithInternalServerFailure("No duplicator found matching dataset", err)
+		serviceContext.RespondWithInternalServerFailure("Unable to create registered deduplicator for dataset", err)
 		return
 	}
 
@@ -126,8 +126,8 @@ func DatasetsDataCreate(serviceContext service.Context) {
 		datum.SetDatasetID(dataset.UploadID)
 	}
 
-	if err = deduplicator.AddDataToDataset(datumArray); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to add data to dataset", err)
+	if err = deduplicator.AddDatasetData(datumArray); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to add dataset data", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/datasets_delete_test.go
+++ b/dataservices/service/api/v1/datasets_delete_test.go
@@ -1,15 +1,16 @@
 package v1_test
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"errors"
 	"net/http"
 
 	"github.com/tidepool-org/platform/app"
+	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
+	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/upload"
 	"github.com/tidepool-org/platform/dataservices/service/api/v1"
 	"github.com/tidepool-org/platform/service"
@@ -35,6 +36,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{false}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{authenticatedUserID}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"root": client.Permission{}}, nil}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: nil}}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{nil}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{nil}
 		})
@@ -43,6 +45,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -54,6 +57,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -66,6 +70,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -78,6 +83,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))
@@ -89,6 +95,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(nil) }).To(Panic())
@@ -101,6 +108,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
@@ -113,6 +121,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -125,6 +134,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -136,6 +146,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -149,6 +160,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -162,6 +174,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.AuthenticationDetailsImpl.IsServerOutputs = []bool{}
 			context.AuthenticationDetailsImpl.UserIDOutputs = []string{}
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -173,6 +186,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("panics if authentication details is missing", func() {
 			context.AuthenticationDetailsImpl = nil
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
@@ -182,6 +196,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("panics if user services client is missing", func() {
 			context.UserServicesClientImpl = nil
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
@@ -191,6 +206,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if user services client get user permissions returns unauthorized error", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{nil, client.NewUnauthorizedError()}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -203,6 +219,7 @@ var _ = Describe("DatasetsDelete", func() {
 		It("responds with error if user services client get user permissions returns any other error", func() {
 			err := errors.New("other")
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{nil, err}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -214,6 +231,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if user services client get user permissions does not return needed permissions", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"view": client.Permission{}}, nil}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -225,6 +243,7 @@ var _ = Describe("DatasetsDelete", func() {
 
 		It("responds with error if user services client get user permissions returns upload permissions, but not user who uploaded", func() {
 			context.UserServicesClientImpl.GetUserPermissionsOutputs = []GetUserPermissionsOutput{{client.Permissions{"upload": client.Permission{}}, nil}}
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{}
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
 			v1.DatasetsDelete(context)
@@ -234,6 +253,60 @@ var _ = Describe("DatasetsDelete", func() {
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
 
+		It("panics if data deduplicator factory is missing", func() {
+			context.DataDeduplicatorFactoryImpl = nil
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if data deduplicator factory is registered with dataset returns an error", func() {
+			err := errors.New("other")
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: false, Error: err}}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to check if registered with dataset", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if data deduplicator factory new registered deduplicator for data returns an error", func() {
+			err := errors.New("other")
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+			context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: nil, Error: err}}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
+			Expect(context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetInputs).To(Equal([]testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{{Logger: context.LoggerImpl, DataStoreSession: context.DataStoreSessionImpl, Dataset: targetUpload}}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to create registered deduplicator for dataset", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+
+		It("responds with error if deduplicator delete dataset returns an error", func() {
+			deduplicatorImpl := testData.NewDeduplicator()
+			err := errors.New("other")
+			context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetOutputs = []testDataDeduplicator.IsRegisteredWithDatasetOutput{{Is: true, Error: nil}}
+			context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetOutputs = []testDataDeduplicator.NewRegisteredDeduplicatorForDatasetOutput{{Deduplicator: deduplicatorImpl, Error: nil}}
+			deduplicatorImpl.DeleteDatasetOutputs = []error{err}
+			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{}
+			context.MetricServicesClientImpl.RecordMetricOutputs = []error{}
+			v1.DatasetsDelete(context)
+			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
+			Expect(context.DataDeduplicatorFactoryImpl.NewRegisteredDeduplicatorForDatasetInputs).To(Equal([]testDataDeduplicator.NewRegisteredDeduplicatorForDatasetInput{{Logger: context.LoggerImpl, DataStoreSession: context.DataStoreSessionImpl, Dataset: targetUpload}}))
+			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to delete dataset", []interface{}{err}}}))
+			Expect(context.ValidateTest()).To(BeTrue())
+			Expect(deduplicatorImpl.UnusedOutputsCount()).To(Equal(0))
+		})
+
 		It("responds with error if data store session delete dataset returns an error", func() {
 			err := errors.New("other")
 			context.DataStoreSessionImpl.DeleteDatasetOutputs = []error{err}
@@ -241,6 +314,7 @@ var _ = Describe("DatasetsDelete", func() {
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.RespondWithInternalServerFailureInputs).To(Equal([]RespondWithInternalServerFailureInput{{"Unable to delete dataset", []interface{}{err}}}))
 			Expect(context.ValidateTest()).To(BeTrue())
@@ -251,6 +325,7 @@ var _ = Describe("DatasetsDelete", func() {
 			Expect(func() { v1.DatasetsDelete(context) }).To(Panic())
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
 			Expect(context.UserServicesClientImpl.GetUserPermissionsInputs).To(Equal([]GetUserPermissionsInput{{context, authenticatedUserID, targetUserID}}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.ValidateTest()).To(BeTrue())
 		})
@@ -259,6 +334,7 @@ var _ = Describe("DatasetsDelete", func() {
 			context.MetricServicesClientImpl.RecordMetricOutputs = []error{errors.New("other")}
 			v1.DatasetsDelete(context)
 			Expect(context.DataStoreSessionImpl.GetDatasetByIDInputs).To(Equal([]string{targetUpload.UploadID}))
+			Expect(context.DataDeduplicatorFactoryImpl.IsRegisteredWithDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.DataStoreSessionImpl.DeleteDatasetInputs).To(Equal([]*upload.Upload{targetUpload}))
 			Expect(context.MetricServicesClientImpl.RecordMetricInputs).To(Equal([]RecordMetricInput{{context, "datasets_delete", nil}}))
 			Expect(context.RespondWithStatusAndDataInputs).To(Equal([]RespondWithStatusAndDataInput{{http.StatusOK, struct{}{}}}))

--- a/dataservices/service/api/v1/datasets_update.go
+++ b/dataservices/service/api/v1/datasets_update.go
@@ -64,14 +64,14 @@ func DatasetsUpdate(serviceContext service.Context) {
 		return
 	}
 
-	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicator(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
+	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewRegisteredDeduplicatorForDataset(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
 	if err != nil {
-		serviceContext.RespondWithInternalServerFailure("No duplicator found matching dataset", err)
+		serviceContext.RespondWithInternalServerFailure("Unable to create registered deduplicator for dataset", err)
 		return
 	}
 
-	if err = deduplicator.FinalizeDataset(); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to finalize dataset", err)
+	if err = deduplicator.DeduplicateDataset(); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to deduplicate dataset", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/users_datasets_create.go
+++ b/dataservices/service/api/v1/users_datasets_create.go
@@ -117,14 +117,14 @@ func UsersDatasetsCreate(serviceContext service.Context) {
 		return
 	}
 
-	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicator(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
+	deduplicator, err := serviceContext.DataDeduplicatorFactory().NewDeduplicatorForDataset(serviceContext.Logger(), serviceContext.DataStoreSession(), dataset)
 	if err != nil {
-		serviceContext.RespondWithInternalServerFailure("No duplicator found matching dataset", err)
+		serviceContext.RespondWithInternalServerFailure("Unable to create deduplicator for dataset", err)
 		return
 	}
 
-	if err = deduplicator.InitializeDataset(); err != nil {
-		serviceContext.RespondWithInternalServerFailure("Unable to initialize dataset", err)
+	if err = deduplicator.RegisterDataset(); err != nil {
+		serviceContext.RespondWithInternalServerFailure("Unable to register dataset with deduplicator", err)
 		return
 	}
 

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/deduplicator"
+	testDataDeduplicator "github.com/tidepool-org/platform/data/deduplicator/test"
 	dataStore "github.com/tidepool-org/platform/data/store"
 	testDataStore "github.com/tidepool-org/platform/data/store/test"
 	"github.com/tidepool-org/platform/log"
@@ -174,6 +175,7 @@ type TestContext struct {
 	RespondWithStatusAndDataInputs         []RespondWithStatusAndDataInput
 	MetricServicesClientImpl               *TestMetricServicesClient
 	UserServicesClientImpl                 *TestUserServicesClient
+	DataDeduplicatorFactoryImpl            *testDataDeduplicator.Factory
 	DataStoreSessionImpl                   *testDataStore.Session
 	TaskStoreSessionImpl                   *TestTaskStoreSession
 	AuthenticationDetailsImpl              *TestAuthenticationDetails
@@ -188,11 +190,12 @@ func NewTestContext() *TestContext {
 			},
 			PathParams: map[string]string{},
 		},
-		MetricServicesClientImpl:  &TestMetricServicesClient{},
-		UserServicesClientImpl:    &TestUserServicesClient{},
-		DataStoreSessionImpl:      testDataStore.NewSession(),
-		TaskStoreSessionImpl:      &TestTaskStoreSession{},
-		AuthenticationDetailsImpl: &TestAuthenticationDetails{},
+		MetricServicesClientImpl:    &TestMetricServicesClient{},
+		UserServicesClientImpl:      &TestUserServicesClient{},
+		DataDeduplicatorFactoryImpl: testDataDeduplicator.NewFactory(),
+		DataStoreSessionImpl:        testDataStore.NewSession(),
+		TaskStoreSessionImpl:        &TestTaskStoreSession{},
+		AuthenticationDetailsImpl:   &TestAuthenticationDetails{},
 	}
 }
 
@@ -237,7 +240,7 @@ func (t *TestContext) DataFactory() data.Factory {
 }
 
 func (t *TestContext) DataDeduplicatorFactory() deduplicator.Factory {
-	panic("Unexpected invocation of DataDeduplicatorFactory on TestContext")
+	return t.DataDeduplicatorFactoryImpl
 }
 
 func (t *TestContext) DataStoreSession() dataStore.Session {
@@ -259,6 +262,7 @@ func (t *TestContext) SetAuthenticationDetails(authenticationDetails userservice
 func (t *TestContext) ValidateTest() bool {
 	return (t.MetricServicesClientImpl == nil || t.MetricServicesClientImpl.ValidateTest()) &&
 		(t.UserServicesClientImpl == nil || t.UserServicesClientImpl.ValidateTest()) &&
+		(t.DataDeduplicatorFactoryImpl == nil || t.DataDeduplicatorFactoryImpl.UnusedOutputsCount() == 0) &&
 		(t.DataStoreSessionImpl == nil || t.DataStoreSessionImpl.UnusedOutputsCount() == 0) &&
 		(t.TaskStoreSessionImpl == nil || t.TaskStoreSessionImpl.ValidateTest()) &&
 		(t.AuthenticationDetailsImpl == nil || t.AuthenticationDetailsImpl.ValidateTest())

--- a/dataservices/service/service/standard.go
+++ b/dataservices/service/service/standard.go
@@ -174,18 +174,18 @@ func (s *Standard) initializeDataDeduplicatorFactory() error {
 		return app.ExtError(err, "service", "unable to create truncate data deduplicator factory")
 	}
 
-	s.Logger().Debug("Creating hash data deduplicator factory")
+	s.Logger().Debug("Creating hash-deactivate-old data deduplicator factory")
 
-	hashDeduplicatorFactory, err := deduplicator.NewHashFactory()
+	hashDeactivateOldDeduplicatorFactory, err := deduplicator.NewHashDeactivateOldFactory()
 	if err != nil {
-		return app.ExtError(err, "service", "unable to create hash data deduplicator factory")
+		return app.ExtError(err, "service", "unable to create hash-deactivate-old data deduplicator factory")
 	}
 
 	s.Logger().Debug("Creating data deduplicator factory")
 
 	factories := []deduplicator.Factory{
 		truncateDeduplicatorFactory,
-		hashDeduplicatorFactory,
+		hashDeactivateOldDeduplicatorFactory,
 	}
 
 	dataDeduplicatorFactory, err := deduplicator.NewDelegateFactory(factories)


### PR DESCRIPTION
- Rename Deduplicator.InitializeDataset to Deduplicator.RegisterDataset
- Rename Deduplicator.FinalizeDataset to Deduplicator.DeduplicateDataset
- Add Deduplicator.DeleteDataset (to allow for special delete rules)
- Add support code for DeduplicatorDescriptor
- Allow factory to distinguish between a dataset without a deduplicator (CanDeduplicateDataset/NewDeduplicatorForDataset) and one that should have a deduplicator registered (IsRegisteredWithDataset/NewRegisteredDeduplicatorForDataset)
- Refactor common factory/deduplicator code into BaseDeduplicator
- Update Delegate deduplicator with latest factory/deduplicator interface
- Refactor common hash functionality into separate file
- Rename Hash deduplicator to HashDropNew (drop new data when old data has same hash)
- Add AfterDeactivateOld deduplicator (deactivate old data after earliest date from new data)
- Add HashDeactivateOld deduplicator (deactivate old data from previous dataset when new data has same hash)
- Update Truncate deduplicator with latest factory/deduplicator interface
- Add new deduplicator-related database access methods
- Update Datasets Delete API to delete via deduplicator (if one associated with dataset), fallback to straight delete
- Update various test support code
- Tests, tests, tests

@jh-bate I tried breaking this down into multiple commits, but nothing really made sense. There is some refactored code and some new code. It might be helpful if you do NOT do a new/old comparison of `hash.go`, `hash_test.go`, `delegate.go` and `delegate_test.go`. While these files already existed, they were affected by major refactors. It may be easier just to look at them as "new" files (try the split view in GitHub).