### PR TITLE
Add automated basal data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add automated basal data type
 * Refactor suppressed basal to improve validations
 * Add build-watch and ci-build-watch targets to automatic build after file change
 * Remove old unused data validator code and unused errors

--- a/data/factory/standard.go
+++ b/data/factory/standard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	"github.com/tidepool-org/platform/data/types/basal"
+	"github.com/tidepool-org/platform/data/types/basal/automated"
 	"github.com/tidepool-org/platform/data/types/basal/scheduled"
 	"github.com/tidepool-org/platform/data/types/basal/suspend"
 	"github.com/tidepool-org/platform/data/types/basal/temporary"
@@ -86,6 +87,7 @@ func NewNewFuncWithKeyAndMap(key string, newFuncMap NewFuncMap) NewFunc {
 
 func NewStandard() (*Standard, error) {
 	var basalNewFuncMap = NewFuncMap{
+		automated.DeliveryType(): NewNewFuncWithFunc(automated.NewDatum),
 		scheduled.DeliveryType(): NewNewFuncWithFunc(scheduled.NewDatum),
 		suspend.DeliveryType():   NewNewFuncWithFunc(suspend.NewDatum),
 		temporary.DeliveryType(): NewNewFuncWithFunc(temporary.NewDatum),

--- a/data/factory/standard_test.go
+++ b/data/factory/standard_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/factory"
 	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/basal/automated"
 	"github.com/tidepool-org/platform/data/types/basal/scheduled"
 	"github.com/tidepool-org/platform/data/types/basal/suspend"
 	"github.com/tidepool-org/platform/data/types/basal/temporary"
@@ -225,6 +226,7 @@ var _ = Describe("Standard", func() {
 			})
 
 			ValidStandardFactoryEntries := []TableEntry{
+				Entry("is basal automated", map[string]string{"type": "basal", "deliveryType": "automated"}, automated.New()),
 				Entry("is basal scheduled", map[string]string{"type": "basal", "deliveryType": "scheduled"}, scheduled.New()),
 				Entry("is basal suspend", map[string]string{"type": "basal", "deliveryType": "suspend"}, suspend.New()),
 				Entry("is basal temp", map[string]string{"type": "basal", "deliveryType": "temp"}, temporary.New()),

--- a/data/types/basal/automated/automated.go
+++ b/data/types/basal/automated/automated.go
@@ -1,0 +1,149 @@
+package automated
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/basal"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/structure"
+)
+
+const (
+	DurationMaximum = 604800000
+	DurationMinimum = 0
+	RateMaximum     = 100.0
+	RateMinimum     = 0.0
+)
+
+type Automated struct {
+	basal.Basal `bson:",inline"`
+
+	Duration         *int     `json:"duration,omitempty" bson:"duration,omitempty"`
+	DurationExpected *int     `json:"expectedDuration,omitempty" bson:"expectedDuration,omitempty"`
+	Rate             *float64 `json:"rate,omitempty" bson:"rate,omitempty"`
+	ScheduleName     *string  `json:"scheduleName,omitempty" bson:"scheduleName,omitempty"`
+}
+
+func DeliveryType() string {
+	return "automated" // TODO: Rename Type to "basal/automated"; remove DeliveryType
+}
+
+func NewDatum() data.Datum {
+	return New()
+}
+
+func New() *Automated {
+	return &Automated{}
+}
+
+func Init() *Automated {
+	automated := New()
+	automated.Init()
+	return automated
+}
+
+func (a *Automated) Init() {
+	a.Basal.Init()
+	a.DeliveryType = DeliveryType()
+
+	a.Duration = nil
+	a.DurationExpected = nil
+	a.Rate = nil
+	a.ScheduleName = nil
+}
+
+func (a *Automated) Parse(parser data.ObjectParser) error {
+	if err := a.Basal.Parse(parser); err != nil {
+		return err
+	}
+
+	a.Duration = parser.ParseInteger("duration")
+	a.DurationExpected = parser.ParseInteger("expectedDuration")
+	a.Rate = parser.ParseFloat("rate")
+	a.ScheduleName = parser.ParseString("scheduleName")
+
+	return nil
+}
+
+func (a *Automated) Validate(validator structure.Validator) {
+	if !validator.HasMeta() {
+		validator = validator.WithMeta(a.Meta())
+	}
+
+	a.Basal.Validate(validator)
+
+	if a.DeliveryType != "" {
+		validator.String("deliveryType", &a.DeliveryType).EqualTo(DeliveryType())
+	}
+
+	validator.Int("duration", a.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
+	expectedDurationValidator := validator.Int("expectedDuration", a.DurationExpected)
+	if a.Duration != nil && *a.Duration >= DurationMinimum && *a.Duration <= DurationMaximum {
+		expectedDurationValidator.InRange(*a.Duration, DurationMaximum)
+	} else {
+		expectedDurationValidator.InRange(DurationMinimum, DurationMaximum)
+	}
+	validator.Float64("rate", a.Rate).Exists().InRange(RateMinimum, RateMaximum)
+	validator.String("scheduleName", a.ScheduleName).NotEmpty()
+}
+
+func (a *Automated) Normalize(normalizer data.Normalizer) {
+	if !normalizer.HasMeta() {
+		normalizer = normalizer.WithMeta(a.Meta())
+	}
+
+	a.Basal.Normalize(normalizer)
+}
+
+type SuppressedAutomated struct {
+	Type         *string `json:"type,omitempty" bson:"type,omitempty"`
+	DeliveryType *string `json:"deliveryType,omitempty" bson:"deliveryType,omitempty"`
+
+	Annotations  *data.BlobArray `json:"annotations,omitempty" bson:"annotations,omitempty"`
+	Rate         *float64        `json:"rate,omitempty" bson:"rate,omitempty"`
+	ScheduleName *string         `json:"scheduleName,omitempty" bson:"scheduleName,omitempty"`
+}
+
+func ParseSuppressedAutomated(parser data.ObjectParser) *SuppressedAutomated {
+	if parser.Object() == nil {
+		return nil
+	}
+	suppressed := NewSuppressedAutomated()
+	suppressed.Parse(parser)
+	parser.ProcessNotParsed()
+	return suppressed
+}
+
+func NewSuppressedAutomated() *SuppressedAutomated {
+	return &SuppressedAutomated{
+		Type:         pointer.String(basal.Type()),
+		DeliveryType: pointer.String(DeliveryType()),
+	}
+}
+
+func (s *SuppressedAutomated) Parse(parser data.ObjectParser) error {
+	s.Type = parser.ParseString("type")
+	s.DeliveryType = parser.ParseString("deliveryType")
+
+	s.Annotations = data.ParseBlobArray(parser.NewChildArrayParser("annotations"))
+	s.Rate = parser.ParseFloat("rate")
+	s.ScheduleName = parser.ParseString("scheduleName")
+
+	return nil
+}
+
+func (s *SuppressedAutomated) Validate(validator structure.Validator) {
+	validator.String("type", s.Type).Exists().EqualTo(basal.Type())
+	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType())
+
+	if s.Annotations != nil {
+		s.Annotations.Validate(validator.WithReference("annotations"))
+	}
+	validator.Float64("rate", s.Rate).Exists().InRange(RateMinimum, RateMaximum)
+	validator.String("scheduleName", s.ScheduleName).NotEmpty()
+}
+
+func (s *SuppressedAutomated) Normalize(normalizer data.Normalizer) {
+	if s.Annotations != nil {
+		s.Annotations.Normalize(normalizer.WithReference("annotations"))
+	}
+}

--- a/data/types/basal/automated/automated_suite_test.go
+++ b/data/types/basal/automated/automated_suite_test.go
@@ -1,0 +1,13 @@
+package automated_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "data/types/basal/automated")
+}

--- a/data/types/basal/automated/automated_test.go
+++ b/data/types/basal/automated/automated_test.go
@@ -1,0 +1,553 @@
+package automated_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
+	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/basal"
+	"github.com/tidepool-org/platform/data/types/basal/automated"
+	testDataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated/test"
+	testDataTypesBasal "github.com/tidepool-org/platform/data/types/basal/test"
+	testDataTypes "github.com/tidepool-org/platform/data/types/test"
+	testErrors "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/structure"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewMeta() interface{} {
+	return &basal.Meta{
+		Type:         "basal",
+		DeliveryType: "automated",
+	}
+}
+
+func NewAutomated() *automated.Automated {
+	datum := automated.New()
+	datum.Basal = *testDataTypesBasal.NewBasal()
+	datum.DeliveryType = "automated"
+	datum.Duration = pointer.Int(test.RandomIntFromRange(automated.DurationMinimum, automated.DurationMaximum))
+	datum.DurationExpected = pointer.Int(test.RandomIntFromRange(*datum.Duration, automated.DurationMaximum))
+	datum.Rate = pointer.Float64(test.RandomFloat64FromRange(automated.RateMinimum, automated.RateMaximum))
+	datum.ScheduleName = pointer.String(testDataTypesBasal.NewScheduleName())
+	return datum
+}
+
+func CloneAutomated(datum *automated.Automated) *automated.Automated {
+	if datum == nil {
+		return nil
+	}
+	clone := automated.New()
+	clone.Basal = *testDataTypesBasal.CloneBasal(&datum.Basal)
+	clone.Duration = test.CloneInt(datum.Duration)
+	clone.DurationExpected = test.CloneInt(datum.DurationExpected)
+	clone.Rate = test.CloneFloat64(datum.Rate)
+	clone.ScheduleName = test.CloneString(datum.ScheduleName)
+	return clone
+}
+
+var _ = Describe("Automated", func() {
+	It("DurationMaximum is expected", func() {
+		Expect(automated.DurationMaximum).To(Equal(604800000))
+	})
+
+	It("DurationMinimum is expected", func() {
+		Expect(automated.DurationMinimum).To(Equal(0))
+	})
+
+	It("RateMaximum is expected", func() {
+		Expect(automated.RateMaximum).To(Equal(100.0))
+	})
+
+	It("RateMinimum is expected", func() {
+		Expect(automated.RateMinimum).To(Equal(0.0))
+	})
+
+	Context("DeliveryType", func() {
+		It("returns the expected delivery type", func() {
+			Expect(automated.DeliveryType()).To(Equal("automated"))
+		})
+	})
+
+	Context("NewDatum", func() {
+		It("returns the expected datum", func() {
+			Expect(automated.NewDatum()).To(Equal(&automated.Automated{}))
+		})
+	})
+
+	Context("New", func() {
+		It("returns the expected datum", func() {
+			Expect(automated.New()).To(Equal(&automated.Automated{}))
+		})
+	})
+
+	Context("Init", func() {
+		It("returns the expected datum with all values initialized", func() {
+			datum := automated.Init()
+			Expect(datum).ToNot(BeNil())
+			Expect(datum.Type).To(Equal("basal"))
+			Expect(datum.DeliveryType).To(Equal("automated"))
+			Expect(datum.Duration).To(BeNil())
+			Expect(datum.DurationExpected).To(BeNil())
+			Expect(datum.Rate).To(BeNil())
+			Expect(datum.ScheduleName).To(BeNil())
+		})
+	})
+
+	Context("with new datum", func() {
+		var datum *automated.Automated
+
+		BeforeEach(func() {
+			datum = NewAutomated()
+		})
+
+		Context("Init", func() {
+			It("initializes the datum", func() {
+				datum.Init()
+				Expect(datum.Type).To(Equal("basal"))
+				Expect(datum.DeliveryType).To(Equal("automated"))
+				Expect(datum.Duration).To(BeNil())
+				Expect(datum.DurationExpected).To(BeNil())
+				Expect(datum.Rate).To(BeNil())
+				Expect(datum.ScheduleName).To(BeNil())
+			})
+		})
+	})
+
+	Context("Automated", func() {
+		Context("Parse", func() {
+			// TODO
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *automated.Automated), expectedErrors ...error) {
+					datum := NewAutomated()
+					mutator(datum)
+					testDataTypes.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *automated.Automated) {},
+				),
+				Entry("type missing",
+					func(datum *automated.Automated) { datum.Type = "" },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &basal.Meta{DeliveryType: "automated"}),
+				),
+				Entry("type invalid",
+					func(datum *automated.Automated) { datum.Type = "invalidType" },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &basal.Meta{Type: "invalidType", DeliveryType: "automated"}),
+				),
+				Entry("type basal",
+					func(datum *automated.Automated) { datum.Type = "basal" },
+				),
+				Entry("delivery type missing",
+					func(datum *automated.Automated) { datum.DeliveryType = "" },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deliveryType", &basal.Meta{Type: "basal"}),
+				),
+				Entry("delivery type invalid",
+					func(datum *automated.Automated) { datum.DeliveryType = "invalidDeliveryType" },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType", &basal.Meta{Type: "basal", DeliveryType: "invalidDeliveryType"}),
+				),
+				Entry("delivery type automated",
+					func(datum *automated.Automated) { datum.DeliveryType = "automated" },
+				),
+				Entry("duration missing; duration expected missing",
+					func(datum *automated.Automated) {
+						datum.Duration = nil
+						datum.DurationExpected = nil
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
+				),
+				Entry("duration missing; duration expected out of range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.Int(-1)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration missing; duration expected in range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.Int(0)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
+				),
+				Entry("duration missing; duration expected in range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.Int(604800000)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
+				),
+				Entry("duration missing; duration expected out of range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.Int(604800001)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration out of range (lower); duration expected missing",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(-1)
+						datum.DurationExpected = nil
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+				),
+				Entry("duration out of range (lower); duration expected out of range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(-1)
+						datum.DurationExpected = pointer.Int(-1)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration out of range (lower); duration expected in range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(-1)
+						datum.DurationExpected = pointer.Int(0)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+				),
+				Entry("duration out of range (lower); duration expected in range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(-1)
+						datum.DurationExpected = pointer.Int(604800000)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+				),
+				Entry("duration out of range (lower); duration expected out of range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(-1)
+						datum.DurationExpected = pointer.Int(604800001)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration in range (lower); duration expected missing",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(0)
+						datum.DurationExpected = nil
+					},
+				),
+				Entry("duration in range (lower); duration expected out of range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(0)
+						datum.DurationExpected = pointer.Int(-1)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration in range (lower); duration expected in range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(0)
+						datum.DurationExpected = pointer.Int(0)
+					},
+				),
+				Entry("duration in range (lower); duration expected in range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(0)
+						datum.DurationExpected = pointer.Int(604800000)
+					},
+				),
+				Entry("duration in range (lower); duration expected out of range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(0)
+						datum.DurationExpected = pointer.Int(604800001)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration in range (upper); duration expected missing",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800000)
+						datum.DurationExpected = nil
+					},
+				),
+				Entry("duration in range (upper); duration expected out of range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800000)
+						datum.DurationExpected = pointer.Int(604799999)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604799999, 604800000, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration in range (upper); duration expected in range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800000)
+						datum.DurationExpected = pointer.Int(604800000)
+					},
+				),
+				Entry("duration in range (upper); duration expected in range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800000)
+						datum.DurationExpected = pointer.Int(604800000)
+					},
+				),
+				Entry("duration in range (upper); duration expected out of range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800000)
+						datum.DurationExpected = pointer.Int(604800001)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 604800000, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration out of range (upper); duration expected missing",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800001)
+						datum.DurationExpected = nil
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+				),
+				Entry("duration out of range (upper); duration expected out of range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800001)
+						datum.DurationExpected = pointer.Int(-1)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration out of range (upper); duration expected in range (lower)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800001)
+						datum.DurationExpected = pointer.Int(0)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+				),
+				Entry("duration out of range (upper); duration expected in range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800001)
+						datum.DurationExpected = pointer.Int(604800000)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+				),
+				Entry("duration out of range (upper); duration expected out of range (upper)",
+					func(datum *automated.Automated) {
+						datum.Duration = pointer.Int(604800001)
+						datum.DurationExpected = pointer.Int(604800001)
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
+				),
+				Entry("rate missing",
+					func(datum *automated.Automated) { datum.Rate = nil },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/rate", NewMeta()),
+				),
+				Entry("rate out of range (lower)",
+					func(datum *automated.Automated) { datum.Rate = pointer.Float64(-0.1) },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", NewMeta()),
+				),
+				Entry("rate in range (lower)",
+					func(datum *automated.Automated) { datum.Rate = pointer.Float64(0.0) },
+				),
+				Entry("rate in range (upper)",
+					func(datum *automated.Automated) { datum.Rate = pointer.Float64(100.0) },
+				),
+				Entry("rate out of range (upper)",
+					func(datum *automated.Automated) { datum.Rate = pointer.Float64(100.1) },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
+				),
+				Entry("schedule name empty",
+					func(datum *automated.Automated) { datum.ScheduleName = pointer.String("") },
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/scheduleName", NewMeta()),
+				),
+				Entry("schedule name valid",
+					func(datum *automated.Automated) {
+						datum.ScheduleName = pointer.String(testDataTypesBasal.NewScheduleName())
+					},
+				),
+				Entry("multiple errors",
+					func(datum *automated.Automated) {
+						datum.Type = "invalidType"
+						datum.DeliveryType = "invalidDeliveryType"
+						datum.Duration = nil
+						datum.DurationExpected = pointer.Int(604800001)
+						datum.Rate = pointer.Float64(100.1)
+						datum.ScheduleName = pointer.String("")
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/scheduleName", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+				),
+			)
+		})
+
+		Context("Normalize", func() {
+			DescribeTable("normalizes the datum",
+				func(mutator func(datum *automated.Automated)) {
+					for _, origin := range structure.Origins() {
+						datum := NewAutomated()
+						mutator(datum)
+						expectedDatum := CloneAutomated(datum)
+						normalizer := dataNormalizer.New()
+						Expect(normalizer).ToNot(BeNil())
+						datum.Normalize(normalizer.WithOrigin(origin))
+						Expect(normalizer.Error()).To(BeNil())
+						Expect(normalizer.Data()).To(BeEmpty())
+						Expect(datum).To(Equal(expectedDatum))
+					}
+				},
+				Entry("does not modify the datum",
+					func(datum *automated.Automated) {},
+				),
+				Entry("does not modify the datum; type missing",
+					func(datum *automated.Automated) { datum.Type = "" },
+				),
+				Entry("does not modify the datum; delivery type missing",
+					func(datum *automated.Automated) { datum.DeliveryType = "" },
+				),
+				Entry("does not modify the datum; duration missing",
+					func(datum *automated.Automated) { datum.Duration = nil },
+				),
+				Entry("does not modify the datum; duration expected missing",
+					func(datum *automated.Automated) { datum.DurationExpected = nil },
+				),
+				Entry("does not modify the datum; rate missing",
+					func(datum *automated.Automated) { datum.Rate = nil },
+				),
+				Entry("does not modify the datum; schedule name missing",
+					func(datum *automated.Automated) { datum.ScheduleName = nil },
+				),
+			)
+		})
+	})
+
+	Context("ParseSuppressedAutomated", func() {
+		// TODO
+	})
+
+	Context("NewSuppressedAutomated", func() {
+		It("returns the expected datum", func() {
+			Expect(automated.NewSuppressedAutomated()).To(Equal(&automated.SuppressedAutomated{
+				Type:         pointer.String("basal"),
+				DeliveryType: pointer.String("automated"),
+			}))
+		})
+	})
+
+	Context("SuppressedAutomated", func() {
+		Context("Parse", func() {
+			// TODO
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *automated.SuppressedAutomated), expectedErrors ...error) {
+					datum := testDataTypesBasalAutomated.NewSuppressedAutomated()
+					mutator(datum)
+					testDataTypes.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *automated.SuppressedAutomated) {},
+				),
+				Entry("type missing",
+					func(datum *automated.SuppressedAutomated) { datum.Type = nil },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/type"),
+				),
+				Entry("type invalid",
+					func(datum *automated.SuppressedAutomated) { datum.Type = pointer.String("invalidType") },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type"),
+				),
+				Entry("type basal",
+					func(datum *automated.SuppressedAutomated) { datum.Type = pointer.String("basal") },
+				),
+				Entry("delivery type missing",
+					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = nil },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/deliveryType"),
+				),
+				Entry("delivery type invalid",
+					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = pointer.String("invalidDeliveryType") },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType"),
+				),
+				Entry("delivery type automated",
+					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = pointer.String("automated") },
+				),
+				Entry("annotations missing",
+					func(datum *automated.SuppressedAutomated) { datum.Annotations = nil },
+				),
+				Entry("annotations valid",
+					func(datum *automated.SuppressedAutomated) { datum.Annotations = testData.NewBlobArray() },
+				),
+				Entry("rate missing",
+					func(datum *automated.SuppressedAutomated) { datum.Rate = nil },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/rate"),
+				),
+				Entry("rate out of range (lower)",
+					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.Float64(-0.1) },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate"),
+				),
+				Entry("rate in range (lower)",
+					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.Float64(0.0) },
+				),
+				Entry("rate in range (upper)",
+					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.Float64(100.0) },
+				),
+				Entry("rate out of range (upper)",
+					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.Float64(100.1) },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate"),
+				),
+				Entry("schedule name empty",
+					func(datum *automated.SuppressedAutomated) { datum.ScheduleName = pointer.String("") },
+					testErrors.WithPointerSource(structureValidator.ErrorValueEmpty(), "/scheduleName"),
+				),
+				Entry("schedule name valid",
+					func(datum *automated.SuppressedAutomated) {
+						datum.ScheduleName = pointer.String(testDataTypesBasal.NewScheduleName())
+					},
+				),
+				Entry("multiple errors",
+					func(datum *automated.SuppressedAutomated) {
+						datum.Type = pointer.String("invalidType")
+						datum.DeliveryType = pointer.String("invalidDeliveryType")
+						datum.Rate = pointer.Float64(100.1)
+						datum.ScheduleName = pointer.String("")
+					},
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueEmpty(), "/scheduleName"),
+				),
+			)
+		})
+
+		Context("Normalize", func() {
+			DescribeTable("normalizes the datum",
+				func(mutator func(datum *automated.SuppressedAutomated)) {
+					for _, origin := range structure.Origins() {
+						datum := testDataTypesBasalAutomated.NewSuppressedAutomated()
+						mutator(datum)
+						expectedDatum := testDataTypesBasalAutomated.CloneSuppressedAutomated(datum)
+						normalizer := dataNormalizer.New()
+						Expect(normalizer).ToNot(BeNil())
+						datum.Normalize(normalizer.WithOrigin(origin))
+						Expect(normalizer.Error()).To(BeNil())
+						Expect(normalizer.Data()).To(BeEmpty())
+						Expect(datum).To(Equal(expectedDatum))
+					}
+				},
+				Entry("does not modify the datum",
+					func(datum *automated.SuppressedAutomated) {},
+				),
+				Entry("does not modify the datum; type missing",
+					func(datum *automated.SuppressedAutomated) { datum.Type = nil },
+				),
+				Entry("does not modify the datum; delivery type missing",
+					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = nil },
+				),
+				Entry("does not modify the datum; annotations missing",
+					func(datum *automated.SuppressedAutomated) { datum.Annotations = nil },
+				),
+				Entry("does not modify the datum; rate missing",
+					func(datum *automated.SuppressedAutomated) { datum.Rate = nil },
+				),
+				Entry("does not modify the datum; schedule name missing",
+					func(datum *automated.SuppressedAutomated) { datum.ScheduleName = nil },
+				),
+			)
+		})
+	})
+})

--- a/data/types/basal/automated/test/automated.go
+++ b/data/types/basal/automated/test/automated.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	testData "github.com/tidepool-org/platform/data/test"
+	"github.com/tidepool-org/platform/data/types/basal/automated"
+	testDataTypesBasal "github.com/tidepool-org/platform/data/types/basal/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewSuppressedAutomated() *automated.SuppressedAutomated {
+	datum := automated.NewSuppressedAutomated()
+	datum.Annotations = testData.NewBlobArray()
+	datum.Rate = pointer.Float64(test.RandomFloat64FromRange(automated.RateMinimum, automated.RateMaximum))
+	datum.ScheduleName = pointer.String(testDataTypesBasal.NewScheduleName())
+	return datum
+}
+
+func CloneSuppressedAutomated(datum *automated.SuppressedAutomated) *automated.SuppressedAutomated {
+	if datum == nil {
+		return nil
+	}
+	clone := automated.NewSuppressedAutomated()
+	clone.Type = datum.Type
+	clone.DeliveryType = datum.DeliveryType
+	clone.Annotations = testData.CloneBlobArray(datum.Annotations)
+	clone.Rate = test.CloneFloat64(datum.Rate)
+	clone.ScheduleName = test.CloneString(datum.ScheduleName)
+	return clone
+}

--- a/data/types/basal/suspend/suspend.go
+++ b/data/types/basal/suspend/suspend.go
@@ -3,6 +3,7 @@ package suspend
 import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/basal"
+	dataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated"
 	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
 	dataTypesBasalTemporary "github.com/tidepool-org/platform/data/types/basal/temporary"
 	"github.com/tidepool-org/platform/service"
@@ -102,6 +103,7 @@ func (s *Suspend) Normalize(normalizer data.Normalizer) {
 }
 
 var suppressedDeliveryTypes = []string{
+	dataTypesBasalAutomated.DeliveryType(),
 	dataTypesBasalScheduled.DeliveryType(),
 	dataTypesBasalTemporary.DeliveryType(),
 }
@@ -109,6 +111,8 @@ var suppressedDeliveryTypes = []string{
 func parseSuppressed(parser data.ObjectParser) Suppressed {
 	if deliveryType := basal.ParseDeliveryType(parser); deliveryType != nil {
 		switch *deliveryType {
+		case dataTypesBasalAutomated.DeliveryType():
+			return dataTypesBasalAutomated.ParseSuppressedAutomated(parser)
 		case dataTypesBasalScheduled.DeliveryType():
 			return dataTypesBasalScheduled.ParseSuppressedScheduled(parser)
 		case dataTypesBasalTemporary.DeliveryType():
@@ -123,6 +127,8 @@ func parseSuppressed(parser data.ObjectParser) Suppressed {
 func validateSuppressed(validator structure.Validator, suppressed Suppressed) {
 	if suppressed != nil {
 		switch suppressed := suppressed.(type) {
+		case *dataTypesBasalAutomated.SuppressedAutomated:
+			suppressed.Validate(validator)
 		case *dataTypesBasalScheduled.SuppressedScheduled:
 			suppressed.Validate(validator)
 		case *dataTypesBasalTemporary.SuppressedTemporary:

--- a/data/types/basal/suspend/suspend_test.go
+++ b/data/types/basal/suspend/suspend_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/tidepool-org/platform/data/parser"
 	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
+	dataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated"
+	testDataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated/test"
 	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
 	testDataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled/test"
 	"github.com/tidepool-org/platform/data/types/basal/suspend"
@@ -55,6 +57,8 @@ func CloneSuspend(datum *suspend.Suspend) *suspend.Suspend {
 	clone.DurationExpected = test.CloneInt(datum.DurationExpected)
 	if datum.Suppressed != nil {
 		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalAutomated.SuppressedAutomated:
+			clone.Suppressed = testDataTypesBasalAutomated.CloneSuppressedAutomated(suppressed)
 		case *dataTypesBasalScheduled.SuppressedScheduled:
 			clone.Suppressed = testDataTypesBasalScheduled.CloneSuppressedScheduled(suppressed)
 		case *dataTypesBasalTemporary.SuppressedTemporary:
@@ -443,6 +447,11 @@ var _ = Describe("Suspend", func() {
 				Entry("suppressed missing",
 					func(datum *suspend.Suspend) { datum.Suppressed = nil },
 				),
+				Entry("suppressed automated",
+					func(datum *suspend.Suspend) {
+						datum.Suppressed = testDataTypesBasalAutomated.NewSuppressedAutomated()
+					},
+				),
 				Entry("suppressed scheduled",
 					func(datum *suspend.Suspend) {
 						datum.Suppressed = testDataTypesBasalScheduled.NewSuppressedScheduled()
@@ -452,6 +461,12 @@ var _ = Describe("Suspend", func() {
 					func(datum *suspend.Suspend) {
 						datum.Suppressed = testDataTypesBasalTemporary.NewSuppressedTemporary(nil)
 					},
+				),
+				Entry("suppressed temporary with suppressed automated",
+					func(datum *suspend.Suspend) {
+						datum.Suppressed = testDataTypesBasalTemporary.NewSuppressedTemporary(testDataTypesBasalAutomated.NewSuppressedAutomated())
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
 				),
 				Entry("suppressed temporary with suppressed scheduled",
 					func(datum *suspend.Suspend) {

--- a/data/types/basal/temporary/temporary_test.go
+++ b/data/types/basal/temporary/temporary_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidepool-org/platform/data/parser"
 	testData "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/data/types/basal"
+	testDataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated/test"
 	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
 	testDataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled/test"
 	"github.com/tidepool-org/platform/data/types/basal/temporary"
@@ -529,6 +530,12 @@ var _ = Describe("Temporary", func() {
 				Entry("suppressed missing",
 					func(datum *temporary.Temporary) { datum.Suppressed = nil },
 				),
+				Entry("suppressed automated",
+					func(datum *temporary.Temporary) {
+						datum.Suppressed = testDataTypesBasalAutomated.NewSuppressedAutomated()
+					},
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed", NewMeta()),
+				),
 				Entry("suppressed scheduled",
 					func(datum *temporary.Temporary) {
 						datum.Suppressed = testDataTypesBasalScheduled.NewSuppressedScheduled()
@@ -691,6 +698,12 @@ var _ = Describe("Temporary", func() {
 				),
 				Entry("suppressed missing",
 					func(datum *temporary.SuppressedTemporary) { datum.Suppressed = nil },
+				),
+				Entry("suppressed automated",
+					func(datum *temporary.SuppressedTemporary) {
+						datum.Suppressed = testDataTypesBasalAutomated.NewSuppressedAutomated()
+					},
+					testErrors.WithPointerSource(structureValidator.ErrorValueExists(), "/suppressed"),
 				),
 				Entry("suppressed scheduled",
 					func(datum *temporary.SuppressedTemporary) {


### PR DESCRIPTION
@jh-bate Add new `basal/automated` type. Very much like `basal/scheduled`, but cannot be suppressed by a `basal/temp` (only by a `basal/suspend`).