### PR TITLE
Rename config String to Get and StringOrDefault to GetWithDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Rename config Reporter functions String to Get and StringOrDefault to GetWithDefault
 - Pull string functions out of app package into specific functions appropriate to including package
 - Pull id functions out of app package into their own id package
 - Pull pointer functions out of app package into their own pointer package

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,8 @@
 package config
 
 type Reporter interface {
-	String(key string) (string, bool)
-	StringOrDefault(key string, defaultValue string) string
+	Get(key string) (string, bool)
+	GetWithDefault(key string, defaultValue string) string
 
 	WithScopes(scopes ...string) Reporter
 }

--- a/config/env/reporter.go
+++ b/config/env/reporter.go
@@ -31,7 +31,7 @@ type reporter struct {
 	scopes []string
 }
 
-func (r *reporter) String(key string) (string, bool) {
+func (r *reporter) Get(key string) (string, bool) {
 	limit := len(r.scopes) - 1
 	if limit < 0 {
 		limit = 0
@@ -49,8 +49,8 @@ func (r *reporter) String(key string) (string, bool) {
 	return "", false
 }
 
-func (r *reporter) StringOrDefault(key string, defaultValue string) string {
-	if value, found := r.String(key); found {
+func (r *reporter) GetWithDefault(key string, defaultValue string) string {
+	if value, found := r.Get(key); found {
 		return value
 	}
 

--- a/config/env/reporter_test.go
+++ b/config/env/reporter_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Reporter", func() {
 			DescribeTable("returns expected values given environment variables",
 				func(environmentKey string, environmentValue string, key string, expectedValue string, expectedFound bool) {
 					Expect(syscall.Setenv(environmentKey, environmentValue)).To(Succeed())
-					actualValue, actualFound := reporter.String(key)
+					actualValue, actualFound := reporter.Get(key)
 					Expect(syscall.Unsetenv(environmentKey)).To(Succeed())
 					Expect(actualFound).To(Equal(expectedFound))
 					Expect(actualValue).To(Equal(expectedValue))
@@ -78,21 +78,21 @@ var _ = Describe("Reporter", func() {
 			)
 		})
 
-		Context("StringOrDefault", func() {
+		Context("GetWithDefault", func() {
 			It("returns the value if found", func() {
 				Expect(syscall.Setenv("TIDEPOOL_TEST_GOLF", "bag")).To(Succeed())
-				Expect(reporter.StringOrDefault("GOLF", "tee")).To(Equal("bag"))
+				Expect(reporter.GetWithDefault("GOLF", "tee")).To(Equal("bag"))
 				Expect(syscall.Unsetenv("TIDEPOOL_TEST_GOLF")).To(Succeed())
 			})
 
 			It("returns the value if found, even if empty", func() {
 				Expect(syscall.Setenv("TIDEPOOL_TEST_HOTEL", "")).To(Succeed())
-				Expect(reporter.StringOrDefault("HOTEL", "room")).To(Equal(""))
+				Expect(reporter.GetWithDefault("HOTEL", "room")).To(Equal(""))
 				Expect(syscall.Unsetenv("TIDEPOOL_TEST_HOTEL")).To(Succeed())
 			})
 
 			It("returns the default valuye if not found", func() {
-				Expect(reporter.StringOrDefault("INDIA", "ink")).To(Equal("ink"))
+				Expect(reporter.GetWithDefault("INDIA", "ink")).To(Equal("ink"))
 			})
 		})
 
@@ -100,7 +100,7 @@ var _ = Describe("Reporter", func() {
 			DescribeTable("returns expected values given environment variables and scopes",
 				func(environmentKey string, environmentValue string, scopes []string, key string, expectedValue string, expectedFound bool) {
 					Expect(syscall.Setenv(environmentKey, environmentValue)).To(Succeed())
-					actualValue, actualFound := reporter.WithScopes(scopes...).String(key)
+					actualValue, actualFound := reporter.WithScopes(scopes...).Get(key)
 					Expect(syscall.Unsetenv(environmentKey)).To(Succeed())
 					Expect(actualFound).To(Equal(expectedFound))
 					Expect(actualValue).To(Equal(expectedValue))

--- a/config/test/reporter.go
+++ b/config/test/reporter.go
@@ -12,13 +12,13 @@ func NewReporter() *Reporter {
 	}
 }
 
-func (r *Reporter) String(key string) (string, bool) {
+func (r *Reporter) Get(key string) (string, bool) {
 	value, found := r.Config[key]
 	return value, found
 }
 
-func (r *Reporter) StringOrDefault(key string, defaultValue string) string {
-	if value, found := r.String(key); found {
+func (r *Reporter) GetWithDefault(key string, defaultValue string) string {
+	if value, found := r.Get(key); found {
 		return value
 	}
 

--- a/dataservices/client/config.go
+++ b/dataservices/client/config.go
@@ -25,8 +25,8 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("client", "config reporter is missing")
 	}
 
-	c.Address = configReporter.StringOrDefault("address", "")
-	if timeoutString, found := configReporter.String("timeout"); found {
+	c.Address = configReporter.GetWithDefault("address", "")
+	if timeoutString, found := configReporter.Get("timeout"); found {
 		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("client", "timeout is invalid")

--- a/log/config.go
+++ b/log/config.go
@@ -22,7 +22,7 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("log", "config reporter is missing")
 	}
 
-	c.Level = configReporter.StringOrDefault("level", "warn")
+	c.Level = configReporter.GetWithDefault("level", "warn")
 
 	return nil
 }

--- a/metricservices/client/config.go
+++ b/metricservices/client/config.go
@@ -25,8 +25,8 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("client", "config reporter is missing")
 	}
 
-	c.Address = configReporter.StringOrDefault("address", "")
-	if timeoutString, found := configReporter.String("timeout"); found {
+	c.Address = configReporter.GetWithDefault("address", "")
+	if timeoutString, found := configReporter.Get("timeout"); found {
 		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("client", "timeout is invalid")

--- a/permission/store/mongo/config.go
+++ b/permission/store/mongo/config.go
@@ -25,7 +25,7 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return err
 	}
 
-	c.Secret = configReporter.StringOrDefault("secret", "")
+	c.Secret = configReporter.GetWithDefault("secret", "")
 
 	return nil
 }

--- a/service/server/config.go
+++ b/service/server/config.go
@@ -29,17 +29,17 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("server", "config reporter is missing")
 	}
 
-	c.Address = configReporter.StringOrDefault("address", "")
-	if tlsString, found := configReporter.String("tls"); found {
+	c.Address = configReporter.GetWithDefault("address", "")
+	if tlsString, found := configReporter.Get("tls"); found {
 		tls, err := strconv.ParseBool(tlsString)
 		if err != nil {
 			return errors.New("server", "tls is invalid")
 		}
 		c.TLS = tls
 	}
-	c.TLSCertificateFile = configReporter.StringOrDefault("tls_certificate_file", "")
-	c.TLSKeyFile = configReporter.StringOrDefault("tls_key_file", "")
-	if timeoutString, found := configReporter.String("timeout"); found {
+	c.TLSCertificateFile = configReporter.GetWithDefault("tls_certificate_file", "")
+	c.TLSKeyFile = configReporter.GetWithDefault("tls_key_file", "")
+	if timeoutString, found := configReporter.Get("timeout"); found {
 		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("server", "timeout is invalid")

--- a/store/mongo/config.go
+++ b/store/mongo/config.go
@@ -33,23 +33,23 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("mongo", "config reporter is missing")
 	}
 
-	c.Addresses = SplitAddresses(configReporter.StringOrDefault("addresses", ""))
-	if tlsString, found := configReporter.String("tls"); found {
+	c.Addresses = SplitAddresses(configReporter.GetWithDefault("addresses", ""))
+	if tlsString, found := configReporter.Get("tls"); found {
 		tls, err := strconv.ParseBool(tlsString)
 		if err != nil {
 			return errors.New("mongo", "tls is invalid")
 		}
 		c.TLS = tls
 	}
-	c.Database = configReporter.StringOrDefault("database", "")
-	c.Collection = configReporter.StringOrDefault("collection", "")
-	if username, found := configReporter.String("username"); found {
+	c.Database = configReporter.GetWithDefault("database", "")
+	c.Collection = configReporter.GetWithDefault("collection", "")
+	if username, found := configReporter.Get("username"); found {
 		c.Username = pointer.String(username)
 	}
-	if password, found := configReporter.String("password"); found {
+	if password, found := configReporter.Get("password"); found {
 		c.Password = pointer.String(password)
 	}
-	if timeoutString, found := configReporter.String("timeout"); found {
+	if timeoutString, found := configReporter.Get("timeout"); found {
 		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("mongo", "timeout is invalid")

--- a/user/store/mongo/config.go
+++ b/user/store/mongo/config.go
@@ -25,7 +25,7 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return err
 	}
 
-	c.PasswordSalt = configReporter.StringOrDefault("password_salt", "")
+	c.PasswordSalt = configReporter.GetWithDefault("password_salt", "")
 
 	return nil
 }

--- a/userservices/client/config.go
+++ b/userservices/client/config.go
@@ -28,16 +28,16 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("client", "config reporter is missing")
 	}
 
-	c.Address = configReporter.StringOrDefault("address", "")
-	if timeoutString, found := configReporter.String("timeout"); found {
+	c.Address = configReporter.GetWithDefault("address", "")
+	if timeoutString, found := configReporter.Get("timeout"); found {
 		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("client", "timeout is invalid")
 		}
 		c.Timeout = time.Duration(timeout) * time.Second
 	}
-	c.ServerTokenSecret = configReporter.StringOrDefault("server_token_secret", "")
-	if serverTokenTimeoutString, found := configReporter.String("server_token_timeout"); found {
+	c.ServerTokenSecret = configReporter.GetWithDefault("server_token_secret", "")
+	if serverTokenTimeoutString, found := configReporter.Get("server_token_timeout"); found {
 		serverTokenTimeout, err := strconv.ParseInt(serverTokenTimeoutString, 10, 0)
 		if err != nil {
 			return errors.New("client", "server token timeout is invalid")


### PR DESCRIPTION
@jh-bate Rename `String` to `Get` and `StringOrDefault` to `GetWithDefault` so that we can later (next commit/PR) add a `Set` and `Delete` function. Much more readable this way, too. For example, `config.Get("address")`.