### PR TITLE
Add deduplicator version; update deduplicator name scheme

### DIFF
--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -2,12 +2,14 @@ package data
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/tidepool-org/platform/errors"
 )
 
 type Deduplicator interface {
 	Name() string
+	Version() string
 
 	RegisterDataset() error
 
@@ -18,8 +20,9 @@ type Deduplicator interface {
 }
 
 type DeduplicatorDescriptor struct {
-	Name string `bson:"name,omitempty"`
-	Hash string `bson:"hash,omitempty"`
+	Name    string `bson:"name,omitempty"`
+	Version string `bson:"version,omitempty"`
+	Hash    string `bson:"hash,omitempty"`
 }
 
 func NewDeduplicatorDescriptor() *DeduplicatorDescriptor {
@@ -31,14 +34,19 @@ func (d *DeduplicatorDescriptor) IsRegisteredWithAnyDeduplicator() bool {
 }
 
 func (d *DeduplicatorDescriptor) IsRegisteredWithNamedDeduplicator(name string) bool {
-	return d.Name == name
+	// TODO: Backwards compatible until after data migration to update deduplicator name scheme
+	return d.Name == name || d.Name == strings.TrimPrefix(name, "org.tidepool.")
 }
 
-func (d *DeduplicatorDescriptor) RegisterWithNamedDeduplicator(name string) error {
+func (d *DeduplicatorDescriptor) RegisterWithDeduplicator(deduplicator Deduplicator) error {
 	if d.Name != "" {
 		return errors.Newf("data", "deduplicator descriptor already registered with %s", strconv.Quote(d.Name))
 	}
+	if d.Version != "" {
+		return errors.New("data", "deduplicator descriptor already registered with unknown deduplicator")
+	}
 
-	d.Name = name
+	d.Name = deduplicator.Name()
+	d.Version = deduplicator.Version()
 	return nil
 }

--- a/data/deduplicator/base_test.go
+++ b/data/deduplicator/base_test.go
@@ -18,21 +18,35 @@ import (
 
 var _ = Describe("Base", func() {
 	var testName string
+	var testVersion string
 
 	BeforeEach(func() {
 		testName = app.NewID()
+		testVersion = "1.2.3"
 	})
 
 	Context("BaseFactory", func() {
 		Context("NewBaseFactory", func() {
 			It("returns an error if the name is missing", func() {
-				testFactory, err := deduplicator.NewBaseFactory("")
+				testFactory, err := deduplicator.NewBaseFactory("", testVersion)
 				Expect(err).To(MatchError("deduplicator: name is missing"))
 				Expect(testFactory).To(BeNil())
 			})
 
+			It("returns an error if the version is missing", func() {
+				testFactory, err := deduplicator.NewBaseFactory(testName, "")
+				Expect(err).To(MatchError("deduplicator: version is missing"))
+				Expect(testFactory).To(BeNil())
+			})
+
+			It("returns an error if the version is invalid", func() {
+				testFactory, err := deduplicator.NewBaseFactory(testName, "x.y.z")
+				Expect(err).To(MatchError("deduplicator: version is invalid"))
+				Expect(testFactory).To(BeNil())
+			})
+
 			It("returns a new factory", func() {
-				testFactory, err := deduplicator.NewBaseFactory(testName)
+				testFactory, err := deduplicator.NewBaseFactory(testName, testVersion)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(testFactory).ToNot(BeNil())
 				Expect(testFactory.Factory).ToNot(BeNil())
@@ -45,7 +59,7 @@ var _ = Describe("Base", func() {
 
 			BeforeEach(func() {
 				var err error
-				testFactory, err = deduplicator.NewBaseFactory(testName)
+				testFactory, err = deduplicator.NewBaseFactory(testName, testVersion)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(testFactory).ToNot(BeNil())
 				testDataset = upload.Init()
@@ -144,8 +158,7 @@ var _ = Describe("Base", func() {
 
 			Context("with registered dataset", func() {
 				BeforeEach(func() {
-					testDataset.Deduplicator = data.NewDeduplicatorDescriptor()
-					testDataset.Deduplicator.RegisterWithNamedDeduplicator(testName)
+					testDataset.Deduplicator = &data.DeduplicatorDescriptor{Name: testName, Version: testVersion}
 				})
 
 				Context("IsRegisteredWithDataset", func() {
@@ -297,52 +310,64 @@ var _ = Describe("Base", func() {
 
 		Context("NewBaseDeduplicator", func() {
 			It("returns an error if the name is missing", func() {
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator("", testLogger, testDataStoreSession, testDataset)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator("", testVersion, testLogger, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("deduplicator: name is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
+			It("returns an error if the version is missing", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, "", testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: version is missing"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
+			It("returns an error if the version is invalid", func() {
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, "x.y.z", testLogger, testDataStoreSession, testDataset)
+				Expect(err).To(MatchError("deduplicator: version is invalid"))
+				Expect(testDeduplicator).To(BeNil())
+			})
+
 			It("returns an error if the logger is missing", func() {
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, nil, testDataStoreSession, testDataset)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testVersion, nil, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("deduplicator: logger is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the data store session is missing", func() {
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, nil, testDataset)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, nil, testDataset)
 				Expect(err).To(MatchError("deduplicator: data store session is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset is missing", func() {
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, nil)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, testDataStoreSession, nil)
 				Expect(err).To(MatchError("deduplicator: dataset is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset id is missing", func() {
 				testDataset.UploadID = ""
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset id is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset user id is missing", func() {
 				testDataset.UserID = ""
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset user id is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
 			It("returns an error if the dataset group id is missing", func() {
 				testDataset.GroupID = ""
-				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				testDeduplicator, err := deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, testDataStoreSession, testDataset)
 				Expect(err).To(MatchError("deduplicator: dataset group id is missing"))
 				Expect(testDeduplicator).To(BeNil())
 			})
 
 			It("successfully returns a new deduplicator", func() {
-				Expect(deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
+				Expect(deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, testDataStoreSession, testDataset)).ToNot(BeNil())
 			})
 		})
 
@@ -351,7 +376,7 @@ var _ = Describe("Base", func() {
 
 			BeforeEach(func() {
 				var err error
-				testDeduplicator, err = deduplicator.NewBaseDeduplicator(testName, testLogger, testDataStoreSession, testDataset)
+				testDeduplicator, err = deduplicator.NewBaseDeduplicator(testName, testVersion, testLogger, testDataStoreSession, testDataset)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(testDeduplicator).ToNot(BeNil())
 			})
@@ -362,9 +387,15 @@ var _ = Describe("Base", func() {
 				})
 			})
 
+			Context("Version", func() {
+				It("returns the version", func() {
+					Expect(testDeduplicator.Version()).To(Equal(testVersion))
+				})
+			})
+
 			Context("RegisterDataset", func() {
 				It("returns an error if a deduplicator already registered dataset", func() {
-					testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: "test"})
+					testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Name: "test", Version: "0.0.0"})
 					err := testDeduplicator.RegisterDataset()
 					Expect(err).To(MatchError(fmt.Sprintf(`deduplicator: already registered dataset with id "%s"`, testDataset.UploadID)))
 				})
@@ -386,13 +417,13 @@ var _ = Describe("Base", func() {
 
 					It("returns successfully if there is no error", func() {
 						Expect(testDeduplicator.RegisterDataset()).To(Succeed())
-						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName}))
+						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName, Version: testVersion}))
 					})
 
 					It("returns successfully even if there is a deduplicator description just without a name", func() {
 						testDataset.SetDeduplicatorDescriptor(&data.DeduplicatorDescriptor{Hash: "test"})
 						Expect(testDeduplicator.RegisterDataset()).To(Succeed())
-						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName, Hash: "test"}))
+						Expect(testDataset.DeduplicatorDescriptor()).To(Equal(&data.DeduplicatorDescriptor{Name: testName, Version: testVersion, Hash: "test"}))
 					})
 				})
 			})

--- a/data/deduplicator/hash_deactivate_old.go
+++ b/data/deduplicator/hash_deactivate_old.go
@@ -19,12 +19,13 @@ type hashDeactivateOldDeduplicator struct {
 	*BaseDeduplicator
 }
 
-const _HashDeactivateOldDeduplicatorName = "hash-deactivate-old"
+const _HashDeactivateOldDeduplicatorName = "org.tidepool.hash-deactivate-old"
+const _HashDeactivateOldDeduplicatorVersion = "1.0.0"
 
 var _HashDeactivateOldExpectedDeviceManufacturers = []string{"Medtronic"}
 
 func NewHashDeactivateOldFactory() (Factory, error) {
-	baseFactory, err := NewBaseFactory(_HashDeactivateOldDeduplicatorName)
+	baseFactory, err := NewBaseFactory(_HashDeactivateOldDeduplicatorName, _HashDeactivateOldDeduplicatorVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +60,7 @@ func (h *hashDeactivateOldFactory) CanDeduplicateDataset(dataset *upload.Upload)
 }
 
 func (h *hashDeactivateOldFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
-	baseDeduplicator, err := NewBaseDeduplicator(h.name, logger, dataStoreSession, dataset)
+	baseDeduplicator, err := NewBaseDeduplicator(h.name, h.version, logger, dataStoreSession, dataset)
 	if err != nil {
 		return nil, err
 	}

--- a/data/deduplicator/truncate.go
+++ b/data/deduplicator/truncate.go
@@ -19,12 +19,13 @@ type truncateDeduplicator struct {
 	*BaseDeduplicator
 }
 
-const _TruncateDeduplicatorName = "truncate"
+const _TruncateDeduplicatorName = "org.tidepool.truncate"
+const _TruncateDeduplicatorVersion = "1.0.0"
 
 var _TruncateExpectedDeviceManufacturers = []string{"Animas"}
 
 func NewTruncateFactory() (Factory, error) {
-	baseFactory, err := NewBaseFactory(_TruncateDeduplicatorName)
+	baseFactory, err := NewBaseFactory(_TruncateDeduplicatorName, _TruncateDeduplicatorVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +60,7 @@ func (t *truncateFactory) CanDeduplicateDataset(dataset *upload.Upload) (bool, e
 }
 
 func (t *truncateFactory) NewDeduplicatorForDataset(logger log.Logger, dataStoreSession store.Session, dataset *upload.Upload) (data.Deduplicator, error) {
-	baseDeduplicator, err := NewBaseDeduplicator(t.name, logger, dataStoreSession, dataset)
+	baseDeduplicator, err := NewBaseDeduplicator(t.name, t.version, logger, dataStoreSession, dataset)
 	if err != nil {
 		return nil, err
 	}

--- a/data/test/deduplicator.go
+++ b/data/test/deduplicator.go
@@ -9,6 +9,8 @@ type Deduplicator struct {
 	ID                            string
 	NameInvocations               int
 	NameOutputs                   []string
+	VersionInvocations            int
+	VersionOutputs                []string
 	RegisterDatasetInvocations    int
 	RegisterDatasetOutputs        []error
 	AddDatasetDataInvocations     int
@@ -35,6 +37,18 @@ func (d *Deduplicator) Name() string {
 
 	output := d.NameOutputs[0]
 	d.NameOutputs = d.NameOutputs[1:]
+	return output
+}
+
+func (d *Deduplicator) Version() string {
+	d.VersionInvocations++
+
+	if len(d.VersionOutputs) == 0 {
+		panic("Unexpected invocation of Version on Deduplicator")
+	}
+
+	output := d.VersionOutputs[0]
+	d.VersionOutputs = d.VersionOutputs[1:]
 	return output
 }
 
@@ -90,6 +104,7 @@ func (d *Deduplicator) DeleteDataset() error {
 
 func (d *Deduplicator) UnusedOutputsCount() int {
 	return len(d.NameOutputs) +
+		len(d.VersionOutputs) +
 		len(d.RegisterDatasetOutputs) +
 		len(d.AddDatasetDataOutputs) +
 		len(d.DeduplicateDatasetOutputs) +


### PR DESCRIPTION
@jh-bate Moving towards a "org.tidepool.X" naming scheme throughout. Add versioning to allow greater flexibility in data mining and implementation.