### PR TITLE
Defer access to context store sessions and log until actually needed

### DIFF
--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -29,15 +29,10 @@ type Store struct {
 	*mongo.Store
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
-	}, nil
+		Session: s.Store.NewSession(logger),
+	}
 }
 
 type Session struct {

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -161,26 +161,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -11,7 +11,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/data/store/test/session.go
+++ b/data/store/test/session.go
@@ -5,6 +5,7 @@ import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/log"
 	commonStore "github.com/tidepool-org/platform/store"
 )
 
@@ -61,6 +62,8 @@ type Session struct {
 	IsClosedInvocations                           int
 	IsClosedOutputs                               []bool
 	CloseInvocations                              int
+	LoggerInvocations                             int
+	LoggerImpl                                    log.Logger
 	SetAgentInvocations                           int
 	SetAgentInputs                                []commonStore.Agent
 	GetDatasetsForUserByIDInvocations             int
@@ -106,7 +109,8 @@ type Session struct {
 
 func NewSession() *Session {
 	return &Session{
-		ID: app.NewID(),
+		ID:         app.NewID(),
+		LoggerImpl: log.NewNull(),
 	}
 }
 
@@ -124,6 +128,12 @@ func (s *Session) IsClosed() bool {
 
 func (s *Session) Close() {
 	s.CloseInvocations++
+}
+
+func (s *Session) Logger() log.Logger {
+	s.LoggerInvocations++
+
+	return s.LoggerImpl
 }
 
 func (s *Session) SetAgent(agent commonStore.Agent) {

--- a/dataservices/service/api/v1/v1_suite_test.go
+++ b/dataservices/service/api/v1/v1_suite_test.go
@@ -125,6 +125,10 @@ func (t *TestTaskStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestTaskStoreSession")
 }
 
+func (t *TestTaskStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestTaskStoreSession")
+}
+
 func (t *TestTaskStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestTaskStoreSession")
 }

--- a/message/store/mongo/mongo.go
+++ b/message/store/mongo/mongo.go
@@ -26,15 +26,10 @@ type Store struct {
 	*mongo.Store
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
-	}, nil
+		Session: s.Store.NewSession(logger),
+	}
 }
 
 type Session struct {

--- a/message/store/mongo/mongo_test.go
+++ b/message/store/mongo/mongo_test.go
@@ -113,26 +113,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/message/store/store.go
+++ b/message/store/store.go
@@ -8,7 +8,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/notification/store/mongo/mongo.go
+++ b/notification/store/mongo/mongo.go
@@ -26,15 +26,10 @@ type Store struct {
 	*mongo.Store
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
-	}, nil
+		Session: s.Store.NewSession(logger),
+	}
 }
 
 type Session struct {

--- a/notification/store/mongo/mongo_test.go
+++ b/notification/store/mongo/mongo_test.go
@@ -99,26 +99,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/notification/store/store.go
+++ b/notification/store/store.go
@@ -8,7 +8,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/permission/store/mongo/mongo.go
+++ b/permission/store/mongo/mongo.go
@@ -38,16 +38,11 @@ type Store struct {
 	config *Config
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
+		Session: s.Store.NewSession(logger),
 		config:  s.config,
-	}, nil
+	}
 }
 
 type Session struct {

--- a/permission/store/mongo/mongo_test.go
+++ b/permission/store/mongo/mongo_test.go
@@ -127,26 +127,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/permission/store/store.go
+++ b/permission/store/store.go
@@ -8,7 +8,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/profile/store/mongo/mongo.go
+++ b/profile/store/mongo/mongo.go
@@ -28,15 +28,10 @@ type Store struct {
 	*mongo.Store
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
-	}, nil
+		Session: s.Store.NewSession(logger),
+	}
 }
 
 type Session struct {

--- a/profile/store/mongo/mongo_test.go
+++ b/profile/store/mongo/mongo_test.go
@@ -84,26 +84,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/profile/store/store.go
+++ b/profile/store/store.go
@@ -9,7 +9,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/service/context/standard.go
+++ b/service/context/standard.go
@@ -39,19 +39,21 @@ func NewStandard(response rest.ResponseWriter, request *rest.Request) (*Standard
 		return nil, errors.New("context", "request is missing")
 	}
 
-	logger := service.GetRequestLogger(request)
-	if logger == nil {
-		logger = log.NewNull()
-	}
-
 	return &Standard{
 		response: response,
 		request:  request,
-		logger:   logger,
 	}, nil
 }
 
 func (s *Standard) Logger() log.Logger {
+	if s.logger == nil {
+		logger := service.GetRequestLogger(s.request)
+		if logger == nil {
+			logger = log.NewNull()
+		}
+		s.logger = logger
+	}
+
 	return s.logger
 }
 
@@ -74,7 +76,7 @@ func (s *Standard) RespondWithError(err *service.Error) {
 }
 
 func (s *Standard) RespondWithInternalServerFailure(message string, failure ...interface{}) {
-	logger := s.logger
+	logger := s.Logger()
 	if len(failure) > 0 {
 		for index := range failure {
 			if err, errOk := failure[index].(error); errOk {

--- a/session/store/mongo/mongo.go
+++ b/session/store/mongo/mongo.go
@@ -26,15 +26,10 @@ type Store struct {
 	*mongo.Store
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
-	}, nil
+		Session: s.Store.NewSession(logger),
+	}
 }
 
 type Session struct {

--- a/session/store/mongo/mongo_test.go
+++ b/session/store/mongo/mongo_test.go
@@ -108,26 +108,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/session/store/store.go
+++ b/session/store/store.go
@@ -8,7 +8,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/store/mongo/mongo.go
+++ b/store/mongo/mongo.go
@@ -134,13 +134,9 @@ func (s *Store) GetStatus() interface{} {
 	return status
 }
 
-func (s *Store) NewSession(logger log.Logger) (*Session, error) {
+func (s *Store) NewSession(logger log.Logger) *Session {
 	if logger == nil {
-		return nil, errors.New("mongo", "logger is missing")
-	}
-
-	if s.IsClosed() {
-		return nil, errors.New("mongo", "store closed")
+		logger = log.NewNull()
 	}
 
 	loggerFields := map[string]interface{}{
@@ -152,7 +148,7 @@ func (s *Store) NewSession(logger log.Logger) (*Session, error) {
 		logger:        logger.WithFields(loggerFields),
 		config:        s.Config,
 		sourceSession: s.Session,
-	}, nil
+	}
 }
 
 type Session struct {

--- a/store/mongo/mongo_test.go
+++ b/store/mongo/mongo_test.go
@@ -154,35 +154,22 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns an error if the logger is missing", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(MatchError("mongo: logger is missing"))
-				Expect(mongoSession).To(BeNil())
-			})
-
-			It("returns an error if the store is closed", func() {
-				mongoStore.Close()
-				Expect(mongoStore.IsClosed()).To(BeTrue())
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).To(MatchError("mongo: store closed"))
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if logger specified", func() {
+				mongoSession = mongoStore.NewSession(logger)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/store/store.go
+++ b/store/store.go
@@ -1,5 +1,7 @@
 package store
 
+import "github.com/tidepool-org/platform/log"
+
 type Store interface {
 	IsClosed() bool
 	Close()
@@ -10,6 +12,8 @@ type Store interface {
 type Session interface {
 	IsClosed() bool
 	Close()
+
+	Logger() log.Logger
 
 	SetAgent(agent Agent)
 }

--- a/task/store/mongo/mongo.go
+++ b/task/store/mongo/mongo.go
@@ -26,15 +26,10 @@ type Store struct {
 	*mongo.Store
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
-	}, nil
+		Session: s.Store.NewSession(logger),
+	}
 }
 
 type Session struct {

--- a/task/store/mongo/mongo_test.go
+++ b/task/store/mongo/mongo_test.go
@@ -95,26 +95,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/task/store/store.go
+++ b/task/store/store.go
@@ -8,7 +8,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/tools/migrate_gid_to_uid/migrate_gid_to_uid.go
+++ b/tools/migrate_gid_to_uid/migrate_gid_to_uid.go
@@ -195,10 +195,7 @@ func buildMetaIDToUserIDMap(logger log.Logger, config *Config) (map[string]strin
 
 	logger.Debug("Creating users session")
 
-	usersSession, err := usersStore.NewSession(logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "migrate_gid_to_uid", "unable to create users session")
-	}
+	usersSession := usersStore.NewSession(logger)
 	defer usersSession.Close()
 
 	logger.Debug("Iterating users")
@@ -272,10 +269,7 @@ func buildGroupIDToUserIDMap(logger log.Logger, config *Config, metaIDToUserIDMa
 
 	logger.Debug("Creating meta session")
 
-	metaSession, err := metaStore.NewSession(logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "migrate_gid_to_uid", "unable to create meta session")
-	}
+	metaSession := metaStore.NewSession(logger)
 	defer metaSession.Close()
 
 	logger.Debug("Iterating meta")
@@ -370,10 +364,7 @@ func migrateGroupIDToUserIDForDeviceData(logger log.Logger, config *Config, grou
 
 	logger.Debug("Creating device data session")
 
-	deviceDataSession, err := deviceDataStore.NewSession(logger)
-	if err != nil {
-		return errors.Wrap(err, "migrate_gid_to_uid", "unable to create device data session")
-	}
+	deviceDataSession := deviceDataStore.NewSession(logger)
 	defer deviceDataSession.Close()
 
 	logger.Debug("Walking group id to user id map")

--- a/tools/migrate_pmid_to_uid/migrate_pmid_to_uid.go
+++ b/tools/migrate_pmid_to_uid/migrate_pmid_to_uid.go
@@ -201,10 +201,7 @@ func buildMetaIDToUserIDMap(logger log.Logger, config *Config) (map[string]strin
 
 	logger.Debug("Creating users session")
 
-	usersSession, err := usersStore.NewSession(logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "migrate_pmid_to_uid", "unable to create users session")
-	}
+	usersSession := usersStore.NewSession(logger)
 	defer usersSession.Close()
 
 	logger.Debug("Iterating users")
@@ -278,10 +275,7 @@ func migrateMetaIDToUserIDForMetadata(logger log.Logger, config *Config, metaIDT
 
 	logger.Debug("Creating metadata session")
 
-	metadataSession, err := metadataStore.NewSession(logger)
-	if err != nil {
-		return errors.Wrap(err, "migrate_pmid_to_uid", "unable to create metadata session")
-	}
+	metadataSession := metadataStore.NewSession(logger)
 	defer metadataSession.Close()
 
 	logger.Debug("Walking meta id to user id map")

--- a/tools/migrate_sessions_expand/migrate_sessions_expand.go
+++ b/tools/migrate_sessions_expand/migrate_sessions_expand.go
@@ -191,16 +191,10 @@ func migrateSessionsToExpandedForm(logger log.Logger, config *Config) error {
 
 	logger.Debug("Creating sessions sessions")
 
-	iterateSessionsSession, err := sessionsStore.NewSession(logger)
-	if err != nil {
-		return errors.Wrap(err, "migrate_sessions_expand", "unable to create iterate sessions session")
-	}
+	iterateSessionsSession := sessionsStore.NewSession(logger)
 	defer iterateSessionsSession.Close()
 
-	updateSessionsSession, err := sessionsStore.NewSession(logger)
-	if err != nil {
-		return errors.Wrap(err, "migrate_sessions_expand", "unable to create update sessions session")
-	}
+	updateSessionsSession := sessionsStore.NewSession(logger)
 	defer updateSessionsSession.Close()
 
 	logger.Debug("Iterating sessions")

--- a/user/store/mongo/mongo.go
+++ b/user/store/mongo/mongo.go
@@ -40,16 +40,11 @@ type Store struct {
 	config *Config
 }
 
-func (s *Store) NewSession(logger log.Logger) (store.Session, error) {
-	baseSession, err := s.Store.NewSession(logger)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *Store) NewSession(logger log.Logger) store.Session {
 	return &Session{
-		Session: baseSession,
+		Session: s.Store.NewSession(logger),
 		config:  s.config,
-	}, nil
+	}
 }
 
 type Session struct {

--- a/user/store/mongo/mongo_test.go
+++ b/user/store/mongo/mongo_test.go
@@ -143,26 +143,23 @@ var _ = Describe("Mongo", func() {
 		})
 
 		Context("NewSession", func() {
-			It("returns an error if unsuccessful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(nil)
-				Expect(err).To(HaveOccurred())
-				Expect(mongoSession).To(BeNil())
+			It("returns a new session if no logger specified", func() {
+				mongoSession = mongoStore.NewSession(nil)
+				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).ToNot(BeNil())
 			})
 
-			It("returns a new session and no error if successful", func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+			It("returns a new session if logger specified", func() {
+				logger := log.NewNull()
+				mongoSession = mongoStore.NewSession(logger)
 				Expect(mongoSession).ToNot(BeNil())
+				Expect(mongoSession.Logger()).To(Equal(logger))
 			})
 		})
 
 		Context("with a new session", func() {
 			BeforeEach(func() {
-				var err error
-				mongoSession, err = mongoStore.NewSession(log.NewNull())
-				Expect(err).ToNot(HaveOccurred())
+				mongoSession = mongoStore.NewSession(log.NewNull())
 				Expect(mongoSession).ToNot(BeNil())
 			})
 

--- a/user/store/store.go
+++ b/user/store/store.go
@@ -9,7 +9,7 @@ import (
 type Store interface {
 	store.Store
 
-	NewSession(logger log.Logger) (Session, error)
+	NewSession(logger log.Logger) Session
 }
 
 type Session interface {

--- a/userservices/service/api/v1/v1_suite_test.go
+++ b/userservices/service/api/v1/v1_suite_test.go
@@ -181,6 +181,10 @@ func (t *TestMessageStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestMessageStoreSession")
 }
 
+func (t *TestMessageStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestMessageStoreSession")
+}
+
 func (t *TestMessageStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestMessageStoreSession")
 }
@@ -217,6 +221,10 @@ func (t *TestNotificationStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestNotificationStoreSession")
 }
 
+func (t *TestNotificationStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestNotificationStoreSession")
+}
+
 func (t *TestNotificationStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestNotificationStoreSession")
 }
@@ -243,6 +251,10 @@ func (t *TestPermissionStoreSession) IsClosed() bool {
 
 func (t *TestPermissionStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestPermissionStoreSession")
+}
+
+func (t *TestPermissionStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestPermissionStoreSession")
 }
 
 func (t *TestPermissionStoreSession) SetAgent(agent commonStore.Agent) {
@@ -280,6 +292,10 @@ func (t *TestProfileStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestProfileStoreSession")
 }
 
+func (t *TestProfileStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestProfileStoreSession")
+}
+
 func (t *TestProfileStoreSession) SetAgent(agent commonStore.Agent) {
 	panic("Unexpected invocation of SetAgent on TestProfileStoreSession")
 }
@@ -314,6 +330,10 @@ func (t *TestSessionStoreSession) IsClosed() bool {
 
 func (t *TestSessionStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestSessionStoreSession")
+}
+
+func (t *TestSessionStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestSessionStoreSession")
 }
 
 func (t *TestSessionStoreSession) SetAgent(agent commonStore.Agent) {
@@ -358,6 +378,10 @@ func (t *TestUserStoreSession) IsClosed() bool {
 
 func (t *TestUserStoreSession) Close() {
 	panic("Unexpected invocation of Close on TestUserStoreSession")
+}
+
+func (t *TestUserStoreSession) Logger() log.Logger {
+	panic("Unexpected invocation of Logger on TestUserStoreSession")
 }
 
 func (t *TestUserStoreSession) SetAgent(agent commonStore.Agent) {


### PR DESCRIPTION
@jh-bate Delay creation of context store sessions until actually needed. Allows for additional configuration later in the request cycle. Also eliminates unnecessary work.