### PR TITLE
Add Object and Array structure validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add Object and Array structure validators
 * Remove data.ValidateInterface...; does not work as expected
 * Remove structure.Validating; does not work as expected
 * Refactor data normalizer to use common structure normalizer

--- a/structure/validator.go
+++ b/structure/validator.go
@@ -22,6 +22,9 @@ type Validator interface {
 	StringArray(reference string, value *[]string) StringArray
 	Time(reference string, value *time.Time) Time
 
+	Object(reference string, value *map[string]interface{}) Object
+	Array(reference string, value *[]interface{}) Array
+
 	WithSource(source Source) Validator
 	WithMeta(meta interface{}) Validator
 	WithReference(reference string) Validator
@@ -127,4 +130,20 @@ type Time interface {
 	AfterNow(threshold time.Duration) Time
 	Before(limit time.Time) Time
 	BeforeNow(threshold time.Duration) Time
+}
+
+type Object interface {
+	Exists() Object
+	NotExists() Object
+
+	Empty() Object
+	NotEmpty() Object
+}
+
+type Array interface {
+	Exists() Array
+	NotExists() Array
+
+	Empty() Array
+	NotEmpty() Array
 }

--- a/structure/validator/array.go
+++ b/structure/validator/array.go
@@ -1,0 +1,50 @@
+package validator
+
+import (
+	"github.com/tidepool-org/platform/structure"
+	structureBase "github.com/tidepool-org/platform/structure/base"
+)
+
+type Array struct {
+	base  *structureBase.Base
+	value *[]interface{}
+}
+
+func NewArray(base *structureBase.Base, value *[]interface{}) *Array {
+	return &Array{
+		base:  base,
+		value: value,
+	}
+}
+
+func (a *Array) Exists() structure.Array {
+	if a.value == nil {
+		a.base.ReportError(ErrorValueNotExists())
+	}
+	return a
+}
+
+func (a *Array) NotExists() structure.Array {
+	if a.value != nil {
+		a.base.ReportError(ErrorValueExists())
+	}
+	return a
+}
+
+func (a *Array) Empty() structure.Array {
+	if a.value != nil {
+		if len(*a.value) != 0 {
+			a.base.ReportError(ErrorValueNotEmpty())
+		}
+	}
+	return a
+}
+
+func (a *Array) NotEmpty() structure.Array {
+	if a.value != nil {
+		if len(*a.value) == 0 {
+			a.base.ReportError(ErrorValueEmpty())
+		}
+	}
+	return a
+}

--- a/structure/validator/array_test.go
+++ b/structure/validator/array_test.go
@@ -1,0 +1,233 @@
+package validator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/structure"
+	structureBase "github.com/tidepool-org/platform/structure/base"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+)
+
+var _ = Describe("Array", func() {
+	var base *structureBase.Base
+
+	BeforeEach(func() {
+		base = structureBase.New()
+	})
+
+	Context("NewArray", func() {
+		It("returns successfully", func() {
+			value := []interface{}{"a", "b"}
+			Expect(structureValidator.NewArray(base, &value)).ToNot(BeNil())
+		})
+	})
+
+	Context("with new validator with nil value", func() {
+		var validator *structureValidator.Array
+		var result structure.Array
+
+		BeforeEach(func() {
+			validator = structureValidator.NewArray(base, nil)
+			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Exists", func() {
+			BeforeEach(func() {
+				result = validator.Exists()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotExists())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotExists", func() {
+			BeforeEach(func() {
+				result = validator.NotExists()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("Empty", func() {
+			BeforeEach(func() {
+				result = validator.Empty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotEmpty", func() {
+			BeforeEach(func() {
+				result = validator.NotEmpty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+	})
+
+	Context("with new validator with empty value", func() {
+		var validator *structureValidator.Array
+		var result structure.Array
+		var value []interface{}
+
+		BeforeEach(func() {
+			value = []interface{}{}
+			validator = structureValidator.NewArray(base, &value)
+			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Exists", func() {
+			BeforeEach(func() {
+				result = validator.Exists()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotExists", func() {
+			BeforeEach(func() {
+				result = validator.NotExists()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueExists())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("Empty", func() {
+			BeforeEach(func() {
+				result = validator.Empty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotEmpty", func() {
+			BeforeEach(func() {
+				result = validator.NotEmpty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueEmpty())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+	})
+
+	Context("with new validator with non-empty value", func() {
+		var validator *structureValidator.Array
+		var result structure.Array
+		var value []interface{}
+
+		BeforeEach(func() {
+			value = []interface{}{"a", "b"}
+			validator = structureValidator.NewArray(base, &value)
+			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Exists", func() {
+			BeforeEach(func() {
+				result = validator.Exists()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotExists", func() {
+			BeforeEach(func() {
+				result = validator.NotExists()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueExists())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("Empty", func() {
+			BeforeEach(func() {
+				result = validator.Empty()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotEmpty())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotEmpty", func() {
+			BeforeEach(func() {
+				result = validator.NotEmpty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+	})
+})

--- a/structure/validator/object.go
+++ b/structure/validator/object.go
@@ -1,0 +1,50 @@
+package validator
+
+import (
+	"github.com/tidepool-org/platform/structure"
+	structureBase "github.com/tidepool-org/platform/structure/base"
+)
+
+type Object struct {
+	base  *structureBase.Base
+	value *map[string]interface{}
+}
+
+func NewObject(base *structureBase.Base, value *map[string]interface{}) *Object {
+	return &Object{
+		base:  base,
+		value: value,
+	}
+}
+
+func (o *Object) Exists() structure.Object {
+	if o.value == nil {
+		o.base.ReportError(ErrorValueNotExists())
+	}
+	return o
+}
+
+func (o *Object) NotExists() structure.Object {
+	if o.value != nil {
+		o.base.ReportError(ErrorValueExists())
+	}
+	return o
+}
+
+func (o *Object) Empty() structure.Object {
+	if o.value != nil {
+		if len(*o.value) != 0 {
+			o.base.ReportError(ErrorValueNotEmpty())
+		}
+	}
+	return o
+}
+
+func (o *Object) NotEmpty() structure.Object {
+	if o.value != nil {
+		if len(*o.value) == 0 {
+			o.base.ReportError(ErrorValueEmpty())
+		}
+	}
+	return o
+}

--- a/structure/validator/object_test.go
+++ b/structure/validator/object_test.go
@@ -1,0 +1,233 @@
+package validator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/structure"
+	structureBase "github.com/tidepool-org/platform/structure/base"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+)
+
+var _ = Describe("Object", func() {
+	var base *structureBase.Base
+
+	BeforeEach(func() {
+		base = structureBase.New()
+	})
+
+	Context("NewObject", func() {
+		It("returns successfully", func() {
+			value := map[string]interface{}{"a": 1, "b": 2}
+			Expect(structureValidator.NewObject(base, &value)).ToNot(BeNil())
+		})
+	})
+
+	Context("with new validator with nil value", func() {
+		var validator *structureValidator.Object
+		var result structure.Object
+
+		BeforeEach(func() {
+			validator = structureValidator.NewObject(base, nil)
+			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Exists", func() {
+			BeforeEach(func() {
+				result = validator.Exists()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotExists())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotExists", func() {
+			BeforeEach(func() {
+				result = validator.NotExists()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("Empty", func() {
+			BeforeEach(func() {
+				result = validator.Empty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotEmpty", func() {
+			BeforeEach(func() {
+				result = validator.NotEmpty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+	})
+
+	Context("with new validator with empty value", func() {
+		var validator *structureValidator.Object
+		var result structure.Object
+		var value map[string]interface{}
+
+		BeforeEach(func() {
+			value = map[string]interface{}{}
+			validator = structureValidator.NewObject(base, &value)
+			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Exists", func() {
+			BeforeEach(func() {
+				result = validator.Exists()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotExists", func() {
+			BeforeEach(func() {
+				result = validator.NotExists()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueExists())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("Empty", func() {
+			BeforeEach(func() {
+				result = validator.Empty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotEmpty", func() {
+			BeforeEach(func() {
+				result = validator.NotEmpty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueEmpty())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+	})
+
+	Context("with new validator with non-empty value", func() {
+		var validator *structureValidator.Object
+		var result structure.Object
+		var value map[string]interface{}
+
+		BeforeEach(func() {
+			value = map[string]interface{}{"a": 1, "b": 2}
+			validator = structureValidator.NewObject(base, &value)
+			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Exists", func() {
+			BeforeEach(func() {
+				result = validator.Exists()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotExists", func() {
+			BeforeEach(func() {
+				result = validator.NotExists()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueExists())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("Empty", func() {
+			BeforeEach(func() {
+				result = validator.Empty()
+			})
+
+			It("reports the expected error", func() {
+				Expect(base.Error()).To(HaveOccurred())
+				Expect(errors.Sanitize(base.Error())).To(Equal(errors.Sanitize(structureValidator.ErrorValueNotEmpty())))
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+
+		Context("NotEmpty", func() {
+			BeforeEach(func() {
+				result = validator.NotEmpty()
+			})
+
+			It("does not report an error", func() {
+				Expect(base.Error()).ToNot(HaveOccurred())
+			})
+
+			It("returns self", func() {
+				Expect(result).To(BeIdenticalTo(validator))
+			})
+		})
+	})
+})

--- a/structure/validator/validator.go
+++ b/structure/validator/validator.go
@@ -58,6 +58,14 @@ func (v *Validator) Time(reference string, value *time.Time) structure.Time {
 	return NewTime(v.base.WithReference(reference), value)
 }
 
+func (v *Validator) Object(reference string, value *map[string]interface{}) structure.Object {
+	return NewObject(v.base.WithReference(reference), value)
+}
+
+func (v *Validator) Array(reference string, value *[]interface{}) structure.Array {
+	return NewArray(v.base.WithReference(reference), value)
+}
+
 func (v *Validator) WithSource(source structure.Source) structure.Validator {
 	return &Validator{
 		base: v.base.WithSource(source),

--- a/structure/validator/validator_test.go
+++ b/structure/validator/validator_test.go
@@ -142,6 +142,28 @@ var _ = Describe("Validator", func() {
 			})
 		})
 
+		Context("Object", func() {
+			It("returns a validator when called with nil value", func() {
+				Expect(validator.Object("reference", nil)).ToNot(BeNil())
+			})
+
+			It("returns a validator when called with non-nil value", func() {
+				value := map[string]interface{}{"a": 1, "b": 2}
+				Expect(validator.Object("reference", &value)).ToNot(BeNil())
+			})
+		})
+
+		Context("Array", func() {
+			It("returns a validator when called with nil value", func() {
+				Expect(validator.Array("reference", nil)).ToNot(BeNil())
+			})
+
+			It("returns a validator when called with non-nil value", func() {
+				value := []interface{}{"a", "b"}
+				Expect(validator.Array("reference", &value)).ToNot(BeNil())
+			})
+		})
+
 		Context("WithSource", func() {
 			It("returns new validator", func() {
 				src := testStructure.NewSource()


### PR DESCRIPTION
@jh-bate More useful structure validators for Objects (map[string]interface{}) and Arrays ([]interface{}).