### PR TITLE
Add time API; return Date header with all responses

### DIFF
--- a/.golintignore
+++ b/.golintignore
@@ -2,3 +2,5 @@
 ./service/context/context_suite_test.go:54:30: method EncodeJson should be EncodeJSON
 ./service/middleware/middleware_suite_test.go:47:30: method WriteJson should be WriteJSON
 ./service/middleware/middleware_suite_test.go:54:30: method EncodeJson should be EncodeJSON
+./service/response_test.go:27:30: method WriteJson should be WriteJSON
+./service/response_test.go:31:30: method EncodeJson should be EncodeJSON

--- a/dataservices/service/api/status.go
+++ b/dataservices/service/api/status.go
@@ -1,6 +1,9 @@
 package api
 
-import "github.com/tidepool-org/platform/dataservices/service"
+import (
+	dataservicesService "github.com/tidepool-org/platform/dataservices/service"
+	"github.com/tidepool-org/platform/service"
+)
 
 type Status struct {
 	Version     string
@@ -9,12 +12,13 @@ type Status struct {
 	Server      interface{}
 }
 
-func (s *Standard) GetStatus(serviceContext service.Context) {
+func (s *Standard) GetStatus(serviceContext dataservicesService.Context) {
 	status := &Status{
 		Version:     s.VersionReporter().Long(),
 		Environment: s.EnvironmentReporter().Name(),
 		DataStore:   s.dataStore.GetStatus(),
 		Server:      s.StatusMiddleware().GetStatus(),
 	}
+	service.AddDateHeader(serviceContext.Response())
 	serviceContext.Response().WriteJson(status)
 }

--- a/dataservices/service/api/v1/time_get.go
+++ b/dataservices/service/api/v1/time_get.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/tidepool-org/platform/dataservices/service"
+)
+
+func TimeGet(serviceContext service.Context) {
+	response := struct {
+		Time string `json:"time"`
+	}{
+		Time: time.Now().UTC().Format(time.RFC3339),
+	}
+	serviceContext.RespondWithStatusAndData(http.StatusOK, response)
+}

--- a/dataservices/service/api/v1/time_get_test.go
+++ b/dataservices/service/api/v1/time_get_test.go
@@ -1,0 +1,24 @@
+package v1_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/dataservices/service/api/v1"
+)
+
+var _ = Describe("TimeGet", func() {
+	Context("Unit Tests", func() {
+		var context *TestContext
+
+		BeforeEach(func() {
+			context = NewTestContext()
+		})
+
+		It("succeeds", func() {
+			v1.TimeGet(context)
+			Expect(context.RespondWithStatusAndDataInputs).To(HaveLen(1))
+			Expect(context.ValidateTest()).To(BeTrue())
+		})
+	})
+})

--- a/dataservices/service/api/v1/v1.go
+++ b/dataservices/service/api/v1/v1.go
@@ -10,5 +10,6 @@ func Routes() []service.Route {
 		service.MakeRoute("DELETE", "/v1/users/:userid/data", Authenticate(UsersDataDelete)),
 		service.MakeRoute("POST", "/v1/users/:userid/datasets", Authenticate(UsersDatasetsCreate)),
 		service.MakeRoute("GET", "/v1/users/:userid/datasets", Authenticate(UsersDatasetsGet)),
+		service.MakeRoute("GET", "/v1/time", TimeGet),
 	}
 }

--- a/dataservices/service/api/version.go
+++ b/dataservices/service/api/version.go
@@ -1,11 +1,15 @@
 package api
 
-import "github.com/tidepool-org/platform/dataservices/service"
+import (
+	dataservicesService "github.com/tidepool-org/platform/dataservices/service"
+	"github.com/tidepool-org/platform/service"
+)
 
 type Version struct {
 	Version string `json:"version"`
 }
 
-func (s *Standard) GetVersion(serviceContext service.Context) {
+func (s *Standard) GetVersion(serviceContext dataservicesService.Context) {
+	service.AddDateHeader(serviceContext.Response())
 	serviceContext.Response().WriteJson(Version{s.VersionReporter().Long()})
 }

--- a/service/context/standard.go
+++ b/service/context/standard.go
@@ -104,8 +104,7 @@ func (s *Standard) RespondWithStatusAndErrors(statusCode int, errors []*service.
 		},
 	}
 
-	s.response.WriteHeader(statusCode)
-	s.response.WriteJson(response)
+	s.respondWithStatusAndResponse(statusCode, response)
 }
 
 func (s *Standard) RespondWithStatusAndData(statusCode int, data interface{}) {
@@ -118,6 +117,12 @@ func (s *Standard) RespondWithStatusAndData(statusCode int, data interface{}) {
 			},
 		},
 	}
+
+	s.respondWithStatusAndResponse(statusCode, response)
+}
+
+func (s *Standard) respondWithStatusAndResponse(statusCode int, response *JSONResponse) {
+	service.AddDateHeader(s.response)
 
 	s.response.WriteHeader(statusCode)
 	s.response.WriteJson(response)

--- a/service/response.go
+++ b/service/response.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"time"
+
+	"github.com/ant0ine/go-json-rest/rest"
+)
+
+func AddDateHeader(response rest.ResponseWriter) {
+	if response != nil {
+		response.Header().Set("Date", time.Now().UTC().Format(time.RFC1123))
+	}
+}

--- a/service/response_test.go
+++ b/service/response_test.go
@@ -1,0 +1,58 @@
+package service_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"net/http"
+	"time"
+
+	"github.com/tidepool-org/platform/service"
+)
+
+type TestResponseWriter struct {
+	HeaderImpl http.Header
+}
+
+func NewTestResponseWriter() *TestResponseWriter {
+	return &TestResponseWriter{
+		HeaderImpl: http.Header{},
+	}
+}
+
+func (t *TestResponseWriter) Header() http.Header {
+	return t.HeaderImpl
+}
+
+func (t *TestResponseWriter) WriteJson(v interface{}) error {
+	panic("Unexpected invocation of WriteJson on TestResponseWriter")
+}
+
+func (t *TestResponseWriter) EncodeJson(v interface{}) ([]byte, error) {
+	panic("Unexpected invocation of EncodeJson on TestResponseWriter")
+}
+
+func (t *TestResponseWriter) WriteHeader(code int) {
+	panic("Unexpected invocation of WriteHeader on TestResponseWriter")
+}
+
+var _ = Describe("Response", func() {
+	Context("with response", func() {
+		var responseWriter *TestResponseWriter
+
+		BeforeEach(func() {
+			responseWriter = NewTestResponseWriter()
+			Expect(responseWriter).ToNot(BeNil())
+		})
+
+		Context("AddDateHeader", func() {
+			It("adds a date header", func() {
+				service.AddDateHeader(responseWriter)
+				Expect(responseWriter.HeaderImpl).To(HaveKey("Date"))
+				date, err := time.Parse(time.RFC1123, responseWriter.HeaderImpl.Get("Date"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(date).To(BeTemporally("~", time.Now(), time.Second))
+			})
+		})
+	})
+})

--- a/userservices/service/api/status.go
+++ b/userservices/service/api/status.go
@@ -1,6 +1,9 @@
 package api
 
-import "github.com/tidepool-org/platform/userservices/service"
+import (
+	"github.com/tidepool-org/platform/service"
+	userservicesService "github.com/tidepool-org/platform/userservices/service"
+)
 
 type Status struct {
 	Version     string
@@ -8,11 +11,12 @@ type Status struct {
 	Server      interface{}
 }
 
-func (s *Standard) GetStatus(serviceContext service.Context) {
+func (s *Standard) GetStatus(serviceContext userservicesService.Context) {
 	status := &Status{
 		Version:     s.VersionReporter().Long(),
 		Environment: s.EnvironmentReporter().Name(),
 		Server:      s.StatusMiddleware().GetStatus(),
 	}
+	service.AddDateHeader(serviceContext.Response())
 	serviceContext.Response().WriteJson(status)
 }

--- a/userservices/service/api/version.go
+++ b/userservices/service/api/version.go
@@ -1,11 +1,15 @@
 package api
 
-import "github.com/tidepool-org/platform/userservices/service"
+import (
+	"github.com/tidepool-org/platform/service"
+	userservicesService "github.com/tidepool-org/platform/userservices/service"
+)
 
 type Version struct {
 	Version string `json:"version"`
 }
 
-func (s *Standard) GetVersion(serviceContext service.Context) {
+func (s *Standard) GetVersion(serviceContext userservicesService.Context) {
+	service.AddDateHeader(serviceContext.Response())
 	serviceContext.Response().WriteJson(Version{s.VersionReporter().Long()})
 }


### PR DESCRIPTION
@jh-bate @gniezen What it says on the tin. This will be used by the uploader to verify that a device is set to the correct time before uploading. (We cannot reasonably rely on the computer time as it may be incorrect.)