### PR TITLE
Refactor version package to align with new application package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 VERSION_BASE:=$(VERSION_BASE:v%=%)
 VERSION_SHORT_COMMIT:=$(shell git rev-parse --short HEAD)
 VERSION_FULL_COMMIT:=$(shell git rev-parse HEAD)
-VERSION_PACKAGE:=$(REPOSITORY)/version
+VERSION_PACKAGE:=$(REPOSITORY)/application/version
 
 GO_LD_FLAGS:=-ldflags "-X $(VERSION_PACKAGE).Base=$(VERSION_BASE) -X $(VERSION_PACKAGE).ShortCommit=$(VERSION_SHORT_COMMIT) -X $(VERSION_PACKAGE).FullCommit=$(VERSION_FULL_COMMIT)"
 

--- a/application/application.go
+++ b/application/application.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	applicationVersion "github.com/tidepool-org/platform/application/version"
 	"github.com/tidepool-org/platform/config"
 	"github.com/tidepool-org/platform/config/env"
 	"github.com/tidepool-org/platform/errors"
@@ -75,7 +76,7 @@ func (a *Application) Logger() log.Logger {
 }
 
 func (a *Application) initializeVersionReporter() error {
-	versionReporter, err := version.NewDefaultReporter()
+	versionReporter, err := applicationVersion.NewReporter()
 	if err != nil {
 		return errors.Wrap(err, "application", "unable to create version reporter")
 	}

--- a/application/application_test.go
+++ b/application/application_test.go
@@ -5,10 +5,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/tidepool-org/platform/application"
+	"github.com/tidepool-org/platform/application/version"
+	_ "github.com/tidepool-org/platform/application/version/test"
 	"github.com/tidepool-org/platform/config"
 	"github.com/tidepool-org/platform/config/env"
-	"github.com/tidepool-org/platform/version"
-	_ "github.com/tidepool-org/platform/version/test"
 )
 
 var _ = Describe("Application", func() {

--- a/application/version/reporter.go
+++ b/application/version/reporter.go
@@ -2,12 +2,14 @@ package version
 
 // WARNING: Concurrent modification of these global variables is unsupported
 
+import "github.com/tidepool-org/platform/version"
+
 var (
 	Base        string
 	ShortCommit string
 	FullCommit  string
 )
 
-func NewDefaultReporter() (Reporter, error) {
-	return NewReporter(Base, ShortCommit, FullCommit)
+func NewReporter() (version.Reporter, error) {
+	return version.NewReporter(Base, ShortCommit, FullCommit)
 }

--- a/application/version/reporter_test.go
+++ b/application/version/reporter_test.go
@@ -4,16 +4,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/version"
+	"github.com/tidepool-org/platform/application/version"
 )
 
-var _ = Describe("Default", func() {
-	Context("NewDefaultReporter", func() {
+var _ = Describe("Reporter", func() {
+	Context("NewReporter", func() {
 		It("returns successfully", func() {
 			version.Base = "1.2.3"
 			version.ShortCommit = "4567890"
 			version.FullCommit = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
-			Expect(version.NewDefaultReporter()).ToNot(BeNil())
+			Expect(version.NewReporter()).ToNot(BeNil())
 		})
 	})
 })

--- a/application/version/test/init.go
+++ b/application/version/test/init.go
@@ -3,7 +3,7 @@ package test
 import (
 	"os"
 
-	"github.com/tidepool-org/platform/version"
+	"github.com/tidepool-org/platform/application/version"
 )
 
 func init() {

--- a/application/version/version_suite_test.go
+++ b/application/version/version_suite_test.go
@@ -1,0 +1,13 @@
+package version_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "application/version")
+}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -4,8 +4,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	_ "github.com/tidepool-org/platform/application/version/test"
 	"github.com/tidepool-org/platform/service"
-	_ "github.com/tidepool-org/platform/version/test"
 )
 
 var _ = Describe("Service", func() {

--- a/tool/mongo/tool_test.go
+++ b/tool/mongo/tool_test.go
@@ -4,11 +4,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/tidepool-org/platform/application/version"
+	_ "github.com/tidepool-org/platform/application/version/test"
 	"github.com/tidepool-org/platform/config"
 	"github.com/tidepool-org/platform/config/env"
 	"github.com/tidepool-org/platform/tool/mongo"
-	"github.com/tidepool-org/platform/version"
-	_ "github.com/tidepool-org/platform/version/test"
 )
 
 var _ = Describe("Tool", func() {

--- a/tool/tool_test.go
+++ b/tool/tool_test.go
@@ -4,9 +4,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/tidepool-org/platform/application/version"
+	_ "github.com/tidepool-org/platform/application/version/test"
 	"github.com/tidepool-org/platform/tool"
-	"github.com/tidepool-org/platform/version"
-	_ "github.com/tidepool-org/platform/version/test"
 )
 
 var _ = Describe("Tool", func() {

--- a/tools/tapi/cmd/cmd.go
+++ b/tools/tapi/cmd/cmd.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/urfave/cli"
 
+	"github.com/tidepool-org/platform/application/version"
 	"github.com/tidepool-org/platform/tools/tapi/api"
-	"github.com/tidepool-org/platform/version"
 )
 
 var EnvironmentEndpointMap = map[string]string{
@@ -22,7 +22,7 @@ var EnvironmentEndpointMap = map[string]string{
 var _API *api.API
 
 func InitializeApplication() (*cli.App, error) {
-	versionReporter, err := version.NewDefaultReporter()
+	versionReporter, err := version.NewReporter()
 	if err != nil {
 		return nil, err
 	}

--- a/version/reporter.go
+++ b/version/reporter.go
@@ -1,0 +1,51 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/tidepool-org/platform/errors"
+)
+
+func NewReporter(base string, shortCommit string, fullCommit string) (Reporter, error) {
+	if base == "" {
+		return nil, errors.New("version", "base is missing")
+	}
+	if shortCommit == "" {
+		return nil, errors.New("version", "short commit is missing")
+	}
+	if fullCommit == "" {
+		return nil, errors.New("version", "full commit is missing")
+	}
+
+	return &reporter{
+		base:        base,
+		shortCommit: shortCommit,
+		fullCommit:  fullCommit,
+	}, nil
+}
+
+type reporter struct {
+	base        string
+	shortCommit string
+	fullCommit  string
+}
+
+func (r *reporter) Base() string {
+	return r.base
+}
+
+func (r *reporter) ShortCommit() string {
+	return r.shortCommit
+}
+
+func (r *reporter) FullCommit() string {
+	return r.fullCommit
+}
+
+func (r *reporter) Short() string {
+	return fmt.Sprintf("%s+%s", r.Base(), r.ShortCommit())
+}
+
+func (r *reporter) Long() string {
+	return fmt.Sprintf("%s+%s", r.Base(), r.FullCommit())
+}

--- a/version/reporter_test.go
+++ b/version/reporter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tidepool-org/platform/version"
 )
 
-var _ = Describe("Version", func() {
+var _ = Describe("Reporter", func() {
 	Context("NewReporter", func() {
 		It("returns an error if base is missing", func() {
 			reporter, err := version.NewReporter("", "4567890", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn")
@@ -15,15 +15,15 @@ var _ = Describe("Version", func() {
 			Expect(reporter).To(BeNil())
 		})
 
-		It("returns an error if shortCommit is missing", func() {
+		It("returns an error if short commit is missing", func() {
 			reporter, err := version.NewReporter("1.2.3", "", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn")
-			Expect(err).To(MatchError("version: shortCommit is missing"))
+			Expect(err).To(MatchError("version: short commit is missing"))
 			Expect(reporter).To(BeNil())
 		})
 
-		It("returns an error if fullCommit is missing", func() {
+		It("returns an error if full commit is missing", func() {
 			reporter, err := version.NewReporter("1.2.3", "4567890", "")
-			Expect(err).To(MatchError("version: fullCommit is missing"))
+			Expect(err).To(MatchError("version: full commit is missing"))
 			Expect(reporter).To(BeNil())
 		})
 
@@ -54,11 +54,11 @@ var _ = Describe("Version", func() {
 			Expect(reporter.FullCommit()).To(Equal("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"))
 		})
 
-		It("returns the expected short form", func() {
+		It("returns the expected short", func() {
 			Expect(reporter.Short()).To(Equal("1.2.3+4567890"))
 		})
 
-		It("returns the expected long form", func() {
+		It("returns the expected long", func() {
 			Expect(reporter.Long()).To(Equal("1.2.3+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"))
 		})
 	})

--- a/version/version.go
+++ b/version/version.go
@@ -1,59 +1,9 @@
 package version
 
-import (
-	"fmt"
-
-	"github.com/tidepool-org/platform/errors"
-)
-
 type Reporter interface {
 	Base() string
 	ShortCommit() string
 	FullCommit() string
 	Short() string
 	Long() string
-}
-
-func NewReporter(base string, shortCommit string, fullCommit string) (Reporter, error) {
-	if base == "" {
-		return nil, errors.New("version", "base is missing")
-	}
-	if shortCommit == "" {
-		return nil, errors.New("version", "shortCommit is missing")
-	}
-	if fullCommit == "" {
-		return nil, errors.New("version", "fullCommit is missing")
-	}
-
-	return &reporter{
-		base:        base,
-		shortCommit: shortCommit,
-		fullCommit:  fullCommit,
-	}, nil
-}
-
-type reporter struct {
-	base        string
-	shortCommit string
-	fullCommit  string
-}
-
-func (r *reporter) Base() string {
-	return r.base
-}
-
-func (r *reporter) ShortCommit() string {
-	return r.shortCommit
-}
-
-func (r *reporter) FullCommit() string {
-	return r.fullCommit
-}
-
-func (r *reporter) Short() string {
-	return fmt.Sprintf("%s+%s", r.Base(), r.ShortCommit())
-}
-
-func (r *reporter) Long() string {
-	return fmt.Sprintf("%s+%s", r.Base(), r.FullCommit())
 }


### PR DESCRIPTION
@jh-bate Relatively minor refactor to move specific incarnation of `VersionReporter` into `application` package (since it is directly tied to the application, after all). Also add a test file that can be included to automatically initialize the default version parameters (normally these are set via the Makefile during builds, but cannot be set during testing via `ginkgo`).