### PR TITLE
Add default source for structure validator, parser, and normalizer

### DIFF
--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -143,7 +143,7 @@ func (t *TaskRunner) Run(ctx context.Context) error {
 	}
 
 	t.context = ctx
-	t.validator = structureValidator.New().WithSource(structure.NewPointerSource())
+	t.validator = structureValidator.New()
 
 	if err := t.getProviderSession(); err != nil {
 		return err

--- a/page/pagination_test.go
+++ b/page/pagination_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/page"
+	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	testHTTP "github.com/tidepool-org/platform/test/http"
@@ -70,7 +71,9 @@ var _ = Describe("Pagination", func() {
 				Expect(pagination.Page).To(Equal(0))
 				Expect(pagination.Size).To(Equal(10))
 				Expect(parser.Error()).To(HaveOccurred())
-				Expect(errors.Sanitize(parser.Error())).To(Equal(errors.Sanitize(structureParser.ErrorTypeNotInt(false))))
+				Expect(errors.Sanitize(parser.Error())).To(Equal(errors.Sanitize(
+					errors.WithSource(structureParser.ErrorTypeNotInt(false), structure.NewPointerSource().WithReference("page")),
+				)))
 			})
 
 			It("reports an error if size is not an int", func() {
@@ -80,7 +83,9 @@ var _ = Describe("Pagination", func() {
 				Expect(pagination.Page).To(Equal(2))
 				Expect(pagination.Size).To(Equal(100))
 				Expect(parser.Error()).To(HaveOccurred())
-				Expect(errors.Sanitize(parser.Error())).To(Equal(errors.Sanitize(structureParser.ErrorTypeNotInt(false))))
+				Expect(errors.Sanitize(parser.Error())).To(Equal(errors.Sanitize(
+					errors.WithSource(structureParser.ErrorTypeNotInt(false), structure.NewPointerSource().WithReference("size")),
+				)))
 			})
 
 			It("reports an error if page and size are not ints", func() {
@@ -91,8 +96,8 @@ var _ = Describe("Pagination", func() {
 				Expect(pagination.Size).To(Equal(100))
 				Expect(parser.Error()).To(HaveOccurred())
 				Expect(errors.Sanitize(parser.Error())).To(Equal(errors.Sanitize(errors.Append(
-					structureParser.ErrorTypeNotInt(false),
-					structureParser.ErrorTypeNotInt(false),
+					errors.WithSource(structureParser.ErrorTypeNotInt(false), structure.NewPointerSource().WithReference("page")),
+					errors.WithSource(structureParser.ErrorTypeNotInt(false), structure.NewPointerSource().WithReference("size")),
 				))))
 			})
 		})
@@ -113,21 +118,27 @@ var _ = Describe("Pagination", func() {
 				pagination.Page = -1
 				pagination.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
-				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0))))
+				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(
+					errors.WithSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), structure.NewPointerSource().WithReference("page")),
+				)))
 			})
 
 			It("reports an error if the size is less than 1", func() {
 				pagination.Size = 0
 				pagination.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
-				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotInRange(0, 1, 100))))
+				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(
+					errors.WithSource(structureValidator.ErrorValueNotInRange(0, 1, 100), structure.NewPointerSource().WithReference("size")),
+				)))
 			})
 
 			It("reports an error if the size is greater than 100", func() {
 				pagination.Size = 101
 				pagination.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
-				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotInRange(101, 1, 100))))
+				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(
+					errors.WithSource(structureValidator.ErrorValueNotInRange(101, 1, 100), structure.NewPointerSource().WithReference("size")),
+				)))
 			})
 
 			It("reports an error if the page and size are less than minimum", func() {
@@ -136,8 +147,8 @@ var _ = Describe("Pagination", func() {
 				pagination.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 				Expect(errors.Sanitize(validator.Error())).To(Equal(errors.Sanitize(errors.Append(
-					structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0),
-					structureValidator.ErrorValueNotInRange(0, 1, 100),
+					errors.WithSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), structure.NewPointerSource().WithReference("page")),
+					errors.WithSource(structureValidator.ErrorValueNotInRange(0, 1, 100), structure.NewPointerSource().WithReference("size")),
 				))))
 			})
 		})

--- a/request/parser.go
+++ b/request/parser.go
@@ -161,7 +161,7 @@ func DecodeValues(values url.Values, objectParsables ...structure.ObjectParsable
 }
 
 func ParseValuesObjects(values url.Values, objectParsables ...structure.ObjectParsable) error {
-	parser := NewValues(&values).WithSource(structure.NewParameterSource())
+	parser := NewValues(&values)
 	for _, objectParsable := range objectParsables {
 		objectParsable.Parse(parser)
 	}

--- a/request/values_parser.go
+++ b/request/values_parser.go
@@ -18,7 +18,7 @@ type Values struct {
 }
 
 func NewValues(values *url.Values) *Values {
-	return NewValuesParser(structureBase.New(), values)
+	return NewValuesParser(structureBase.New().WithSource(structure.NewParameterSource()), values)
 }
 
 func NewValuesParser(base *structureBase.Base, values *url.Values) *Values {

--- a/structure/normalizer/normalizer.go
+++ b/structure/normalizer/normalizer.go
@@ -10,7 +10,7 @@ type Normalizer struct {
 }
 
 func New() *Normalizer {
-	return NewNormalizer(structureBase.New())
+	return NewNormalizer(structureBase.New().WithSource(structure.NewPointerSource()))
 }
 
 func NewNormalizer(base *structureBase.Base) *Normalizer {

--- a/structure/parser/array_parser.go
+++ b/structure/parser/array_parser.go
@@ -16,7 +16,7 @@ type Array struct {
 }
 
 func NewArray(array *[]interface{}) *Array {
-	return NewArrayParser(structureBase.New(), array)
+	return NewArrayParser(structureBase.New().WithSource(structure.NewPointerSource()), array)
 }
 
 func NewArrayParser(base *structureBase.Base, array *[]interface{}) *Array {

--- a/structure/parser/object_parser.go
+++ b/structure/parser/object_parser.go
@@ -15,7 +15,7 @@ type Object struct {
 }
 
 func NewObject(object *map[string]interface{}) *Object {
-	return NewObjectParser(structureBase.New(), object)
+	return NewObjectParser(structureBase.New().WithSource(structure.NewPointerSource()), object)
 }
 
 func NewObjectParser(base *structureBase.Base, object *map[string]interface{}) *Object {

--- a/structure/validator/validator.go
+++ b/structure/validator/validator.go
@@ -12,7 +12,7 @@ type Validator struct {
 }
 
 func New() *Validator {
-	return NewValidator(structureBase.New())
+	return NewValidator(structureBase.New().WithSource(structure.NewPointerSource()))
 }
 
 func NewValidator(base *structureBase.Base) *Validator {


### PR DESCRIPTION
@jh-bate By adding a default source for structure functionality then we can capture, by default, the most information about what structures fields fail validation, parsing, or normalization.  (Not as "perfect" as specifying the source at the time of processing, but this is much more pragmatic. Almost all will use the default and only structures parsed out of the request query will use a specific non-default source.)