### PR TITLE
Remove legacy code to fixup unexpected data from Dexcom API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+- Remove legacy code to fixup unexpected data from Dexcom API
 - Properly handle expired access tokens from Dexcom API
 - Warn on excessive duration Dexcom API requests and overall task
 - Add custom User-Agent header to client requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## v1.22.0
+
 - Remove legacy code to fixup unexpected data from Dexcom API
 - Properly handle expired access tokens from Dexcom API
 - Warn on excessive duration Dexcom API requests and overall task

--- a/auth/service/api/v1/oauth.go
+++ b/auth/service/api/v1/oauth.go
@@ -142,9 +142,6 @@ func (r *Router) OAuthProviderRedirectGet(res rest.ResponseWriter, req *rest.Req
 		return
 	}
 
-	// HACK: Dexcom - expires_in=600000 (should be 600) - force to immediate expiration
-	token.Expiry = time.Now()
-
 	oauthToken, err := oauth.NewTokenFromRawToken(token)
 	if err != nil {
 		r.htmlOnError(res, req, err)

--- a/dexcom/calibration.go
+++ b/dexcom/calibration.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 )
 
@@ -66,12 +65,6 @@ func (c *Calibration) Parse(parser structure.ObjectParser) {
 }
 
 func (c *Calibration) Validate(validator structure.Validator) {
-	// HACK: Dexcom - use id stripped of incorrect trailing decimals
-	if c.TransmitterID != nil {
-		transmitterID := hackTransmitterIDExpression.FindString(*c.TransmitterID)
-		c.TransmitterID = pointer.String(transmitterID)
-	}
-
 	validator.Time("systemTime", &c.SystemTime).BeforeNow(NowThreshold)
 	validator.Time("displayTime", &c.DisplayTime).NotZero()
 	validator.String("unit", &c.Unit).OneOf(UnitMgdL) // TODO: Add UnitMmolL

--- a/dexcom/device.go
+++ b/dexcom/device.go
@@ -208,11 +208,6 @@ func (a *AlertSetting) validateHigh(validator structure.Validator) {
 }
 
 func (a *AlertSetting) validateRise(validator structure.Validator) {
-	// HACK: Dexcom - use "mg/dL/min" rather than incorrect "minutes"
-	if a.Unit == UnitMinutes {
-		a.Unit = UnitMgdLMin
-	}
-
 	validator.String("unit", &a.Unit).OneOf(UnitMgdLMin) // TODO: Add UnitMmolLMin
 	switch a.Unit {
 	case UnitMgdLMin:
@@ -225,15 +220,6 @@ func (a *AlertSetting) validateRise(validator structure.Validator) {
 }
 
 func (a *AlertSetting) validateFall(validator structure.Validator) {
-	// HACK: Dexcom - use "mg/dL/min" rather than incorrect "minutes"
-	if a.Unit == UnitMinutes {
-		a.Unit = UnitMgdLMin
-	}
-	// HACK: Dexcom - use positive value rather than incorrect negative value
-	if a.Value < 0 {
-		a.Value = -a.Value
-	}
-
 	validator.String("unit", &a.Unit).OneOf(UnitMgdLMin) // TODO: UnitMmolLMin
 	switch a.Unit {
 	case UnitMgdLMin:

--- a/dexcom/dexcom.go
+++ b/dexcom/dexcom.go
@@ -75,5 +75,3 @@ const (
 )
 
 var TransmitterIDExpression = regexp.MustCompile(TransmitterIDExpressionString)
-
-var hackTransmitterIDExpression = regexp.MustCompile("^([0-9A-Z]{5,6})") // HACK: Dexcom - some transmitter ids have trailing decimal point

--- a/dexcom/egv.go
+++ b/dexcom/egv.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 )
 
@@ -84,12 +83,6 @@ func (e *EGV) Parse(parser structure.ObjectParser) {
 }
 
 func (e *EGV) Validate(validator structure.Validator) {
-	// HACK: Dexcom - use id stripped of incorrect trailing decimals
-	if e.TransmitterID != nil {
-		transmitterID := hackTransmitterIDExpression.FindString(*e.TransmitterID)
-		e.TransmitterID = pointer.String(transmitterID)
-	}
-
 	validator.Time("systemTime", &e.SystemTime).BeforeNow(NowThreshold)
 	validator.Time("displayTime", &e.DisplayTime).NotZero()
 	validator.String("unit", &e.Unit).OneOf(UnitMgdL) // TODO: Add UnitMmolL

--- a/dexcom/event.go
+++ b/dexcom/event.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 )
 
@@ -83,11 +82,6 @@ func (e *Event) Validate(validator structure.Validator) {
 }
 
 func (e *Event) validateCarbs(validator structure.Validator) {
-	// HACK: Dexcom - use nil rather than incorrect "unknown" eventSubType
-	if e.EventSubType != nil && *e.EventSubType == "unknown" {
-		e.EventSubType = nil
-	}
-
 	validator.String("eventSubType", e.EventSubType).NotExists()
 	if e.Unit != nil || e.Value != nil {
 		validator.String("unit", e.Unit).Exists().EqualTo(UnitGrams)
@@ -110,19 +104,6 @@ func (e *Event) validateHealth(validator structure.Validator) {
 }
 
 func (e *Event) validateInsulin(validator structure.Validator) {
-	// HACK: Dexcom - use nil rather than incorrect "unknown" eventSubType
-	if e.EventSubType != nil && *e.EventSubType == "unknown" {
-		e.EventSubType = nil
-	}
-	// HACK: Dexcom - use "units" rather than incorrect "unknown" unit
-	if e.Unit != nil && *e.Unit == "unknown" {
-		e.Unit = pointer.String(UnitUnits)
-	}
-	// HACK: Dexcom - use zero rather than incorrect negative value
-	if e.Value != nil && *e.Value < 0 {
-		e.Value = pointer.Float64(0)
-	}
-
 	validator.String("eventSubType", e.EventSubType).NotExists()
 	if e.Unit != nil || e.Value != nil {
 		validator.String("unit", e.Unit).Exists().EqualTo(UnitUnits)

--- a/oauth/token/source.go
+++ b/oauth/token/source.go
@@ -3,7 +3,6 @@ package context
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"golang.org/x/oauth2"
 
@@ -70,15 +69,9 @@ func (s *Source) RefreshedToken() (*oauth.Token, error) {
 		return nil, errors.Wrap(err, "unable to get token")
 	}
 
-	// HACK: Dexcom - expires_in=600000 (should be 600)
-	tknSrcTkn.Expiry = s.token.ExpirationTime
-
 	if s.token.MatchesRawToken(tknSrcTkn) {
 		return nil, nil
 	}
-
-	// HACK: Dexcom - expires_in=600000 (should be 600)
-	tknSrcTkn.Expiry = time.Now().Add(10 * time.Minute).Truncate(time.Second)
 
 	tkn, err := oauth.NewTokenFromRawToken(tknSrcTkn)
 	if err != nil {


### PR DESCRIPTION
@jh-bate We'll only use this after getting positive confirmation from Dexcom that this legacy code is no longer necessary.