### PR TITLE
Return error from config.Get rather than bool for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Return error from config.Get rather than bool for compatibility
+* Allow additional scopes on tools
 * Fix start script source of environment file
 * Add LifeScan Verio and LifeScan Verio Flex to supported devices
 * Accomodate out-of-sync server time between Tidepool and Dexcom

--- a/auth/client/external.go
+++ b/auth/client/external.go
@@ -42,8 +42,9 @@ func (e *ExternalConfig) Load(configReporter config.Reporter) error {
 	}
 
 	e.ServerSessionTokenSecret = configReporter.GetWithDefault("server_session_token_secret", "")
-	if serverSessionTokenTimeoutString, found := configReporter.Get("server_session_token_timeout"); found {
-		serverSessionTokenTimeoutInteger, err := strconv.ParseInt(serverSessionTokenTimeoutString, 10, 0)
+	if serverSessionTokenTimeoutString, err := configReporter.Get("server_session_token_timeout"); err == nil {
+		var serverSessionTokenTimeoutInteger int64
+		serverSessionTokenTimeoutInteger, err = strconv.ParseInt(serverSessionTokenTimeoutString, 10, 0)
 		if err != nil {
 			return errors.New("server session token timeout is invalid")
 		}

--- a/client/config.go
+++ b/client/config.go
@@ -22,7 +22,7 @@ func (c *Config) Load(configReporter config.Reporter) error {
 	}
 
 	c.Address = configReporter.GetWithDefault("address", "")
-	if userAgent, found := configReporter.Get("user_agent"); found {
+	if userAgent, err := configReporter.Get("user_agent"); err == nil {
 		c.UserAgent = userAgent
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 import "strings"
 
 type Reporter interface {
-	Get(key string) (string, bool)
+	Get(key string) (string, error)
 	GetWithDefault(key string, defaultValue string) string
 
 	Set(key string, value string)

--- a/config/env/reporter.go
+++ b/config/env/reporter.go
@@ -31,7 +31,7 @@ type reporter struct {
 	scopes []string
 }
 
-func (r *reporter) Get(key string) (string, bool) {
+func (r *reporter) Get(key string) (string, error) {
 	limit := len(r.scopes) - 1
 	if limit < 0 {
 		limit = 0
@@ -39,19 +39,19 @@ func (r *reporter) Get(key string) (string, bool) {
 
 	for i := 0; i <= limit; i++ {
 		if value, found := syscall.Getenv(r.getKey(r.scopes[i:], key)); found {
-			return value, true
+			return value, nil
 		}
 	}
 
-	return "", false
+	return "", config.ErrorKeyNotFound(r.getKey(r.scopes, key))
 }
 
 func (r *reporter) GetWithDefault(key string, defaultValue string) string {
-	if value, found := r.Get(key); found {
-		return value
+	value, err := r.Get(key)
+	if err != nil {
+		return defaultValue
 	}
-
-	return defaultValue
+	return value
 }
 
 func (r *reporter) Set(key string, value string) {

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,9 @@
+package config
+
+import "github.com/tidepool-org/platform/errors"
+
+const ErrorCodeKeyNotFound = "key-not-found"
+
+func ErrorKeyNotFound(key string) error {
+	return errors.Preparedf(ErrorCodeKeyNotFound, "key not found", "key %q not found", key)
+}

--- a/config/errors_test.go
+++ b/config/errors_test.go
@@ -1,0 +1,27 @@
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidepool-org/platform/config"
+	"github.com/tidepool-org/platform/errors"
+)
+
+var _ = Describe("Errors", func() {
+	DescribeTable("all errors",
+		func(err error, code string, title string, detail string) {
+			Expect(err).ToNot(BeNil())
+			Expect(errors.Code(err)).To(Equal(code))
+			Expect(errors.Cause(err)).To(Equal(err))
+			bytes, bytesErr := json.Marshal(errors.Sanitize(err))
+			Expect(bytesErr).ToNot(HaveOccurred())
+			Expect(bytes).To(MatchJSON(fmt.Sprintf(`{"code": %q, "title": %q, "detail": %q}`, code, title, detail)))
+		},
+		Entry("is ErrorKeyNotFound", config.ErrorKeyNotFound("TEST"), "key-not-found", "key not found", "key \"TEST\" not found"),
+	)
+})

--- a/config/test/reporter.go
+++ b/config/test/reporter.go
@@ -17,17 +17,20 @@ func NewReporter() *Reporter {
 	}
 }
 
-func (r *Reporter) Get(key string) (string, bool) {
+func (r *Reporter) Get(key string) (string, error) {
 	value, found := r.Config[key]
-	return value, found
+	if !found {
+		return "", config.ErrorKeyNotFound(key)
+	}
+	return value, nil
 }
 
 func (r *Reporter) GetWithDefault(key string, defaultValue string) string {
-	if value, found := r.Get(key); found {
-		return value
+	value, err := r.Get(key)
+	if err != nil {
+		return defaultValue
 	}
-
-	return defaultValue
+	return value
 }
 
 func (r *Reporter) Set(key string, value string) {

--- a/platform/config.go
+++ b/platform/config.go
@@ -27,8 +27,9 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return err
 	}
 
-	if timeoutString, found := configReporter.Get("timeout"); found {
-		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
+	if timeoutString, err := configReporter.Get("timeout"); err == nil {
+		var timeout int64
+		timeout, err = strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("timeout is invalid")
 		}

--- a/service/server/config.go
+++ b/service/server/config.go
@@ -30,8 +30,9 @@ func (c *Config) Load(configReporter config.Reporter) error {
 	}
 
 	c.Address = configReporter.GetWithDefault("address", "")
-	if tlsString, found := configReporter.Get("tls"); found {
-		tls, err := strconv.ParseBool(tlsString)
+	if tlsString, err := configReporter.Get("tls"); err == nil {
+		var tls bool
+		tls, err = strconv.ParseBool(tlsString)
 		if err != nil {
 			return errors.New("tls is invalid")
 		}
@@ -39,8 +40,9 @@ func (c *Config) Load(configReporter config.Reporter) error {
 	}
 	c.TLSCertificateFile = configReporter.GetWithDefault("tls_certificate_file", "")
 	c.TLSKeyFile = configReporter.GetWithDefault("tls_key_file", "")
-	if timeoutString, found := configReporter.Get("timeout"); found {
-		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
+	if timeoutString, err := configReporter.Get("timeout"); err == nil {
+		var timeout int64
+		timeout, err = strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("timeout is invalid")
 		}

--- a/store/mongo/config.go
+++ b/store/mongo/config.go
@@ -33,8 +33,9 @@ func (c *Config) Load(configReporter config.Reporter) error {
 	}
 
 	c.Addresses = SplitAddresses(configReporter.GetWithDefault("addresses", ""))
-	if tlsString, found := configReporter.Get("tls"); found {
-		tls, err := strconv.ParseBool(tlsString)
+	if tlsString, err := configReporter.Get("tls"); err == nil {
+		var tls bool
+		tls, err = strconv.ParseBool(tlsString)
 		if err != nil {
 			return errors.New("tls is invalid")
 		}
@@ -42,14 +43,15 @@ func (c *Config) Load(configReporter config.Reporter) error {
 	}
 	c.Database = configReporter.GetWithDefault("database", "")
 	c.CollectionPrefix = configReporter.GetWithDefault("collection_prefix", "")
-	if username, found := configReporter.Get("username"); found {
+	if username, err := configReporter.Get("username"); err == nil {
 		c.Username = pointer.String(username)
 	}
-	if password, found := configReporter.Get("password"); found {
+	if password, err := configReporter.Get("password"); err == nil {
 		c.Password = pointer.String(password)
 	}
-	if timeoutString, found := configReporter.Get("timeout"); found {
-		timeout, err := strconv.ParseInt(timeoutString, 10, 0)
+	if timeoutString, err := configReporter.Get("timeout"); err == nil {
+		var timeout int64
+		timeout, err = strconv.ParseInt(timeoutString, 10, 0)
 		if err != nil {
 			return errors.New("timeout is invalid")
 		}

--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -33,15 +33,17 @@ func (c *Config) Load(configReporter config.Reporter) error {
 		return errors.New("config reporter is missing")
 	}
 
-	if workersString, found := configReporter.Get("workers"); found {
-		workers, err := strconv.ParseInt(workersString, 10, 0)
+	if workersString, err := configReporter.Get("workers"); err == nil {
+		var workers int64
+		workers, err = strconv.ParseInt(workersString, 10, 0)
 		if err != nil {
 			return errors.New("workers is invalid")
 		}
 		c.Workers = int(workers)
 	}
-	if delayString, found := configReporter.Get("delay"); found {
-		delay, err := strconv.ParseInt(delayString, 10, 0)
+	if delayString, err := configReporter.Get("delay"); err == nil {
+		var delay int64
+		delay, err = strconv.ParseInt(delayString, 10, 0)
 		if err != nil {
 			return errors.New("delay is invalid")
 		}


### PR DESCRIPTION
@jh-bate Need to switch to returning error if config value not found, rather than a simple bool for more normal Golang functionality.