### PR TITLE
Add build-watch and ci-build-watch targets to automatic build after file change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add build-watch and ci-build-watch targets to automatic build after file change
 * Remove old unused data validator code and unused errors
 * Use consistent paradigm for creation of contained data objects
 * Randomize most test input for data validate and normalize

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,13 @@ build: check-environment
 	@echo "go build $(BUILD)"
 	@cd $(ROOT_DIRECTORY) && $(FIND_MAIN_CMD) | $(TRANSFORM_GO_BUILD_CMD) | while read LINE; do $(GO_BUILD_CMD) $${LINE}; done
 
+build-watch:
+	@cd $(ROOT_DIRECTORY) && BUILD=$(BUILD) CompileDaemon -build-dir='.' -build='make build' -color -directory='.' -exclude='*_test.go' -include='Makefile' -recursive=true
+
 ci-build: pre-build build
+
+ci-build-watch:
+	@cd $(ROOT_DIRECTORY) && BUILD=$(BUILD) CompileDaemon -build-dir='.' -build='make ci-build' -color -directory='.' -include='Makefile' -recursive=true
 
 service-build:
 ifdef SERVICE


### PR DESCRIPTION
@jh-bate This works pretty much the same as `make test-watch` where the tests are automatically run if it detects any file changes. These two targets just do `build` or `ci-build` if any files change. Works well when writing code to quickly get rid of syntax errors and the like.