### PR TITLE
Add header middleware; add MD5 hash of authentication token to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 ## HEAD
 
+- Bump `hash_deactivate_old` data deduplicator to version 1.1.0
+- Update `hash_deactivate_old` data deduplicator to use archived dataset id and time fields to accurately:
+  - Deactivate deduplicate data on dataset addition
+  - Activate undeduplicated data on dataset deletion
+  - Record entire deduplication history
+- Update mongo queries related to `hash_deactivate_old` data deduplicator
+- Remove backwards-compatible legacy deduplicator name test in `DeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator` (after `v1.8.0` required migration)
+- Add archived dataset id and time fields to base data type
 - Add MD5 hash of authentication token to request logger
 - Add service middleware to extract select request headers and add as request logger fields
 - Defer access to context store sessions and log until actually needed
 
-## 1.8.0 (2017-08-09)
+## v1.8.0 (2017-08-09)
 
 - Add CHANGELOG.md
 - **REQUIRED MIGRATION**: `migrate_data_deduplicator_descriptor` - data deduplicator descriptor name and version
@@ -17,4 +25,6 @@
 - Remove unused data store functionality
 - Remove unused data deduplicators
 
-## 1.7.0 (2017-06-22)
+## v1.7.0 (2017-06-22)
+
+- See commit history for details on this and all previous releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+- Add MD5 hash of authentication token to request logger
+- Add service middleware to extract select request headers and add as request logger fields
 - Defer access to context store sessions and log until actually needed
 
 ## 1.8.0 (2017-08-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## v1.9.0 (2017-08-10)
+
 - Bump `hash_deactivate_old` data deduplicator to version 1.1.0
 - Update `hash_deactivate_old` data deduplicator to use archived dataset id and time fields to accurately:
   - Deactivate deduplicate data on dataset addition

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -4,9 +4,15 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/md5"
+	"encoding/hex"
 
 	"github.com/tidepool-org/platform/errors"
 )
+
+func HashWithMD5(sourceString string) string {
+	md5Sum := md5.Sum([]byte(sourceString))
+	return hex.EncodeToString(md5Sum[:])
+}
 
 func EncryptWithAES256UsingPassphrase(bytes []byte, passphrase []byte) (_ []byte, err error) {
 	defer func() {

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/tidepool-org/platform/errors"
 )
@@ -34,8 +33,7 @@ func (d *DeduplicatorDescriptor) IsRegisteredWithAnyDeduplicator() bool {
 }
 
 func (d *DeduplicatorDescriptor) IsRegisteredWithNamedDeduplicator(name string) bool {
-	// TODO: Backwards compatible until after data migration to update deduplicator name scheme
-	return d.Name == name || d.Name == strings.TrimPrefix(name, "org.tidepool.")
+	return d.Name == name
 }
 
 func (d *DeduplicatorDescriptor) RegisterWithDeduplicator(deduplicator Deduplicator) error {

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -19,15 +19,13 @@ type Session interface {
 
 	GetDatasetsForUserByID(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
 	GetDatasetByID(datasetID string) (*upload.Upload, error)
-	FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error)
 	CreateDataset(dataset *upload.Upload) error
 	UpdateDataset(dataset *upload.Upload) error
 	DeleteDataset(dataset *upload.Upload) error
-	GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error)
 	CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error
 	ActivateDatasetData(dataset *upload.Upload) error
-	SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error
-	SetDeviceDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error
+	ArchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error
+	UnarchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
 	DestroyDataForUserByID(userID string) error
 }

--- a/data/store/test/session.go
+++ b/data/store/test/session.go
@@ -25,86 +25,53 @@ type GetDatasetByIDOutput struct {
 	Error   error
 }
 
-type FindPreviousActiveDatasetForDeviceOutput struct {
-	Dataset *upload.Upload
-	Error   error
-}
-
-type GetDatasetDataDeduplicatorHashesInput struct {
-	Dataset *upload.Upload
-	Active  bool
-}
-
-type GetDatasetDataDeduplicatorHashesOutput struct {
-	Hashes []string
-	Error  error
-}
-
 type CreateDatasetDataInput struct {
 	Dataset     *upload.Upload
 	DatasetData []data.Datum
 }
 
-type SetDatasetDataActiveUsingHashesInput struct {
-	Dataset *upload.Upload
-	Hashes  []string
-	Active  bool
-}
-
-type SetDeviceDataActiveUsingHashesInput struct {
-	Dataset *upload.Upload
-	Hashes  []string
-	Active  bool
-}
-
 type Session struct {
-	ID                                            string
-	IsClosedInvocations                           int
-	IsClosedOutputs                               []bool
-	CloseInvocations                              int
-	LoggerInvocations                             int
-	LoggerImpl                                    log.Logger
-	SetAgentInvocations                           int
-	SetAgentInputs                                []commonStore.Agent
-	GetDatasetsForUserByIDInvocations             int
-	GetDatasetsForUserByIDInputs                  []GetDatasetsForUserByIDInput
-	GetDatasetsForUserByIDOutputs                 []GetDatasetsForUserByIDOutput
-	GetDatasetByIDInvocations                     int
-	GetDatasetByIDInputs                          []string
-	GetDatasetByIDOutputs                         []GetDatasetByIDOutput
-	FindPreviousActiveDatasetForDeviceInvocations int
-	FindPreviousActiveDatasetForDeviceInputs      []*upload.Upload
-	FindPreviousActiveDatasetForDeviceOutputs     []FindPreviousActiveDatasetForDeviceOutput
-	CreateDatasetInvocations                      int
-	CreateDatasetInputs                           []*upload.Upload
-	CreateDatasetOutputs                          []error
-	UpdateDatasetInvocations                      int
-	UpdateDatasetInputs                           []*upload.Upload
-	UpdateDatasetOutputs                          []error
-	DeleteDatasetInvocations                      int
-	DeleteDatasetInputs                           []*upload.Upload
-	DeleteDatasetOutputs                          []error
-	GetDatasetDataDeduplicatorHashesInvocations   int
-	GetDatasetDataDeduplicatorHashesInputs        []GetDatasetDataDeduplicatorHashesInput
-	GetDatasetDataDeduplicatorHashesOutputs       []GetDatasetDataDeduplicatorHashesOutput
-	CreateDatasetDataInvocations                  int
-	CreateDatasetDataInputs                       []CreateDatasetDataInput
-	CreateDatasetDataOutputs                      []error
-	ActivateDatasetDataInvocations                int
-	ActivateDatasetDataInputs                     []*upload.Upload
-	ActivateDatasetDataOutputs                    []error
-	SetDatasetDataActiveUsingHashesInvocations    int
-	SetDatasetDataActiveUsingHashesInputs         []SetDatasetDataActiveUsingHashesInput
-	SetDatasetDataActiveUsingHashesOutputs        []error
-	SetDeviceDataActiveUsingHashesInvocations     int
-	SetDeviceDataActiveUsingHashesInputs          []SetDeviceDataActiveUsingHashesInput
-	SetDeviceDataActiveUsingHashesOutputs         []error
-	DeleteOtherDatasetDataInvocations             int
-	DeleteOtherDatasetDataInputs                  []*upload.Upload
-	DeleteOtherDatasetDataOutputs                 []error
-	DestroyDataForUserByIDInvocations             int
-	DestroyDataForUserByIDInputs                  []string
-	DestroyDataForUserByIDOutputs                 []error
+	ID                                                   string
+	IsClosedInvocations                                  int
+	IsClosedOutputs                                      []bool
+	CloseInvocations                                     int
+	LoggerInvocations                                    int
+	LoggerImpl                                           log.Logger
+	SetAgentInvocations                                  int
+	SetAgentInputs                                       []commonStore.Agent
+	GetDatasetsForUserByIDInvocations                    int
+	GetDatasetsForUserByIDInputs                         []GetDatasetsForUserByIDInput
+	GetDatasetsForUserByIDOutputs                        []GetDatasetsForUserByIDOutput
+	GetDatasetByIDInvocations                            int
+	GetDatasetByIDInputs                                 []string
+	GetDatasetByIDOutputs                                []GetDatasetByIDOutput
+	CreateDatasetInvocations                             int
+	CreateDatasetInputs                                  []*upload.Upload
+	CreateDatasetOutputs                                 []error
+	UpdateDatasetInvocations                             int
+	UpdateDatasetInputs                                  []*upload.Upload
+	UpdateDatasetOutputs                                 []error
+	DeleteDatasetInvocations                             int
+	DeleteDatasetInputs                                  []*upload.Upload
+	DeleteDatasetOutputs                                 []error
+	CreateDatasetDataInvocations                         int
+	CreateDatasetDataInputs                              []CreateDatasetDataInput
+	CreateDatasetDataOutputs                             []error
+	ActivateDatasetDataInvocations                       int
+	ActivateDatasetDataInputs                            []*upload.Upload
+	ActivateDatasetDataOutputs                           []error
+	ArchiveDeviceDataUsingHashesFromDatasetInvocations   int
+	ArchiveDeviceDataUsingHashesFromDatasetInputs        []*upload.Upload
+	ArchiveDeviceDataUsingHashesFromDatasetOutputs       []error
+	UnarchiveDeviceDataUsingHashesFromDatasetInvocations int
+	UnarchiveDeviceDataUsingHashesFromDatasetInputs      []*upload.Upload
+	UnarchiveDeviceDataUsingHashesFromDatasetOutputs     []error
+	DeleteOtherDatasetDataInvocations                    int
+	DeleteOtherDatasetDataInputs                         []*upload.Upload
+	DeleteOtherDatasetDataOutputs                        []error
+	DestroyDataForUserByIDInvocations                    int
+	DestroyDataForUserByIDInputs                         []string
+	DestroyDataForUserByIDOutputs                        []error
 }
 
 func NewSession() *Session {
@@ -170,20 +137,6 @@ func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	return output.Dataset, output.Error
 }
 
-func (s *Session) FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error) {
-	s.FindPreviousActiveDatasetForDeviceInvocations++
-
-	s.FindPreviousActiveDatasetForDeviceInputs = append(s.FindPreviousActiveDatasetForDeviceInputs, dataset)
-
-	if len(s.FindPreviousActiveDatasetForDeviceOutputs) == 0 {
-		panic("Unexpected invocation of FindPreviousActiveDatasetForDevice on Session")
-	}
-
-	output := s.FindPreviousActiveDatasetForDeviceOutputs[0]
-	s.FindPreviousActiveDatasetForDeviceOutputs = s.FindPreviousActiveDatasetForDeviceOutputs[1:]
-	return output.Dataset, output.Error
-}
-
 func (s *Session) CreateDataset(dataset *upload.Upload) error {
 	s.CreateDatasetInvocations++
 
@@ -226,20 +179,6 @@ func (s *Session) DeleteDataset(dataset *upload.Upload) error {
 	return output
 }
 
-func (s *Session) GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error) {
-	s.GetDatasetDataDeduplicatorHashesInvocations++
-
-	s.GetDatasetDataDeduplicatorHashesInputs = append(s.GetDatasetDataDeduplicatorHashesInputs, GetDatasetDataDeduplicatorHashesInput{dataset, active})
-
-	if len(s.GetDatasetDataDeduplicatorHashesOutputs) == 0 {
-		panic("Unexpected invocation of GetDatasetDataDeduplicatorHashes on Session")
-	}
-
-	output := s.GetDatasetDataDeduplicatorHashesOutputs[0]
-	s.GetDatasetDataDeduplicatorHashesOutputs = s.GetDatasetDataDeduplicatorHashesOutputs[1:]
-	return output.Hashes, output.Error
-}
-
 func (s *Session) CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error {
 	s.CreateDatasetDataInvocations++
 
@@ -268,31 +207,31 @@ func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 	return output
 }
 
-func (s *Session) SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error {
-	s.SetDatasetDataActiveUsingHashesInvocations++
+func (s *Session) ArchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error {
+	s.ArchiveDeviceDataUsingHashesFromDatasetInvocations++
 
-	s.SetDatasetDataActiveUsingHashesInputs = append(s.SetDatasetDataActiveUsingHashesInputs, SetDatasetDataActiveUsingHashesInput{dataset, queryHashes, active})
+	s.ArchiveDeviceDataUsingHashesFromDatasetInputs = append(s.ArchiveDeviceDataUsingHashesFromDatasetInputs, dataset)
 
-	if len(s.SetDatasetDataActiveUsingHashesOutputs) == 0 {
-		panic("Unexpected invocation of SetDatasetDataActiveUsingHashes on Session")
+	if len(s.ArchiveDeviceDataUsingHashesFromDatasetOutputs) == 0 {
+		panic("Unexpected invocation of ArchiveDeviceDataUsingHashesFromDataset on Session")
 	}
 
-	output := s.SetDatasetDataActiveUsingHashesOutputs[0]
-	s.SetDatasetDataActiveUsingHashesOutputs = s.SetDatasetDataActiveUsingHashesOutputs[1:]
+	output := s.ArchiveDeviceDataUsingHashesFromDatasetOutputs[0]
+	s.ArchiveDeviceDataUsingHashesFromDatasetOutputs = s.ArchiveDeviceDataUsingHashesFromDatasetOutputs[1:]
 	return output
 }
 
-func (s *Session) SetDeviceDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error {
-	s.SetDeviceDataActiveUsingHashesInvocations++
+func (s *Session) UnarchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error {
+	s.UnarchiveDeviceDataUsingHashesFromDatasetInvocations++
 
-	s.SetDeviceDataActiveUsingHashesInputs = append(s.SetDeviceDataActiveUsingHashesInputs, SetDeviceDataActiveUsingHashesInput{dataset, queryHashes, active})
+	s.UnarchiveDeviceDataUsingHashesFromDatasetInputs = append(s.UnarchiveDeviceDataUsingHashesFromDatasetInputs, dataset)
 
-	if len(s.SetDeviceDataActiveUsingHashesOutputs) == 0 {
-		panic("Unexpected invocation of SetDeviceDataActiveUsingHashes on Session")
+	if len(s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs) == 0 {
+		panic("Unexpected invocation of UnarchiveDeviceDataUsingHashesFromDataset on Session")
 	}
 
-	output := s.SetDeviceDataActiveUsingHashesOutputs[0]
-	s.SetDeviceDataActiveUsingHashesOutputs = s.SetDeviceDataActiveUsingHashesOutputs[1:]
+	output := s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs[0]
+	s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs = s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs[1:]
 	return output
 }
 
@@ -328,14 +267,13 @@ func (s *Session) UnusedOutputsCount() int {
 	return len(s.IsClosedOutputs) +
 		len(s.GetDatasetsForUserByIDOutputs) +
 		len(s.GetDatasetByIDOutputs) +
-		len(s.FindPreviousActiveDatasetForDeviceOutputs) +
 		len(s.CreateDatasetOutputs) +
 		len(s.UpdateDatasetOutputs) +
 		len(s.DeleteDatasetOutputs) +
-		len(s.GetDatasetDataDeduplicatorHashesOutputs) +
 		len(s.CreateDatasetDataOutputs) +
 		len(s.ActivateDatasetDataOutputs) +
-		len(s.SetDatasetDataActiveUsingHashesOutputs) +
+		len(s.ArchiveDeviceDataUsingHashesFromDatasetOutputs) +
+		len(s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs) +
 		len(s.DeleteOtherDatasetDataOutputs) +
 		len(s.DestroyDataForUserByIDOutputs)
 }

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -9,22 +9,24 @@ import (
 const SchemaVersionCurrent = 3
 
 type Base struct {
-	Active         bool                         `json:"-" bson:"_active"`
-	CreatedTime    string                       `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
-	CreatedUserID  string                       `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
-	Deduplicator   *data.DeduplicatorDescriptor `json:"-" bson:"_deduplicator,omitempty"`
-	DeletedTime    string                       `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
-	DeletedUserID  string                       `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
-	GroupID        string                       `json:"-" bson:"_groupId,omitempty"`
-	GUID           string                       `json:"guid,omitempty" bson:"guid,omitempty"`
-	ID             string                       `json:"id,omitempty" bson:"id,omitempty"`
-	ModifiedTime   string                       `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
-	ModifiedUserID string                       `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
-	SchemaVersion  int                          `json:"-" bson:"_schemaVersion,omitempty"`
-	Type           string                       `json:"type,omitempty" bson:"type,omitempty"`
-	UploadID       string                       `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
-	UserID         string                       `json:"-" bson:"_userId,omitempty"`
-	Version        int                          `json:"-" bson:"_version,omitempty"`
+	Active            bool                         `json:"-" bson:"_active"`
+	ArchivedDatasetID string                       `json:"-" bson:"archivedDatasetId,omitempty"`
+	ArchivedTime      string                       `json:"-" bson:"archivedTime,omitempty"`
+	CreatedTime       string                       `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
+	CreatedUserID     string                       `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
+	Deduplicator      *data.DeduplicatorDescriptor `json:"-" bson:"_deduplicator,omitempty"`
+	DeletedTime       string                       `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
+	DeletedUserID     string                       `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
+	GroupID           string                       `json:"-" bson:"_groupId,omitempty"`
+	GUID              string                       `json:"guid,omitempty" bson:"guid,omitempty"`
+	ID                string                       `json:"id,omitempty" bson:"id,omitempty"`
+	ModifiedTime      string                       `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	ModifiedUserID    string                       `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
+	SchemaVersion     int                          `json:"-" bson:"_schemaVersion,omitempty"`
+	Type              string                       `json:"type,omitempty" bson:"type,omitempty"`
+	UploadID          string                       `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
+	UserID            string                       `json:"-" bson:"_userId,omitempty"`
+	Version           int                          `json:"-" bson:"_version,omitempty"`
 
 	Annotations      *[]interface{} `json:"annotations,omitempty" bson:"annotations,omitempty"`
 	ClockDriftOffset *int           `json:"clockDriftOffset,omitempty" bson:"clockDriftOffset,omitempty"`
@@ -43,6 +45,8 @@ type Meta struct {
 
 func (b *Base) Init() {
 	b.Active = false
+	b.ArchivedDatasetID = ""
+	b.ArchivedTime = ""
 	b.CreatedTime = ""
 	b.CreatedUserID = ""
 	b.Deduplicator = nil

--- a/dataservices/service/service/standard.go
+++ b/dataservices/service/service/standard.go
@@ -4,10 +4,12 @@ import (
 	"github.com/tidepool-org/platform/data/deduplicator"
 	"github.com/tidepool-org/platform/data/factory"
 	dataMongo "github.com/tidepool-org/platform/data/store/mongo"
+	dataservicesClient "github.com/tidepool-org/platform/dataservices/client"
 	"github.com/tidepool-org/platform/dataservices/service/api"
 	"github.com/tidepool-org/platform/dataservices/service/api/v1"
 	"github.com/tidepool-org/platform/errors"
 	metricservicesClient "github.com/tidepool-org/platform/metricservices/client"
+	"github.com/tidepool-org/platform/service/middleware"
 	"github.com/tidepool-org/platform/service/server"
 	"github.com/tidepool-org/platform/service/service"
 	baseMongo "github.com/tidepool-org/platform/store/mongo"
@@ -244,6 +246,11 @@ func (s *Standard) initializeDataServicesAPI() error {
 	if err = s.dataServicesAPI.InitializeMiddleware(); err != nil {
 		return errors.Wrap(err, "service", "unable to initialize data services api middleware")
 	}
+
+	s.Logger().Debug("Configuring data services api middleware headers")
+
+	s.dataServicesAPI.HeaderMiddleware().AddHeaderFieldFunc(
+		dataservicesClient.TidepoolAuthenticationTokenHeaderName, middleware.NewMD5FieldFunc("authenticationTokenMD5"))
 
 	s.Logger().Debug("Initializing data services api router")
 

--- a/service/api/standard.go
+++ b/service/api/standard.go
@@ -17,6 +17,7 @@ type Standard struct {
 	environmentReporter environment.Reporter
 	logger              log.Logger
 	api                 *rest.Api
+	headerMiddleware    *middleware.Header
 	statusMiddleware    *rest.StatusMiddleware
 }
 
@@ -55,6 +56,10 @@ func (s *Standard) API() *rest.Api {
 	return s.api
 }
 
+func (s *Standard) HeaderMiddleware() *middleware.Header {
+	return s.headerMiddleware
+}
+
 func (s *Standard) StatusMiddleware() *rest.StatusMiddleware {
 	return s.statusMiddleware
 }
@@ -69,6 +74,10 @@ func (s *Standard) InitializeMiddleware() error {
 		return err
 	}
 	traceMiddleware, err := middleware.NewTrace()
+	if err != nil {
+		return err
+	}
+	headerMiddleware, err := middleware.NewHeader()
 	if err != nil {
 		return err
 	}
@@ -89,6 +98,7 @@ func (s *Standard) InitializeMiddleware() error {
 	middlewareStack := []rest.Middleware{
 		loggerMiddleware,
 		traceMiddleware,
+		headerMiddleware,
 		accessLogMiddleware,
 		statusMiddleware,
 		timerMiddleware,
@@ -99,6 +109,7 @@ func (s *Standard) InitializeMiddleware() error {
 
 	s.api.Use(middlewareStack...)
 
+	s.headerMiddleware = headerMiddleware
 	s.statusMiddleware = statusMiddleware
 
 	return nil

--- a/service/middleware/header.go
+++ b/service/middleware/header.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"github.com/ant0ine/go-json-rest/rest"
+
+	"github.com/tidepool-org/platform/crypto"
+	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/service"
+)
+
+type FieldFunc func(newFields log.Fields, value string) log.Fields
+
+type StringFieldFuncMap map[string]FieldFunc
+
+type Header struct {
+	HeaderFieldFuncs StringFieldFuncMap
+}
+
+const (
+	_HeaderValueMaximumLength = 256
+)
+
+func NewRawFieldFunc(key string) FieldFunc {
+	return func(fields log.Fields, value string) log.Fields {
+		if value != "" {
+			if len(value) > _HeaderValueMaximumLength {
+				value = value[:_HeaderValueMaximumLength]
+			}
+			fields[key] = value
+		}
+		return fields
+	}
+}
+
+func NewMD5FieldFunc(key string) FieldFunc {
+	return func(fields log.Fields, value string) log.Fields {
+		if value != "" {
+			fields[key] = crypto.HashWithMD5(value)
+		}
+		return fields
+	}
+}
+
+func NewHeader() (*Header, error) {
+	return &Header{
+		HeaderFieldFuncs: StringFieldFuncMap{},
+	}, nil
+}
+
+func (h *Header) AddHeaderFieldFunc(header string, fieldFunc FieldFunc) {
+	h.HeaderFieldFuncs[header] = fieldFunc
+}
+
+func (h *Header) MiddlewareFunc(handler rest.HandlerFunc) rest.HandlerFunc {
+	return func(response rest.ResponseWriter, request *rest.Request) {
+		if handler != nil && response != nil && request != nil {
+			oldLogger := service.GetRequestLogger(request)
+
+			defer func() {
+				service.SetRequestLogger(request, oldLogger)
+			}()
+
+			if oldLogger != nil {
+				newFields := log.Fields{}
+
+				for header, fieldFunc := range h.HeaderFieldFuncs {
+					if fieldFunc != nil {
+						newFields = fieldFunc(newFields, request.Header.Get(header))
+					}
+				}
+
+				if len(newFields) > 0 {
+					service.SetRequestLogger(request, oldLogger.WithFields(newFields))
+				}
+			}
+
+			handler(response, request)
+		}
+	}
+}

--- a/service/middleware/header_test.go
+++ b/service/middleware/header_test.go
@@ -1,0 +1,87 @@
+package middleware_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"strings"
+
+	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/service/middleware"
+)
+
+var _ = Describe("Header", func() {
+	Context("NewRawFieldFunc", func() {
+		var fieldFunc middleware.FieldFunc
+		var testFields log.Fields
+
+		BeforeEach(func() {
+			fieldFunc = middleware.NewRawFieldFunc("new")
+			testFields = log.Fields{}
+			testFields["existing"] = "value-for-existing"
+		})
+
+		It("the function does not add an empty string", func() {
+			Expect(fieldFunc(testFields, "")).To(Equal(log.Fields{"existing": "value-for-existing"}))
+		})
+
+		It("the function adds a string", func() {
+			Expect(fieldFunc(testFields, "value-for-new")).To(Equal(log.Fields{"existing": "value-for-existing", "new": "value-for-new"}))
+		})
+
+		It("the function adds a string truncated to 256 characters", func() {
+			longString := strings.Repeat("1234567890", 100)
+			Expect(fieldFunc(testFields, longString)).To(Equal(log.Fields{"existing": "value-for-existing", "new": longString[:256]}))
+		})
+	})
+
+	Context("NewMD5FieldFunc", func() {
+		var fieldFunc middleware.FieldFunc
+		var testFields log.Fields
+
+		BeforeEach(func() {
+			fieldFunc = middleware.NewMD5FieldFunc("new")
+			testFields = log.Fields{}
+			testFields["existing"] = "value-for-existing"
+		})
+
+		It("the function does not add an empty string", func() {
+			Expect(fieldFunc(testFields, "")).To(Equal(log.Fields{"existing": "value-for-existing"}))
+		})
+
+		It("the function adds a string hashed using MD5", func() {
+			Expect(fieldFunc(testFields, "value-for-new")).To(Equal(log.Fields{"existing": "value-for-existing", "new": "1823b9b9b0d449ca00fe70e37436b8a0"}))
+		})
+	})
+
+	Context("NewHeader", func() {
+		It("returns successfully", func() {
+			headerMiddleware, err := middleware.NewHeader()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(headerMiddleware).ToNot(BeNil())
+			Expect(headerMiddleware.HeaderFieldFuncs).ToNot(BeNil())
+		})
+	})
+
+	Context("with header middleware", func() {
+		var headerMiddleware *middleware.Header
+
+		BeforeEach(func() {
+			var err error
+			headerMiddleware, err = middleware.NewHeader()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(headerMiddleware).ToNot(BeNil())
+		})
+
+		Context("AddHeaderFieldFunc", func() {
+			It("adds the header field func", func() {
+				existingFunc := middleware.NewRawFieldFunc("existing")
+				headerMiddleware.HeaderFieldFuncs["existing"] = existingFunc
+				newFunc := middleware.NewRawFieldFunc("new")
+				headerMiddleware.AddHeaderFieldFunc("new", newFunc)
+				Expect(headerMiddleware.HeaderFieldFuncs).To(HaveKey("existing"))
+				Expect(headerMiddleware.HeaderFieldFuncs).To(HaveKey("new"))
+			})
+		})
+	})
+})

--- a/userservices/client/standard.go
+++ b/userservices/client/standard.go
@@ -111,7 +111,7 @@ func (s *Standard) ValidateAuthenticationToken(context service.Context, authenti
 		return nil, errors.New("client", "client is closed")
 	}
 
-	context.Logger().WithField("authenticationToken", authenticationToken).Debug("Validating authentication token")
+	context.Logger().Debug("Validating authentication token")
 
 	var authentication struct {
 		IsServer bool

--- a/userservices/service/service/standard.go
+++ b/userservices/service/service/standard.go
@@ -8,6 +8,7 @@ import (
 	notificationMongo "github.com/tidepool-org/platform/notification/store/mongo"
 	permissionMongo "github.com/tidepool-org/platform/permission/store/mongo"
 	profileMongo "github.com/tidepool-org/platform/profile/store/mongo"
+	"github.com/tidepool-org/platform/service/middleware"
 	"github.com/tidepool-org/platform/service/server"
 	"github.com/tidepool-org/platform/service/service"
 	sessionMongo "github.com/tidepool-org/platform/session/store/mongo"
@@ -330,6 +331,11 @@ func (s *Standard) initializeUserServicesAPI() error {
 	if err = s.userServicesAPI.InitializeMiddleware(); err != nil {
 		return errors.Wrap(err, "service", "unable to initialize user services api middleware")
 	}
+
+	s.Logger().Debug("Configuring user services api middleware headers")
+
+	s.userServicesAPI.HeaderMiddleware().AddHeaderFieldFunc(
+		userservicesClient.TidepoolAuthenticationTokenHeaderName, middleware.NewMD5FieldFunc("authenticationTokenMD5"))
 
 	s.Logger().Debug("Initializing user services api router")
 


### PR DESCRIPTION
@jh-bate Needed this for debugging a problem on production recently. Adding it so we have it in the future. The authentication token (X-Tidepool-Session-Token header value) is MD5 hashed first before adding to the log to 1) prevent unnecessary exposure of session tokens; and 2) shrink the size of the value added to the log. This means that you need to run the session token through an MD5 hasher before searching the logs.