### PR TITLE
Add ability to set and delete to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD
 
-- Rename config Reporter functions String to Get and StringOrDefault to GetWithDefault
+- Add config Reporter functions `Set` and `Delete`
+- Rename config Reporter functions `String` to `Get` and `StringOrDefault` to `GetWithDefault`
 - Pull string functions out of app package into specific functions appropriate to including package
 - Pull id functions out of app package into their own id package
 - Pull pointer functions out of app package into their own pointer package
@@ -8,9 +9,9 @@
 - Introduce new scoped config mechanism using only environment variables and not external files
 - Update all config struct usage to reflect new scoped config mechanism
 - Delete deprecated config files
-- Remove github.com/tidepool-org/configor dependency
+- Remove `github.com/tidepool-org/configor` dependency
 - Remove legacy group id from data replaced by user id
-- Remove deprecated user services Client.GetUserGroupID
+- Remove deprecated user services `Client.GetUserGroupID`
 
 ## v1.9.0 (2017-08-10)
 
@@ -33,7 +34,7 @@
 - Force `precise` Ubuntu distribution for Travis (update to `trusty` later)
 - Add deduplicator version
 - Update deduplicator name scheme
-- Add github.com/blang/semver package dependency
+- Add `github.com/blang/semver package` dependency
 - Fix dependency import capitalization
 - Update dependencies
 - Remove unused data store functionality

--- a/config/config.go
+++ b/config/config.go
@@ -4,5 +4,9 @@ type Reporter interface {
 	Get(key string) (string, bool)
 	GetWithDefault(key string, defaultValue string) string
 
+	Set(key string, value string)
+
+	Delete(key string)
+
 	WithScopes(scopes ...string) Reporter
 }

--- a/config/env/reporter_test.go
+++ b/config/env/reporter_test.go
@@ -96,6 +96,27 @@ var _ = Describe("Reporter", func() {
 			})
 		})
 
+		Context("Set", func() {
+			It("sets the key with the value", func() {
+				Expect(syscall.Unsetenv("TIDEPOOL_TEST_JULIETTE")).To(Succeed())
+				reporter.Set("JULIETTE", "romeo")
+				value, found := syscall.Getenv("TIDEPOOL_TEST_JULIETTE")
+				Expect(found).To(BeTrue())
+				Expect(value).To(Equal("romeo"))
+				Expect(syscall.Unsetenv("TIDEPOOL_TEST_JULIETTE")).To(Succeed())
+			})
+		})
+
+		Context("Delete", func() {
+			It("deletes the key", func() {
+				Expect(syscall.Setenv("TIDEPOOL_TEST_KILO", "meter")).To(Succeed())
+				reporter.Delete("KILO")
+				value, found := syscall.Getenv("TIDEPOOL_TEST_KILO")
+				Expect(found).To(BeFalse())
+				Expect(value).ToNot(Equal("meter"))
+			})
+		})
+
 		Context("WithScopes", func() {
 			DescribeTable("returns expected values given environment variables and scopes",
 				func(environmentKey string, environmentValue string, scopes []string, key string, expectedValue string, expectedFound bool) {

--- a/config/test/reporter.go
+++ b/config/test/reporter.go
@@ -25,6 +25,14 @@ func (r *Reporter) GetWithDefault(key string, defaultValue string) string {
 	return defaultValue
 }
 
+func (r *Reporter) Set(key string, value string) {
+	r.Config[key] = value
+}
+
+func (r *Reporter) Delete(key string) {
+	delete(r.Config, key)
+}
+
 func (r *Reporter) WithScopes(scopes ...string) config.Reporter {
 	panic("Unexpected invocation of WithScopes on Reporter")
 }


### PR DESCRIPTION
@jh-bate Add aforementioned `Set` and `Delete` to config. Allows for overriding configuration from command line applications (later commit/PR).