### PR TITLE
Refactor oauth package to allow alternate grant workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Refactor oauth package to allow alternate grant workflows
 * Add Makefile generate target for code generation
 * Update mechanism to find files with main()
 * Add file embedding tool to Makefile

--- a/dexcom/client/client.go
+++ b/dexcom/client/client.go
@@ -21,8 +21,8 @@ type Client struct {
 	client *oauthClient.Client
 }
 
-func New(cfg *client.Config, prvdr oauth.Provider) (*Client, error) {
-	clnt, err := oauthClient.New(cfg, prvdr)
+func New(cfg *client.Config, tknSrcSrc oauth.TokenSourceSource) (*Client, error) {
+	clnt, err := oauthClient.New(cfg, tknSrcSrc)
 	if err != nil {
 		return nil, err
 	}

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -304,7 +304,7 @@ func (t *TaskRunner) updateDataSource(dataSourceUpdate *data.DataSourceUpdate) e
 }
 
 func (t *TaskRunner) createTokenSource() error {
-	tokenSource, err := oauthToken.NewSource(t.providerSession.OAuthToken)
+	tokenSource, err := oauthToken.NewSourceWithToken(t.providerSession.OAuthToken)
 	if err != nil {
 		t.task.SetFailed()
 		return errors.Wrap(err, "unable to create token source")

--- a/dexcom/provider/provider.go
+++ b/dexcom/provider/provider.go
@@ -33,7 +33,7 @@ func New(configReporter config.Reporter, dataClient dataClient.Client, taskClien
 		return nil, errors.New("task client is missing")
 	}
 
-	prvdr, err := oauthProvider.New(ProviderName, configReporter.WithScopes(ProviderName))
+	prvdr, err := oauthProvider.NewProvider(ProviderName, configReporter.WithScopes(ProviderName))
 	if err != nil {
 		return nil, err
 	}

--- a/oauth/client/client.go
+++ b/oauth/client/client.go
@@ -9,16 +9,16 @@ import (
 )
 
 type Client struct {
-	client   *client.Client
-	provider oauth.Provider
+	client            *client.Client
+	tokenSourceSource oauth.TokenSourceSource
 }
 
-func New(cfg *client.Config, prvdr oauth.Provider) (*Client, error) {
+func New(cfg *client.Config, tknSrcSrc oauth.TokenSourceSource) (*Client, error) {
 	if cfg == nil {
 		return nil, errors.New("config is missing")
 	}
-	if prvdr == nil {
-		return nil, errors.New("provider is missing")
+	if tknSrcSrc == nil {
+		return nil, errors.New("token source source is missing")
 	}
 
 	clnt, err := client.New(cfg)
@@ -27,8 +27,8 @@ func New(cfg *client.Config, prvdr oauth.Provider) (*Client, error) {
 	}
 
 	return &Client{
-		client:   clnt,
-		provider: prvdr,
+		client:            clnt,
+		tokenSourceSource: tknSrcSrc,
 	}, nil
 }
 
@@ -40,12 +40,12 @@ func (c *Client) AppendURLQuery(urlString string, query map[string]string) strin
 	return c.client.AppendURLQuery(urlString, query)
 }
 
-func (c *Client) SendOAuthRequest(ctx context.Context, method string, url string, mutators []client.Mutator, requestBody interface{}, responseBody interface{}, tokenSource oauth.TokenSource) error {
-	if tokenSource == nil {
-		return errors.New("token source is missing")
+func (c *Client) SendOAuthRequest(ctx context.Context, method string, url string, mutators []client.Mutator, requestBody interface{}, responseBody interface{}, httpClientSource oauth.HTTPClientSource) error {
+	if httpClientSource == nil {
+		return errors.New("http client source is missing")
 	}
 
-	httpClient, err := tokenSource.HTTPClient(ctx, c.provider)
+	httpClient, err := httpClientSource.HTTPClient(ctx, c.tokenSourceSource)
 	if err != nil {
 		return err
 	}

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -14,16 +14,26 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+type TokenSourceSource interface {
+	TokenSource(ctx context.Context, token *Token) (oauth2.TokenSource, error)
+}
+
 type Provider interface {
 	provider.Provider
+	TokenSourceSource
 
-	Config() *oauth2.Config
+	CalculateStateForRestrictedToken(restrictedToken string) string // state = crypto of provider name, restrictedToken, secret
+	GetAuthorizationCodeURLWithState(state string) string
+	ExchangeAuthorizationCodeForToken(ctx context.Context, authorizationCode string) (*Token, error)
+}
 
-	State(restrictedToken string) string // state = crypto of provider name, restrictedToken, secret
+type HTTPClientSource interface {
+	HTTPClient(ctx context.Context, tokenSourceSource TokenSourceSource) (*http.Client, error)
 }
 
 type TokenSource interface {
-	HTTPClient(ctx context.Context, prvdr Provider) (*http.Client, error)
+	HTTPClientSource
+
 	RefreshedToken() (*Token, error)
 	ExpireToken()
 }

--- a/oauth/provider/provider.go
+++ b/oauth/provider/provider.go
@@ -9,22 +9,18 @@ import (
 	"github.com/tidepool-org/platform/config"
 	"github.com/tidepool-org/platform/crypto"
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/oauth"
 )
 
 const ProviderType = "oauth"
 
 type Provider struct {
-	name         string
-	clientID     string
-	clientSecret string
-	authorizeURL string
-	tokenURL     string
-	redirectURL  string
-	scopes       []string
-	stateSalt    string
+	name      string
+	config    *oauth2.Config
+	stateSalt string
 }
 
-func New(name string, configReporter config.Reporter) (*Provider, error) {
+func NewProvider(name string, configReporter config.Reporter) (*Provider, error) {
 	if name == "" {
 		return nil, errors.New("name is missing")
 	}
@@ -32,44 +28,38 @@ func New(name string, configReporter config.Reporter) (*Provider, error) {
 		return nil, errors.New("config reporter is missing")
 	}
 
-	clientID := configReporter.GetWithDefault("client_id", "")
-	if clientID == "" {
+	cfg := &oauth2.Config{}
+	cfg.ClientID = configReporter.GetWithDefault("client_id", "")
+	if cfg.ClientID == "" {
 		return nil, errors.New("client id is missing")
 	}
-	clientSecret := configReporter.GetWithDefault("client_secret", "")
-	if clientSecret == "" {
+	cfg.ClientSecret = configReporter.GetWithDefault("client_secret", "")
+	if cfg.ClientSecret == "" {
 		return nil, errors.New("client secret is missing")
 	}
-	authorizeURL := configReporter.GetWithDefault("authorize_url", "")
-	if authorizeURL == "" {
+	cfg.Endpoint.AuthURL = configReporter.GetWithDefault("authorize_url", "")
+	if cfg.Endpoint.AuthURL == "" {
 		return nil, errors.New("authorize url is missing")
 	}
-	tokenURL := configReporter.GetWithDefault("token_url", "")
-	if tokenURL == "" {
+	cfg.Endpoint.TokenURL = configReporter.GetWithDefault("token_url", "")
+	if cfg.Endpoint.TokenURL == "" {
 		return nil, errors.New("token url is missing")
 	}
-	redirectURL := configReporter.GetWithDefault("redirect_url", "")
-	if redirectURL == "" {
+	cfg.RedirectURL = configReporter.GetWithDefault("redirect_url", "")
+	if cfg.RedirectURL == "" {
 		return nil, errors.New("redirect url is missing")
 	}
-	scopes := SplitScopes(configReporter.GetWithDefault("scopes", ""))
-	if len(scopes) == 0 {
-		return nil, errors.New("scopes is missing")
-	}
+	cfg.Scopes = SplitScopes(configReporter.GetWithDefault("scopes", ""))
+
 	stateSalt := configReporter.GetWithDefault("state_salt", "")
 	if stateSalt == "" {
 		return nil, errors.New("state salt is missing")
 	}
 
 	return &Provider{
-		name:         name,
-		clientID:     clientID,
-		clientSecret: clientSecret,
-		authorizeURL: authorizeURL,
-		tokenURL:     tokenURL,
-		redirectURL:  redirectURL,
-		scopes:       scopes,
-		stateSalt:    stateSalt,
+		name:      name,
+		config:    cfg,
+		stateSalt: stateSalt,
 	}, nil
 }
 
@@ -89,21 +79,34 @@ func (p *Provider) OnDelete(ctx context.Context, userID string, providerSessionI
 	return nil
 }
 
-func (p *Provider) Config() *oauth2.Config {
-	return &oauth2.Config{
-		ClientID:     p.clientID,
-		ClientSecret: p.clientSecret,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  p.authorizeURL,
-			TokenURL: p.tokenURL,
-		},
-		RedirectURL: p.redirectURL,
-		Scopes:      p.scopes,
+func (p *Provider) TokenSource(ctx context.Context, token *oauth.Token) (oauth2.TokenSource, error) {
+	if token == nil {
+		return nil, errors.New("token is missing")
 	}
+
+	tknSrc := p.config.TokenSource(ctx, token.RawToken())
+	if tknSrc == nil {
+		return nil, errors.New("unable to create token source")
+	}
+
+	return tknSrc, nil
 }
 
-func (p *Provider) State(restrictedToken string) string {
+func (p *Provider) CalculateStateForRestrictedToken(restrictedToken string) string {
 	return crypto.HashWithMD5(fmt.Sprintf("%s:%s:%s:%s", p.Type(), p.Name(), restrictedToken, p.stateSalt))
+}
+
+func (p *Provider) GetAuthorizationCodeURLWithState(state string) string {
+	return p.config.AuthCodeURL(state)
+}
+
+func (p *Provider) ExchangeAuthorizationCodeForToken(ctx context.Context, authorizationCode string) (*oauth.Token, error) {
+	token, err := p.config.Exchange(ctx, authorizationCode)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to exchange authorization code for token")
+	}
+
+	return oauth.NewTokenFromRawToken(token)
 }
 
 func SplitScopes(scopes string) []string {

--- a/oauth/token/source.go
+++ b/oauth/token/source.go
@@ -11,13 +11,17 @@ import (
 )
 
 type Source struct {
-	token       *oauth.Token
-	tokenSource oauth2.TokenSource
-	httpClient  *http.Client
-	provider    oauth.Provider
+	token             *oauth.Token
+	tokenSourceSource oauth.TokenSourceSource
+	tokenSource       oauth2.TokenSource
+	httpClient        *http.Client
 }
 
-func NewSource(tkn *oauth.Token) (*Source, error) {
+func NewSource() (*Source, error) {
+	return &Source{}, nil
+}
+
+func NewSourceWithToken(tkn *oauth.Token) (*Source, error) {
 	if tkn == nil {
 		return nil, errors.New("token is missing")
 	}
@@ -26,24 +30,18 @@ func NewSource(tkn *oauth.Token) (*Source, error) {
 		token: tkn,
 	}, nil
 }
-
-func (s *Source) HTTPClient(ctx context.Context, prvdr oauth.Provider) (*http.Client, error) {
+func (s *Source) HTTPClient(ctx context.Context, tknSrcSrc oauth.TokenSourceSource) (*http.Client, error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")
 	}
-	if prvdr == nil {
-		return nil, errors.New("provider is missing")
+	if tknSrcSrc == nil {
+		return nil, errors.New("token source source is missing")
 	}
 
-	if prvdr != s.provider {
-		cfg := prvdr.Config()
-		if cfg == nil {
-			return nil, errors.New("unable to create provider config")
-		}
-
-		tknSrc := cfg.TokenSource(ctx, s.token.RawToken())
-		if tknSrc == nil {
-			return nil, errors.New("unable to create token source")
+	if tknSrcSrc != s.tokenSourceSource {
+		tknSrc, err := tknSrcSrc.TokenSource(ctx, s.token)
+		if err != nil {
+			return nil, err
 		}
 
 		httpClient := oauth2.NewClient(ctx, tknSrc)
@@ -51,9 +49,9 @@ func (s *Source) HTTPClient(ctx context.Context, prvdr oauth.Provider) (*http.Cl
 			return nil, errors.New("unable to create http client")
 		}
 
+		s.tokenSourceSource = tknSrcSrc
 		s.tokenSource = tknSrc
 		s.httpClient = httpClient
-		s.provider = prvdr
 	}
 
 	return s.httpClient, nil
@@ -69,7 +67,7 @@ func (s *Source) RefreshedToken() (*oauth.Token, error) {
 		return nil, errors.Wrap(err, "unable to get token")
 	}
 
-	if s.token.MatchesRawToken(tknSrcTkn) {
+	if s.token == nil || s.token.MatchesRawToken(tknSrcTkn) {
 		return nil, nil
 	}
 
@@ -83,9 +81,11 @@ func (s *Source) RefreshedToken() (*oauth.Token, error) {
 }
 
 func (s *Source) ExpireToken() {
-	s.provider = nil
 	s.httpClient = nil
 	s.tokenSource = nil
+	s.tokenSourceSource = nil
 
-	s.token.Expire()
+	if s.token != nil {
+		s.token.Expire()
+	}
 }


### PR DESCRIPTION
@jh-bate Cleanup of oauth package to be more friendly to other grant types. Next commit adds the client credentials grant, which will be used by the Auth0 management tool.