### PR TITLE
Add data archive fields; revamp Mongo queries for consistent deduplication and delete for Medtronic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 ## HEAD
 
+- Bump `hash_deactivate_old` data deduplicator to version 1.1.0
+- Update `hash_deactivate_old` data deduplicator to use archived dataset id and time fields to accurately:
+  - Deactivate deduplicate data on dataset addition
+  - Activate undeduplicated data on dataset deletion
+  - Record entire deduplication history
+- Update mongo queries related to `hash_deactivate_old` data deduplicator
+- Remove backwards-compatible legacy deduplicator name test in `DeduplicatorDescriptor.IsRegisteredWithNamedDeduplicator` (after `v1.8.0` required migration)
+- Add archived dataset id and time fields to base data type
 - Add MD5 hash of authentication token to request logger
 - Add service middleware to extract select request headers and add as request logger fields
 - Defer access to context store sessions and log until actually needed
 
-## 1.8.0 (2017-08-09)
+## v1.8.0 (2017-08-09)
 
 - Add CHANGELOG.md
 - **REQUIRED MIGRATION**: `migrate_data_deduplicator_descriptor` - data deduplicator descriptor name and version
@@ -17,4 +25,6 @@
 - Remove unused data store functionality
 - Remove unused data deduplicators
 
-## 1.7.0 (2017-06-22)
+## v1.7.0 (2017-06-22)
+
+- See commit history for details on this and all previous releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## v1.9.0 (2017-08-10)
+
 - Bump `hash_deactivate_old` data deduplicator to version 1.1.0
 - Update `hash_deactivate_old` data deduplicator to use archived dataset id and time fields to accurately:
   - Deactivate deduplicate data on dataset addition

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/tidepool-org/platform/errors"
 )
@@ -34,8 +33,7 @@ func (d *DeduplicatorDescriptor) IsRegisteredWithAnyDeduplicator() bool {
 }
 
 func (d *DeduplicatorDescriptor) IsRegisteredWithNamedDeduplicator(name string) bool {
-	// TODO: Backwards compatible until after data migration to update deduplicator name scheme
-	return d.Name == name || d.Name == strings.TrimPrefix(name, "org.tidepool.")
+	return d.Name == name
 }
 
 func (d *DeduplicatorDescriptor) RegisterWithDeduplicator(deduplicator Deduplicator) error {

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -19,15 +19,13 @@ type Session interface {
 
 	GetDatasetsForUserByID(userID string, filter *Filter, pagination *Pagination) ([]*upload.Upload, error)
 	GetDatasetByID(datasetID string) (*upload.Upload, error)
-	FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error)
 	CreateDataset(dataset *upload.Upload) error
 	UpdateDataset(dataset *upload.Upload) error
 	DeleteDataset(dataset *upload.Upload) error
-	GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error)
 	CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error
 	ActivateDatasetData(dataset *upload.Upload) error
-	SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error
-	SetDeviceDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error
+	ArchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error
+	UnarchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error
 	DeleteOtherDatasetData(dataset *upload.Upload) error
 	DestroyDataForUserByID(userID string) error
 }

--- a/data/store/test/session.go
+++ b/data/store/test/session.go
@@ -25,86 +25,53 @@ type GetDatasetByIDOutput struct {
 	Error   error
 }
 
-type FindPreviousActiveDatasetForDeviceOutput struct {
-	Dataset *upload.Upload
-	Error   error
-}
-
-type GetDatasetDataDeduplicatorHashesInput struct {
-	Dataset *upload.Upload
-	Active  bool
-}
-
-type GetDatasetDataDeduplicatorHashesOutput struct {
-	Hashes []string
-	Error  error
-}
-
 type CreateDatasetDataInput struct {
 	Dataset     *upload.Upload
 	DatasetData []data.Datum
 }
 
-type SetDatasetDataActiveUsingHashesInput struct {
-	Dataset *upload.Upload
-	Hashes  []string
-	Active  bool
-}
-
-type SetDeviceDataActiveUsingHashesInput struct {
-	Dataset *upload.Upload
-	Hashes  []string
-	Active  bool
-}
-
 type Session struct {
-	ID                                            string
-	IsClosedInvocations                           int
-	IsClosedOutputs                               []bool
-	CloseInvocations                              int
-	LoggerInvocations                             int
-	LoggerImpl                                    log.Logger
-	SetAgentInvocations                           int
-	SetAgentInputs                                []commonStore.Agent
-	GetDatasetsForUserByIDInvocations             int
-	GetDatasetsForUserByIDInputs                  []GetDatasetsForUserByIDInput
-	GetDatasetsForUserByIDOutputs                 []GetDatasetsForUserByIDOutput
-	GetDatasetByIDInvocations                     int
-	GetDatasetByIDInputs                          []string
-	GetDatasetByIDOutputs                         []GetDatasetByIDOutput
-	FindPreviousActiveDatasetForDeviceInvocations int
-	FindPreviousActiveDatasetForDeviceInputs      []*upload.Upload
-	FindPreviousActiveDatasetForDeviceOutputs     []FindPreviousActiveDatasetForDeviceOutput
-	CreateDatasetInvocations                      int
-	CreateDatasetInputs                           []*upload.Upload
-	CreateDatasetOutputs                          []error
-	UpdateDatasetInvocations                      int
-	UpdateDatasetInputs                           []*upload.Upload
-	UpdateDatasetOutputs                          []error
-	DeleteDatasetInvocations                      int
-	DeleteDatasetInputs                           []*upload.Upload
-	DeleteDatasetOutputs                          []error
-	GetDatasetDataDeduplicatorHashesInvocations   int
-	GetDatasetDataDeduplicatorHashesInputs        []GetDatasetDataDeduplicatorHashesInput
-	GetDatasetDataDeduplicatorHashesOutputs       []GetDatasetDataDeduplicatorHashesOutput
-	CreateDatasetDataInvocations                  int
-	CreateDatasetDataInputs                       []CreateDatasetDataInput
-	CreateDatasetDataOutputs                      []error
-	ActivateDatasetDataInvocations                int
-	ActivateDatasetDataInputs                     []*upload.Upload
-	ActivateDatasetDataOutputs                    []error
-	SetDatasetDataActiveUsingHashesInvocations    int
-	SetDatasetDataActiveUsingHashesInputs         []SetDatasetDataActiveUsingHashesInput
-	SetDatasetDataActiveUsingHashesOutputs        []error
-	SetDeviceDataActiveUsingHashesInvocations     int
-	SetDeviceDataActiveUsingHashesInputs          []SetDeviceDataActiveUsingHashesInput
-	SetDeviceDataActiveUsingHashesOutputs         []error
-	DeleteOtherDatasetDataInvocations             int
-	DeleteOtherDatasetDataInputs                  []*upload.Upload
-	DeleteOtherDatasetDataOutputs                 []error
-	DestroyDataForUserByIDInvocations             int
-	DestroyDataForUserByIDInputs                  []string
-	DestroyDataForUserByIDOutputs                 []error
+	ID                                                   string
+	IsClosedInvocations                                  int
+	IsClosedOutputs                                      []bool
+	CloseInvocations                                     int
+	LoggerInvocations                                    int
+	LoggerImpl                                           log.Logger
+	SetAgentInvocations                                  int
+	SetAgentInputs                                       []commonStore.Agent
+	GetDatasetsForUserByIDInvocations                    int
+	GetDatasetsForUserByIDInputs                         []GetDatasetsForUserByIDInput
+	GetDatasetsForUserByIDOutputs                        []GetDatasetsForUserByIDOutput
+	GetDatasetByIDInvocations                            int
+	GetDatasetByIDInputs                                 []string
+	GetDatasetByIDOutputs                                []GetDatasetByIDOutput
+	CreateDatasetInvocations                             int
+	CreateDatasetInputs                                  []*upload.Upload
+	CreateDatasetOutputs                                 []error
+	UpdateDatasetInvocations                             int
+	UpdateDatasetInputs                                  []*upload.Upload
+	UpdateDatasetOutputs                                 []error
+	DeleteDatasetInvocations                             int
+	DeleteDatasetInputs                                  []*upload.Upload
+	DeleteDatasetOutputs                                 []error
+	CreateDatasetDataInvocations                         int
+	CreateDatasetDataInputs                              []CreateDatasetDataInput
+	CreateDatasetDataOutputs                             []error
+	ActivateDatasetDataInvocations                       int
+	ActivateDatasetDataInputs                            []*upload.Upload
+	ActivateDatasetDataOutputs                           []error
+	ArchiveDeviceDataUsingHashesFromDatasetInvocations   int
+	ArchiveDeviceDataUsingHashesFromDatasetInputs        []*upload.Upload
+	ArchiveDeviceDataUsingHashesFromDatasetOutputs       []error
+	UnarchiveDeviceDataUsingHashesFromDatasetInvocations int
+	UnarchiveDeviceDataUsingHashesFromDatasetInputs      []*upload.Upload
+	UnarchiveDeviceDataUsingHashesFromDatasetOutputs     []error
+	DeleteOtherDatasetDataInvocations                    int
+	DeleteOtherDatasetDataInputs                         []*upload.Upload
+	DeleteOtherDatasetDataOutputs                        []error
+	DestroyDataForUserByIDInvocations                    int
+	DestroyDataForUserByIDInputs                         []string
+	DestroyDataForUserByIDOutputs                        []error
 }
 
 func NewSession() *Session {
@@ -170,20 +137,6 @@ func (s *Session) GetDatasetByID(datasetID string) (*upload.Upload, error) {
 	return output.Dataset, output.Error
 }
 
-func (s *Session) FindPreviousActiveDatasetForDevice(dataset *upload.Upload) (*upload.Upload, error) {
-	s.FindPreviousActiveDatasetForDeviceInvocations++
-
-	s.FindPreviousActiveDatasetForDeviceInputs = append(s.FindPreviousActiveDatasetForDeviceInputs, dataset)
-
-	if len(s.FindPreviousActiveDatasetForDeviceOutputs) == 0 {
-		panic("Unexpected invocation of FindPreviousActiveDatasetForDevice on Session")
-	}
-
-	output := s.FindPreviousActiveDatasetForDeviceOutputs[0]
-	s.FindPreviousActiveDatasetForDeviceOutputs = s.FindPreviousActiveDatasetForDeviceOutputs[1:]
-	return output.Dataset, output.Error
-}
-
 func (s *Session) CreateDataset(dataset *upload.Upload) error {
 	s.CreateDatasetInvocations++
 
@@ -226,20 +179,6 @@ func (s *Session) DeleteDataset(dataset *upload.Upload) error {
 	return output
 }
 
-func (s *Session) GetDatasetDataDeduplicatorHashes(dataset *upload.Upload, active bool) ([]string, error) {
-	s.GetDatasetDataDeduplicatorHashesInvocations++
-
-	s.GetDatasetDataDeduplicatorHashesInputs = append(s.GetDatasetDataDeduplicatorHashesInputs, GetDatasetDataDeduplicatorHashesInput{dataset, active})
-
-	if len(s.GetDatasetDataDeduplicatorHashesOutputs) == 0 {
-		panic("Unexpected invocation of GetDatasetDataDeduplicatorHashes on Session")
-	}
-
-	output := s.GetDatasetDataDeduplicatorHashesOutputs[0]
-	s.GetDatasetDataDeduplicatorHashesOutputs = s.GetDatasetDataDeduplicatorHashesOutputs[1:]
-	return output.Hashes, output.Error
-}
-
 func (s *Session) CreateDatasetData(dataset *upload.Upload, datasetData []data.Datum) error {
 	s.CreateDatasetDataInvocations++
 
@@ -268,31 +207,31 @@ func (s *Session) ActivateDatasetData(dataset *upload.Upload) error {
 	return output
 }
 
-func (s *Session) SetDatasetDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error {
-	s.SetDatasetDataActiveUsingHashesInvocations++
+func (s *Session) ArchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error {
+	s.ArchiveDeviceDataUsingHashesFromDatasetInvocations++
 
-	s.SetDatasetDataActiveUsingHashesInputs = append(s.SetDatasetDataActiveUsingHashesInputs, SetDatasetDataActiveUsingHashesInput{dataset, queryHashes, active})
+	s.ArchiveDeviceDataUsingHashesFromDatasetInputs = append(s.ArchiveDeviceDataUsingHashesFromDatasetInputs, dataset)
 
-	if len(s.SetDatasetDataActiveUsingHashesOutputs) == 0 {
-		panic("Unexpected invocation of SetDatasetDataActiveUsingHashes on Session")
+	if len(s.ArchiveDeviceDataUsingHashesFromDatasetOutputs) == 0 {
+		panic("Unexpected invocation of ArchiveDeviceDataUsingHashesFromDataset on Session")
 	}
 
-	output := s.SetDatasetDataActiveUsingHashesOutputs[0]
-	s.SetDatasetDataActiveUsingHashesOutputs = s.SetDatasetDataActiveUsingHashesOutputs[1:]
+	output := s.ArchiveDeviceDataUsingHashesFromDatasetOutputs[0]
+	s.ArchiveDeviceDataUsingHashesFromDatasetOutputs = s.ArchiveDeviceDataUsingHashesFromDatasetOutputs[1:]
 	return output
 }
 
-func (s *Session) SetDeviceDataActiveUsingHashes(dataset *upload.Upload, queryHashes []string, active bool) error {
-	s.SetDeviceDataActiveUsingHashesInvocations++
+func (s *Session) UnarchiveDeviceDataUsingHashesFromDataset(dataset *upload.Upload) error {
+	s.UnarchiveDeviceDataUsingHashesFromDatasetInvocations++
 
-	s.SetDeviceDataActiveUsingHashesInputs = append(s.SetDeviceDataActiveUsingHashesInputs, SetDeviceDataActiveUsingHashesInput{dataset, queryHashes, active})
+	s.UnarchiveDeviceDataUsingHashesFromDatasetInputs = append(s.UnarchiveDeviceDataUsingHashesFromDatasetInputs, dataset)
 
-	if len(s.SetDeviceDataActiveUsingHashesOutputs) == 0 {
-		panic("Unexpected invocation of SetDeviceDataActiveUsingHashes on Session")
+	if len(s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs) == 0 {
+		panic("Unexpected invocation of UnarchiveDeviceDataUsingHashesFromDataset on Session")
 	}
 
-	output := s.SetDeviceDataActiveUsingHashesOutputs[0]
-	s.SetDeviceDataActiveUsingHashesOutputs = s.SetDeviceDataActiveUsingHashesOutputs[1:]
+	output := s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs[0]
+	s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs = s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs[1:]
 	return output
 }
 
@@ -328,14 +267,13 @@ func (s *Session) UnusedOutputsCount() int {
 	return len(s.IsClosedOutputs) +
 		len(s.GetDatasetsForUserByIDOutputs) +
 		len(s.GetDatasetByIDOutputs) +
-		len(s.FindPreviousActiveDatasetForDeviceOutputs) +
 		len(s.CreateDatasetOutputs) +
 		len(s.UpdateDatasetOutputs) +
 		len(s.DeleteDatasetOutputs) +
-		len(s.GetDatasetDataDeduplicatorHashesOutputs) +
 		len(s.CreateDatasetDataOutputs) +
 		len(s.ActivateDatasetDataOutputs) +
-		len(s.SetDatasetDataActiveUsingHashesOutputs) +
+		len(s.ArchiveDeviceDataUsingHashesFromDatasetOutputs) +
+		len(s.UnarchiveDeviceDataUsingHashesFromDatasetOutputs) +
 		len(s.DeleteOtherDatasetDataOutputs) +
 		len(s.DestroyDataForUserByIDOutputs)
 }

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -9,22 +9,24 @@ import (
 const SchemaVersionCurrent = 3
 
 type Base struct {
-	Active         bool                         `json:"-" bson:"_active"`
-	CreatedTime    string                       `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
-	CreatedUserID  string                       `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
-	Deduplicator   *data.DeduplicatorDescriptor `json:"-" bson:"_deduplicator,omitempty"`
-	DeletedTime    string                       `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
-	DeletedUserID  string                       `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
-	GroupID        string                       `json:"-" bson:"_groupId,omitempty"`
-	GUID           string                       `json:"guid,omitempty" bson:"guid,omitempty"`
-	ID             string                       `json:"id,omitempty" bson:"id,omitempty"`
-	ModifiedTime   string                       `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
-	ModifiedUserID string                       `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
-	SchemaVersion  int                          `json:"-" bson:"_schemaVersion,omitempty"`
-	Type           string                       `json:"type,omitempty" bson:"type,omitempty"`
-	UploadID       string                       `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
-	UserID         string                       `json:"-" bson:"_userId,omitempty"`
-	Version        int                          `json:"-" bson:"_version,omitempty"`
+	Active            bool                         `json:"-" bson:"_active"`
+	ArchivedDatasetID string                       `json:"-" bson:"archivedDatasetId,omitempty"`
+	ArchivedTime      string                       `json:"-" bson:"archivedTime,omitempty"`
+	CreatedTime       string                       `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
+	CreatedUserID     string                       `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
+	Deduplicator      *data.DeduplicatorDescriptor `json:"-" bson:"_deduplicator,omitempty"`
+	DeletedTime       string                       `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
+	DeletedUserID     string                       `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
+	GroupID           string                       `json:"-" bson:"_groupId,omitempty"`
+	GUID              string                       `json:"guid,omitempty" bson:"guid,omitempty"`
+	ID                string                       `json:"id,omitempty" bson:"id,omitempty"`
+	ModifiedTime      string                       `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	ModifiedUserID    string                       `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
+	SchemaVersion     int                          `json:"-" bson:"_schemaVersion,omitempty"`
+	Type              string                       `json:"type,omitempty" bson:"type,omitempty"`
+	UploadID          string                       `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
+	UserID            string                       `json:"-" bson:"_userId,omitempty"`
+	Version           int                          `json:"-" bson:"_version,omitempty"`
 
 	Annotations      *[]interface{} `json:"annotations,omitempty" bson:"annotations,omitempty"`
 	ClockDriftOffset *int           `json:"clockDriftOffset,omitempty" bson:"clockDriftOffset,omitempty"`
@@ -43,6 +45,8 @@ type Meta struct {
 
 func (b *Base) Init() {
 	b.Active = false
+	b.ArchivedDatasetID = ""
+	b.ArchivedTime = ""
 	b.CreatedTime = ""
 	b.CreatedUserID = ""
 	b.Deduplicator = nil


### PR DESCRIPTION
@jh-bate Add `archivedTime` and `archivedDatasetId` field to all data records. Allows exact history of deduplication with multiple uploads that can be unrolled. Allows fully accurate deduplication and upload deletion. Key changes are in the mongo queries. Upload deduplication is still fast with the same two queries (with a couple extra fields on update, but that doesn't affect performance). Upload deletion is now a couple more database calls, but still reasonable performance with latest indexes. (Also, upload deletion performance isn't that important.)