### PR TITLE
Refactor data type functions to constants

### DIFF
--- a/.golintignore
+++ b/.golintignore
@@ -19,7 +19,7 @@
 ./data/storeDEPRECATED/store.go:1:1: don't use MixedCaps in package name; storeDEPRECATED should be storedeprecated
 ./data/storeDEPRECATED/store_suite_test.go:1:1: don't use MixedCaps in package name; storeDEPRECATED_test should be storedeprecated_test
 ./data/storeDEPRECATED/store_test.go:1:1: don't use MixedCaps in package name; storeDEPRECATED_test should be storedeprecated_test
-./data/types/device/alarm/alarm.go:25:6: func name will be used as alarm.AlarmTypes by other packages, and that stutters; consider calling this Types
+./data/types/device/alarm/alarm.go:27:6: func name will be used as alarm.AlarmTypes by other packages, and that stutters; consider calling this Types
 ./service/response_test.go:27:30: method WriteJson should be WriteJSON
 ./service/response_test.go:31:30: method EncodeJson should be EncodeJSON
 ./task/task.go:22:6: type name will be used as task.TaskAccessor by other packages, and that stutters; consider calling this Accessor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Refactor data type functions to constants
+
 ## v1.25.0
 
 * Use correct 2-Clause BSD License

--- a/data/factory/standard.go
+++ b/data/factory/standard.go
@@ -87,41 +87,41 @@ func NewNewFuncWithKeyAndMap(key string, newFuncMap NewFuncMap) NewFunc {
 
 func NewStandard() (*Standard, error) {
 	var basalNewFuncMap = NewFuncMap{
-		automated.DeliveryType(): NewNewFuncWithFunc(automated.NewDatum),
-		scheduled.DeliveryType(): NewNewFuncWithFunc(scheduled.NewDatum),
-		suspend.DeliveryType():   NewNewFuncWithFunc(suspend.NewDatum),
-		temporary.DeliveryType(): NewNewFuncWithFunc(temporary.NewDatum),
+		automated.DeliveryType: NewNewFuncWithFunc(automated.NewDatum),
+		scheduled.DeliveryType: NewNewFuncWithFunc(scheduled.NewDatum),
+		suspend.DeliveryType:   NewNewFuncWithFunc(suspend.NewDatum),
+		temporary.DeliveryType: NewNewFuncWithFunc(temporary.NewDatum),
 	}
 
 	var bolusNewFuncMap = NewFuncMap{
-		combination.SubType(): NewNewFuncWithFunc(combination.NewDatum),
-		extended.SubType():    NewNewFuncWithFunc(extended.NewDatum),
-		normal.SubType():      NewNewFuncWithFunc(normal.NewDatum),
+		combination.SubType: NewNewFuncWithFunc(combination.NewDatum),
+		extended.SubType:    NewNewFuncWithFunc(extended.NewDatum),
+		normal.SubType:      NewNewFuncWithFunc(normal.NewDatum),
 	}
 
 	var deviceNewFuncMap = NewFuncMap{
-		alarm.SubType():           NewNewFuncWithFunc(alarm.NewDatum),
-		calibration.SubType():     NewNewFuncWithFunc(calibration.NewDatum),
-		prime.SubType():           NewNewFuncWithFunc(prime.NewDatum),
-		reservoirchange.SubType(): NewNewFuncWithFunc(reservoirchange.NewDatum),
-		status.SubType():          NewNewFuncWithFunc(status.NewDatum),
-		timechange.SubType():      NewNewFuncWithFunc(timechange.NewDatum),
+		alarm.SubType:           NewNewFuncWithFunc(alarm.NewDatum),
+		calibration.SubType:     NewNewFuncWithFunc(calibration.NewDatum),
+		prime.SubType:           NewNewFuncWithFunc(prime.NewDatum),
+		reservoirchange.SubType: NewNewFuncWithFunc(reservoirchange.NewDatum),
+		status.SubType:          NewNewFuncWithFunc(status.NewDatum),
+		timechange.SubType:      NewNewFuncWithFunc(timechange.NewDatum),
 	}
 
 	var baseNewFuncMap = NewFuncMap{
-		basal.Type():         NewNewFuncWithKeyAndMap("deliveryType", basalNewFuncMap),
-		bolus.Type():         NewNewFuncWithKeyAndMap("subType", bolusNewFuncMap),
-		calculator.Type():    NewNewFuncWithFunc(calculator.NewDatum),
-		continuous.Type():    NewNewFuncWithFunc(continuous.NewDatum),
-		device.Type():        NewNewFuncWithKeyAndMap("subType", deviceNewFuncMap),
-		food.Type():          NewNewFuncWithFunc(food.NewDatum),
-		insulin.Type():       NewNewFuncWithFunc(insulin.NewDatum),
-		ketone.Type():        NewNewFuncWithFunc(ketone.NewDatum),
-		physical.Type():      NewNewFuncWithFunc(physical.NewDatum),
-		pump.Type():          NewNewFuncWithFunc(pump.NewDatum),
-		reported.Type():      NewNewFuncWithFunc(reported.NewDatum),
-		selfmonitored.Type(): NewNewFuncWithFunc(selfmonitored.NewDatum),
-		upload.Type():        NewNewFuncWithFunc(upload.NewDatum),
+		basal.Type:         NewNewFuncWithKeyAndMap("deliveryType", basalNewFuncMap),
+		bolus.Type:         NewNewFuncWithKeyAndMap("subType", bolusNewFuncMap),
+		calculator.Type:    NewNewFuncWithFunc(calculator.NewDatum),
+		continuous.Type:    NewNewFuncWithFunc(continuous.NewDatum),
+		device.Type:        NewNewFuncWithKeyAndMap("subType", deviceNewFuncMap),
+		food.Type:          NewNewFuncWithFunc(food.NewDatum),
+		insulin.Type:       NewNewFuncWithFunc(insulin.NewDatum),
+		ketone.Type:        NewNewFuncWithFunc(ketone.NewDatum),
+		physical.Type:      NewNewFuncWithFunc(physical.NewDatum),
+		pump.Type:          NewNewFuncWithFunc(pump.NewDatum),
+		reported.Type:      NewNewFuncWithFunc(reported.NewDatum),
+		selfmonitored.Type: NewNewFuncWithFunc(selfmonitored.NewDatum),
+		upload.Type:        NewNewFuncWithFunc(upload.NewDatum),
 	}
 
 	return &Standard{

--- a/data/types/activity/physical/physical.go
+++ b/data/types/activity/physical/physical.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	Type = "physicalActivity" // TODO: Change to "activity/physical"
+
 	ReportedIntensityHigh   = "high"
 	ReportedIntensityLow    = "low"
 	ReportedIntensityMedium = "medium"
@@ -27,10 +29,6 @@ type Physical struct {
 	ReportedIntensity *string   `json:"reportedIntensity,omitempty" bson:"reportedIntensity,omitempty"`
 }
 
-func Type() string {
-	return "physicalActivity" // TODO: Change to "activity/physical"
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -47,7 +45,7 @@ func Init() *Physical {
 
 func (p *Physical) Init() {
 	p.Base.Init()
-	p.Type = Type()
+	p.Type = Type
 
 	p.Duration = nil
 	p.ReportedIntensity = nil
@@ -74,7 +72,7 @@ func (p *Physical) Validate(validator structure.Validator) {
 	p.Base.Validate(validator)
 
 	if p.Type != "" {
-		validator.String("type", &p.Type).EqualTo(Type())
+		validator.String("type", &p.Type).EqualTo(Type)
 	}
 
 	if p.Duration != nil {

--- a/data/types/activity/physical/physical_test.go
+++ b/data/types/activity/physical/physical_test.go
@@ -43,6 +43,10 @@ func ClonePhysical(datum *physical.Physical) *physical.Physical {
 }
 
 var _ = Describe("Physical", func() {
+	It("Type is expected", func() {
+		Expect(physical.Type).To(Equal("physicalActivity"))
+	})
+
 	It("ReportedIntensityHigh is expected", func() {
 		Expect(physical.ReportedIntensityHigh).To(Equal("high"))
 	})
@@ -57,12 +61,6 @@ var _ = Describe("Physical", func() {
 
 	It("ReportedIntensities returns expected", func() {
 		Expect(physical.ReportedIntensities()).To(Equal([]string{"high", "low", "medium"}))
-	})
-
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(physical.Type()).To(Equal("physicalActivity"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/basal/automated/automated.go
+++ b/data/types/basal/automated/automated.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	DeliveryType = "automated" // TODO: Rename Type to "basal/automated"; remove DeliveryType
+
 	DurationMaximum = 604800000
 	DurationMinimum = 0
 	RateMaximum     = 100.0
@@ -21,10 +23,6 @@ type Automated struct {
 	DurationExpected *int     `json:"expectedDuration,omitempty" bson:"expectedDuration,omitempty"`
 	Rate             *float64 `json:"rate,omitempty" bson:"rate,omitempty"`
 	ScheduleName     *string  `json:"scheduleName,omitempty" bson:"scheduleName,omitempty"`
-}
-
-func DeliveryType() string {
-	return "automated" // TODO: Rename Type to "basal/automated"; remove DeliveryType
 }
 
 func NewDatum() data.Datum {
@@ -43,7 +41,7 @@ func Init() *Automated {
 
 func (a *Automated) Init() {
 	a.Basal.Init()
-	a.DeliveryType = DeliveryType()
+	a.DeliveryType = DeliveryType
 
 	a.Duration = nil
 	a.DurationExpected = nil
@@ -72,7 +70,7 @@ func (a *Automated) Validate(validator structure.Validator) {
 	a.Basal.Validate(validator)
 
 	if a.DeliveryType != "" {
-		validator.String("deliveryType", &a.DeliveryType).EqualTo(DeliveryType())
+		validator.String("deliveryType", &a.DeliveryType).EqualTo(DeliveryType)
 	}
 
 	validator.Int("duration", a.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
@@ -115,8 +113,8 @@ func ParseSuppressedAutomated(parser data.ObjectParser) *SuppressedAutomated {
 
 func NewSuppressedAutomated() *SuppressedAutomated {
 	return &SuppressedAutomated{
-		Type:         pointer.String(basal.Type()),
-		DeliveryType: pointer.String(DeliveryType()),
+		Type:         pointer.String(basal.Type),
+		DeliveryType: pointer.String(DeliveryType),
 	}
 }
 
@@ -132,8 +130,8 @@ func (s *SuppressedAutomated) Parse(parser data.ObjectParser) error {
 }
 
 func (s *SuppressedAutomated) Validate(validator structure.Validator) {
-	validator.String("type", s.Type).Exists().EqualTo(basal.Type())
-	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType())
+	validator.String("type", s.Type).Exists().EqualTo(basal.Type)
+	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType)
 
 	if s.Annotations != nil {
 		s.Annotations.Validate(validator.WithReference("annotations"))

--- a/data/types/basal/automated/automated_test.go
+++ b/data/types/basal/automated/automated_test.go
@@ -51,6 +51,10 @@ func CloneAutomated(datum *automated.Automated) *automated.Automated {
 }
 
 var _ = Describe("Automated", func() {
+	It("DeliveryType is expected", func() {
+		Expect(automated.DeliveryType).To(Equal("automated"))
+	})
+
 	It("DurationMaximum is expected", func() {
 		Expect(automated.DurationMaximum).To(Equal(604800000))
 	})
@@ -65,12 +69,6 @@ var _ = Describe("Automated", func() {
 
 	It("RateMinimum is expected", func() {
 		Expect(automated.RateMinimum).To(Equal(0.0))
-	})
-
-	Context("DeliveryType", func() {
-		It("returns the expected delivery type", func() {
-			Expect(automated.DeliveryType()).To(Equal("automated"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/basal/basal.go
+++ b/data/types/basal/basal.go
@@ -10,6 +10,10 @@ import (
 
 // TODO: Can we use suppressed by reference only (i.e. by id)?
 
+const (
+	Type = "basal"
+)
+
 type Basal struct {
 	types.Base `bson:",inline"`
 
@@ -21,13 +25,9 @@ type Meta struct {
 	DeliveryType string `json:"deliveryType,omitempty"`
 }
 
-func Type() string {
-	return "basal"
-}
-
 func (b *Basal) Init() {
 	b.Base.Init()
-	b.Type = Type()
+	b.Type = Type
 
 	b.DeliveryType = ""
 }
@@ -49,7 +49,7 @@ func (b *Basal) Validate(validator structure.Validator) {
 	b.Base.Validate(validator)
 
 	if b.Type != "" {
-		validator.String("type", &b.Type).EqualTo(Type())
+		validator.String("type", &b.Type).EqualTo(Type)
 	}
 
 	validator.String("deliveryType", &b.DeliveryType).Exists().NotEmpty()
@@ -78,8 +78,8 @@ func ParseDeliveryType(parser data.ObjectParser) *string {
 		parser.AppendError("type", service.ErrorValueNotExists())
 		return nil
 	}
-	if *typ != Type() {
-		parser.AppendError("type", service.ErrorValueStringNotOneOf(*typ, []string{Type()}))
+	if *typ != Type {
+		parser.AppendError("type", service.ErrorValueStringNotOneOf(*typ, []string{Type}))
 		return nil
 	}
 

--- a/data/types/basal/basal_test.go
+++ b/data/types/basal/basal_test.go
@@ -35,10 +35,8 @@ func NewTestBasal(sourceTime interface{}, sourceDeliveryType interface{}) *basal
 }
 
 var _ = Describe("Basal", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(basal.Type()).To(Equal("basal"))
-		})
+	It("Type is expected", func() {
+		Expect(basal.Type).To(Equal("basal"))
 	})
 
 	Context("with new datum", func() {

--- a/data/types/basal/scheduled/scheduled.go
+++ b/data/types/basal/scheduled/scheduled.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	DeliveryType = "scheduled" // TODO: Rename Type to "basal/scheduled"; remove DeliveryType
+
 	DurationMaximum = 604800000
 	DurationMinimum = 0
 	RateMaximum     = 100.0
@@ -21,10 +23,6 @@ type Scheduled struct {
 	DurationExpected *int     `json:"expectedDuration,omitempty" bson:"expectedDuration,omitempty"`
 	Rate             *float64 `json:"rate,omitempty" bson:"rate,omitempty"`
 	ScheduleName     *string  `json:"scheduleName,omitempty" bson:"scheduleName,omitempty"`
-}
-
-func DeliveryType() string {
-	return "scheduled" // TODO: Rename Type to "basal/scheduled"; remove DeliveryType
 }
 
 func NewDatum() data.Datum {
@@ -43,7 +41,7 @@ func Init() *Scheduled {
 
 func (s *Scheduled) Init() {
 	s.Basal.Init()
-	s.DeliveryType = DeliveryType()
+	s.DeliveryType = DeliveryType
 
 	s.Duration = nil
 	s.DurationExpected = nil
@@ -72,7 +70,7 @@ func (s *Scheduled) Validate(validator structure.Validator) {
 	s.Basal.Validate(validator)
 
 	if s.DeliveryType != "" {
-		validator.String("deliveryType", &s.DeliveryType).EqualTo(DeliveryType())
+		validator.String("deliveryType", &s.DeliveryType).EqualTo(DeliveryType)
 	}
 
 	validator.Int("duration", s.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
@@ -115,8 +113,8 @@ func ParseSuppressedScheduled(parser data.ObjectParser) *SuppressedScheduled {
 
 func NewSuppressedScheduled() *SuppressedScheduled {
 	return &SuppressedScheduled{
-		Type:         pointer.String(basal.Type()),
-		DeliveryType: pointer.String(DeliveryType()),
+		Type:         pointer.String(basal.Type),
+		DeliveryType: pointer.String(DeliveryType),
 	}
 }
 
@@ -132,8 +130,8 @@ func (s *SuppressedScheduled) Parse(parser data.ObjectParser) error {
 }
 
 func (s *SuppressedScheduled) Validate(validator structure.Validator) {
-	validator.String("type", s.Type).Exists().EqualTo(basal.Type())
-	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType())
+	validator.String("type", s.Type).Exists().EqualTo(basal.Type)
+	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType)
 
 	if s.Annotations != nil {
 		s.Annotations.Validate(validator.WithReference("annotations"))

--- a/data/types/basal/scheduled/scheduled_test.go
+++ b/data/types/basal/scheduled/scheduled_test.go
@@ -78,6 +78,10 @@ func NewTestScheduled(sourceTime interface{}, sourceDuration interface{}, source
 }
 
 var _ = Describe("Scheduled", func() {
+	It("DeliveryType is expected", func() {
+		Expect(scheduled.DeliveryType).To(Equal("scheduled"))
+	})
+
 	It("DurationMaximum is expected", func() {
 		Expect(scheduled.DurationMaximum).To(Equal(604800000))
 	})
@@ -92,12 +96,6 @@ var _ = Describe("Scheduled", func() {
 
 	It("RateMinimum is expected", func() {
 		Expect(scheduled.RateMinimum).To(Equal(0.0))
-	})
-
-	Context("DeliveryType", func() {
-		It("returns the expected delivery type", func() {
-			Expect(scheduled.DeliveryType()).To(Equal("scheduled"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/basal/suspend/suspend.go
+++ b/data/types/basal/suspend/suspend.go
@@ -12,6 +12,8 @@ import (
 )
 
 const (
+	DeliveryType = "suspend" // TODO: Rename Type to "basal/suspended"; remove DeliveryType
+
 	DurationMaximum = 604800000
 	DurationMinimum = 0
 )
@@ -30,10 +32,6 @@ type Suspend struct {
 	Suppressed       Suppressed `json:"suppressed,omitempty" bson:"suppressed,omitempty"`
 }
 
-func DeliveryType() string {
-	return "suspend" // TODO: Rename Type to "basal/suspended"; remove DeliveryType
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -50,7 +48,7 @@ func Init() *Suspend {
 
 func (s *Suspend) Init() {
 	s.Basal.Init()
-	s.DeliveryType = DeliveryType()
+	s.DeliveryType = DeliveryType
 
 	s.Duration = nil
 	s.DurationExpected = nil
@@ -77,7 +75,7 @@ func (s *Suspend) Validate(validator structure.Validator) {
 	s.Basal.Validate(validator)
 
 	if s.DeliveryType != "" {
-		validator.String("deliveryType", &s.DeliveryType).EqualTo(DeliveryType())
+		validator.String("deliveryType", &s.DeliveryType).EqualTo(DeliveryType)
 	}
 
 	validator.Int("duration", s.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
@@ -103,19 +101,19 @@ func (s *Suspend) Normalize(normalizer data.Normalizer) {
 }
 
 var suppressedDeliveryTypes = []string{
-	dataTypesBasalAutomated.DeliveryType(),
-	dataTypesBasalScheduled.DeliveryType(),
-	dataTypesBasalTemporary.DeliveryType(),
+	dataTypesBasalAutomated.DeliveryType,
+	dataTypesBasalScheduled.DeliveryType,
+	dataTypesBasalTemporary.DeliveryType,
 }
 
 func parseSuppressed(parser data.ObjectParser) Suppressed {
 	if deliveryType := basal.ParseDeliveryType(parser); deliveryType != nil {
 		switch *deliveryType {
-		case dataTypesBasalAutomated.DeliveryType():
+		case dataTypesBasalAutomated.DeliveryType:
 			return dataTypesBasalAutomated.ParseSuppressedAutomated(parser)
-		case dataTypesBasalScheduled.DeliveryType():
+		case dataTypesBasalScheduled.DeliveryType:
 			return dataTypesBasalScheduled.ParseSuppressedScheduled(parser)
-		case dataTypesBasalTemporary.DeliveryType():
+		case dataTypesBasalTemporary.DeliveryType:
 			return dataTypesBasalTemporary.ParseSuppressedTemporary(parser)
 		default:
 			parser.AppendError("type", service.ErrorValueStringNotOneOf(*deliveryType, suppressedDeliveryTypes))

--- a/data/types/basal/suspend/suspend_test.go
+++ b/data/types/basal/suspend/suspend_test.go
@@ -85,18 +85,16 @@ func NewTestSuspend(sourceTime interface{}, sourceDuration interface{}, sourceDu
 }
 
 var _ = Describe("Suspend", func() {
+	It("DeliveryType is expected", func() {
+		Expect(suspend.DeliveryType).To(Equal("suspend"))
+	})
+
 	It("DurationMaximum is expected", func() {
 		Expect(suspend.DurationMaximum).To(Equal(604800000))
 	})
 
 	It("DurationMinimum is expected", func() {
 		Expect(suspend.DurationMinimum).To(Equal(0))
-	})
-
-	Context("DeliveryType", func() {
-		It("returns the expected delivery type", func() {
-			Expect(suspend.DeliveryType()).To(Equal("suspend"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/basal/temporary/temporary.go
+++ b/data/types/basal/temporary/temporary.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	DeliveryType = "temp" // TODO: Rename Type to "basal/temporary"; remove DeliveryType
+
 	DurationMaximum = 604800000
 	DurationMinimum = 0
 	PercentMaximum  = 10.0
@@ -35,10 +37,6 @@ type Temporary struct {
 	Suppressed       Suppressed `json:"suppressed,omitempty" bson:"suppressed,omitempty"`
 }
 
-func DeliveryType() string {
-	return "temp" // TODO: Rename Type to "basal/temporary"; remove DeliveryType
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -55,7 +53,7 @@ func Init() *Temporary {
 
 func (t *Temporary) Init() {
 	t.Basal.Init()
-	t.DeliveryType = DeliveryType()
+	t.DeliveryType = DeliveryType
 
 	t.Duration = nil
 	t.DurationExpected = nil
@@ -86,7 +84,7 @@ func (t *Temporary) Validate(validator structure.Validator) {
 	t.Basal.Validate(validator)
 
 	if t.DeliveryType != "" {
-		validator.String("deliveryType", &t.DeliveryType).EqualTo(DeliveryType())
+		validator.String("deliveryType", &t.DeliveryType).EqualTo(DeliveryType)
 	}
 
 	validator.Int("duration", t.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
@@ -135,8 +133,8 @@ func ParseSuppressedTemporary(parser data.ObjectParser) *SuppressedTemporary {
 
 func NewSuppressedTemporary() *SuppressedTemporary {
 	return &SuppressedTemporary{
-		Type:         pointer.String(basal.Type()),
-		DeliveryType: pointer.String(DeliveryType()),
+		Type:         pointer.String(basal.Type),
+		DeliveryType: pointer.String(DeliveryType),
 	}
 }
 
@@ -153,8 +151,8 @@ func (s *SuppressedTemporary) Parse(parser data.ObjectParser) error {
 }
 
 func (s *SuppressedTemporary) Validate(validator structure.Validator) {
-	validator.String("type", s.Type).Exists().EqualTo(basal.Type())
-	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType())
+	validator.String("type", s.Type).Exists().EqualTo(basal.Type)
+	validator.String("deliveryType", s.DeliveryType).Exists().EqualTo(DeliveryType)
 
 	if s.Annotations != nil {
 		s.Annotations.Validate(validator.WithReference("annotations"))
@@ -174,13 +172,13 @@ func (s *SuppressedTemporary) Normalize(normalizer data.Normalizer) {
 }
 
 var suppressedDeliveryTypes = []string{
-	dataTypesBasalScheduled.DeliveryType(),
+	dataTypesBasalScheduled.DeliveryType,
 }
 
 func parseSuppressed(parser data.ObjectParser) Suppressed {
 	if deliveryType := basal.ParseDeliveryType(parser); deliveryType != nil {
 		switch *deliveryType {
-		case dataTypesBasalScheduled.DeliveryType():
+		case dataTypesBasalScheduled.DeliveryType:
 			return dataTypesBasalScheduled.ParseSuppressedScheduled(parser)
 		default:
 			parser.AppendError("type", service.ErrorValueStringNotOneOf(*deliveryType, suppressedDeliveryTypes))

--- a/data/types/basal/temporary/temporary_test.go
+++ b/data/types/basal/temporary/temporary_test.go
@@ -89,6 +89,10 @@ func NewTestTemporary(sourceTime interface{}, sourceDuration interface{}, source
 }
 
 var _ = Describe("Temporary", func() {
+	It("DeliveryType is expected", func() {
+		Expect(temporary.DeliveryType).To(Equal("temp"))
+	})
+
 	It("DurationMaximum is expected", func() {
 		Expect(temporary.DurationMaximum).To(Equal(604800000))
 	})
@@ -111,12 +115,6 @@ var _ = Describe("Temporary", func() {
 
 	It("RateMinimum is expected", func() {
 		Expect(temporary.RateMinimum).To(Equal(0.0))
-	})
-
-	Context("DeliveryType", func() {
-		It("returns the expected delivery type", func() {
-			Expect(temporary.DeliveryType()).To(Equal("temp"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/blood/glucose/continuous/continuous.go
+++ b/data/types/blood/glucose/continuous/continuous.go
@@ -6,12 +6,12 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "cbg"
+)
+
 type Continuous struct {
 	glucose.Glucose `bson:",inline"`
-}
-
-func Type() string {
-	return "cbg"
 }
 
 func NewDatum() data.Datum {
@@ -30,7 +30,7 @@ func Init() *Continuous {
 
 func (c *Continuous) Init() {
 	c.Glucose.Init()
-	c.Type = Type()
+	c.Type = Type
 }
 
 func (c *Continuous) Validate(validator structure.Validator) {
@@ -41,7 +41,7 @@ func (c *Continuous) Validate(validator structure.Validator) {
 	c.Glucose.Validate(validator)
 
 	if c.Type != "" {
-		validator.String("type", &c.Type).EqualTo(Type())
+		validator.String("type", &c.Type).EqualTo(Type)
 	}
 }
 

--- a/data/types/blood/glucose/continuous/continuous_test.go
+++ b/data/types/blood/glucose/continuous/continuous_test.go
@@ -40,10 +40,8 @@ func CloneContinuous(datum *continuous.Continuous) *continuous.Continuous {
 }
 
 var _ = Describe("Continuous", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(continuous.Type()).To(Equal("cbg"))
-		})
+	It("Type is expected", func() {
+		Expect(continuous.Type).To(Equal("cbg"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/blood/glucose/selfmonitored/selfmonitored.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	Type = "smbg"
+
 	SubTypeLinked = "linked"
 	SubTypeManual = "manual"
 )
@@ -22,10 +24,6 @@ type SelfMonitored struct {
 	glucose.Glucose `bson:",inline"`
 
 	SubType *string `json:"subType,omitempty" bson:"subType,omitempty"`
-}
-
-func Type() string {
-	return "smbg"
 }
 
 func NewDatum() data.Datum {
@@ -44,7 +42,7 @@ func Init() *SelfMonitored {
 
 func (s *SelfMonitored) Init() {
 	s.Glucose.Init()
-	s.Type = Type()
+	s.Type = Type
 
 	s.SubType = nil
 }
@@ -67,7 +65,7 @@ func (s *SelfMonitored) Validate(validator structure.Validator) {
 	s.Glucose.Validate(validator)
 
 	if s.Type != "" {
-		validator.String("type", &s.Type).EqualTo(Type())
+		validator.String("type", &s.Type).EqualTo(Type)
 	}
 
 	validator.String("subType", s.SubType).OneOf(SubTypes()...)

--- a/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
@@ -68,6 +68,10 @@ func NewTestSelfMonitored(sourceTime interface{}, sourceUnits interface{}, sourc
 }
 
 var _ = Describe("SelfMonitored", func() {
+	It("Type is expected", func() {
+		Expect(selfmonitored.Type).To(Equal("smbg"))
+	})
+
 	It("SubTypeLinked is expected", func() {
 		Expect(selfmonitored.SubTypeLinked).To(Equal("linked"))
 	})
@@ -78,12 +82,6 @@ var _ = Describe("SelfMonitored", func() {
 
 	It("SubTypes returns expected", func() {
 		Expect(selfmonitored.SubTypes()).To(Equal([]string{"linked", "manual"}))
-	})
-
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(selfmonitored.Type()).To(Equal("smbg"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/blood/ketone/ketone.go
+++ b/data/types/blood/ketone/ketone.go
@@ -7,12 +7,12 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "bloodKetone"
+)
+
 type Ketone struct {
 	blood.Blood `bson:",inline"`
-}
-
-func Type() string {
-	return "bloodKetone"
 }
 
 func NewDatum() data.Datum {
@@ -31,7 +31,7 @@ func Init() *Ketone {
 
 func (k *Ketone) Init() {
 	k.Blood.Init()
-	k.Type = Type()
+	k.Type = Type
 }
 
 func (k *Ketone) Validate(validator structure.Validator) {
@@ -42,7 +42,7 @@ func (k *Ketone) Validate(validator structure.Validator) {
 	k.Blood.Validate(validator)
 
 	if k.Type != "" {
-		validator.String("type", &k.Type).EqualTo(Type())
+		validator.String("type", &k.Type).EqualTo(Type)
 	}
 
 	validator.String("units", k.Units).Exists().OneOf(ketone.Units()...)

--- a/data/types/blood/ketone/ketone_test.go
+++ b/data/types/blood/ketone/ketone_test.go
@@ -43,10 +43,8 @@ func CloneKetone(datum *ketone.Ketone) *ketone.Ketone {
 }
 
 var _ = Describe("Ketone", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(ketone.Type()).To(Equal("bloodKetone"))
-		})
+	It("Type is expected", func() {
+		Expect(ketone.Type).To(Equal("bloodKetone"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/bolus/bolus.go
+++ b/data/types/bolus/bolus.go
@@ -7,6 +7,10 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "bolus"
+)
+
 type Bolus struct {
 	types.Base `bson:",inline"`
 
@@ -18,13 +22,9 @@ type Meta struct {
 	SubType string `json:"subType,omitempty"`
 }
 
-func Type() string {
-	return "bolus"
-}
-
 func (b *Bolus) Init() {
 	b.Base.Init()
-	b.Type = Type()
+	b.Type = Type
 
 	b.SubType = ""
 }
@@ -46,7 +46,7 @@ func (b *Bolus) Validate(validator structure.Validator) {
 	b.Base.Validate(validator)
 
 	if b.Type != "" {
-		validator.String("type", &b.Type).EqualTo(Type())
+		validator.String("type", &b.Type).EqualTo(Type)
 	}
 
 	validator.String("subType", &b.SubType).Exists().NotEmpty()

--- a/data/types/bolus/bolus_test.go
+++ b/data/types/bolus/bolus_test.go
@@ -35,10 +35,8 @@ func NewTestBolus(sourceTime interface{}, sourceSubType interface{}) *bolus.Bolu
 }
 
 var _ = Describe("Bolus", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(bolus.Type()).To(Equal("bolus"))
-		})
+	It("Type is expected", func() {
+		Expect(bolus.Type).To(Equal("bolus"))
 	})
 
 	Context("with new datum", func() {

--- a/data/types/bolus/combination/combination.go
+++ b/data/types/bolus/combination/combination.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	SubType = "dual/square" // TODO: Rename Type to "bolus/combination"; remove SubType
+
 	DurationMaximum = 86400000
 	DurationMinimum = 0
 	ExtendedMaximum = 100.0
@@ -26,10 +28,6 @@ type Combination struct {
 	NormalExpected   *float64 `json:"expectedNormal,omitempty" bson:"expectedNormal,omitempty"`
 }
 
-func SubType() string {
-	return "dual/square" // TODO: Rename Type to "bolus/combination"; remove SubType
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -46,7 +44,7 @@ func Init() *Combination {
 
 func (c *Combination) Init() {
 	c.Bolus.Init()
-	c.SubType = SubType()
+	c.SubType = SubType
 
 	c.Duration = nil
 	c.DurationExpected = nil
@@ -79,7 +77,7 @@ func (c *Combination) Validate(validator structure.Validator) {
 	c.Bolus.Validate(validator)
 
 	if c.SubType != "" {
-		validator.String("subType", &c.SubType).EqualTo(SubType())
+		validator.String("subType", &c.SubType).EqualTo(SubType)
 	}
 
 	if c.NormalExpected != nil {

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -59,6 +59,10 @@ func NewTestCombination(sourceTime interface{}, sourceDuration interface{}, sour
 }
 
 var _ = Describe("Combination", func() {
+	It("SubType is expected", func() {
+		Expect(combination.SubType).To(Equal("dual/square"))
+	})
+
 	It("DurationMaximum is expected", func() {
 		Expect(combination.DurationMaximum).To(Equal(86400000))
 	})
@@ -81,12 +85,6 @@ var _ = Describe("Combination", func() {
 
 	It("NormalMinimum is expected", func() {
 		Expect(combination.NormalMinimum).To(Equal(0.0))
-	})
-
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(combination.SubType()).To(Equal("dual/square"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/bolus/extended/extended.go
+++ b/data/types/bolus/extended/extended.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	SubType = "square" // TODO: Rename Type to "bolus/extended"; remove SubType
+
 	DurationMaximum = 86400000
 	DurationMinimum = 0
 	ExtendedMaximum = 100.0
@@ -20,10 +22,6 @@ type Extended struct {
 	DurationExpected *int     `json:"expectedDuration,omitempty" bson:"expectedDuration,omitempty"`
 	Extended         *float64 `json:"extended,omitempty" bson:"extended,omitempty"`
 	ExtendedExpected *float64 `json:"expectedExtended,omitempty" bson:"expectedExtended,omitempty"`
-}
-
-func SubType() string {
-	return "square" // TODO: Rename Type to "bolus/extended"; remove SubType
 }
 
 func NewDatum() data.Datum {
@@ -42,7 +40,7 @@ func Init() *Extended {
 
 func (e *Extended) Init() {
 	e.Bolus.Init()
-	e.SubType = SubType()
+	e.SubType = SubType
 
 	e.Duration = nil
 	e.DurationExpected = nil
@@ -71,7 +69,7 @@ func (e *Extended) Validate(validator structure.Validator) {
 	e.Bolus.Validate(validator)
 
 	if e.SubType != "" {
-		validator.String("subType", &e.SubType).EqualTo(SubType())
+		validator.String("subType", &e.SubType).EqualTo(SubType)
 	}
 
 	validator.Int("duration", e.Duration).Exists().InRange(DurationMinimum, DurationMaximum)

--- a/data/types/bolus/extended/extended_test.go
+++ b/data/types/bolus/extended/extended_test.go
@@ -52,6 +52,10 @@ func NewTestExtended(sourceTime interface{}, sourceDuration interface{}, sourceD
 }
 
 var _ = Describe("Extended", func() {
+	It("SubType is expected", func() {
+		Expect(extended.SubType).To(Equal("square"))
+	})
+
 	It("DurationMaximum is expected", func() {
 		Expect(extended.DurationMaximum).To(Equal(86400000))
 	})
@@ -66,12 +70,6 @@ var _ = Describe("Extended", func() {
 
 	It("ExtendedMinimum is expected", func() {
 		Expect(extended.ExtendedMinimum).To(Equal(0.0))
-	})
-
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(extended.SubType()).To(Equal("square"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/bolus/normal/normal.go
+++ b/data/types/bolus/normal/normal.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	SubType = "normal" // TODO: Rename Type to "bolus/normal"; remove SubType
+
 	NormalMaximum = 100.0
 	NormalMinimum = 0.0
 )
@@ -16,10 +18,6 @@ type Normal struct {
 
 	Normal         *float64 `json:"normal,omitempty" bson:"normal,omitempty"`
 	NormalExpected *float64 `json:"expectedNormal,omitempty" bson:"expectedNormal,omitempty"`
-}
-
-func SubType() string {
-	return "normal" // TODO: Rename Type to "bolus/normal"; remove SubType
 }
 
 func NewDatum() data.Datum {
@@ -38,7 +36,7 @@ func Init() *Normal {
 
 func (n *Normal) Init() {
 	n.Bolus.Init()
-	n.SubType = SubType()
+	n.SubType = SubType
 
 	n.Normal = nil
 	n.NormalExpected = nil
@@ -63,7 +61,7 @@ func (n *Normal) Validate(validator structure.Validator) {
 	n.Bolus.Validate(validator)
 
 	if n.SubType != "" {
-		validator.String("subType", &n.SubType).EqualTo(SubType())
+		validator.String("subType", &n.SubType).EqualTo(SubType)
 	}
 
 	validator.Float64("normal", n.Normal).Exists().InRange(NormalMinimum, NormalMaximum)

--- a/data/types/bolus/normal/normal_test.go
+++ b/data/types/bolus/normal/normal_test.go
@@ -46,18 +46,16 @@ func NewTestNormal(sourceTime interface{}, sourceNormal interface{}, sourceNorma
 }
 
 var _ = Describe("Normal", func() {
+	It("SubType is expected", func() {
+		Expect(normal.SubType).To(Equal("normal"))
+	})
+
 	It("NormalMaximum is expected", func() {
 		Expect(normal.NormalMaximum).To(Equal(100.0))
 	})
 
 	It("NormalMinimum is expected", func() {
 		Expect(normal.NormalMinimum).To(Equal(0.0))
-	})
-
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(normal.SubType()).To(Equal("normal"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/calculator/calculator.go
+++ b/data/types/calculator/calculator.go
@@ -15,6 +15,8 @@ import (
 )
 
 const (
+	Type = "wizard" // TODO: Rename Type to "calculator"
+
 	CarbohydrateInputMaximum        = 1000.0
 	CarbohydrateInputMinimum        = 0.0
 	InsulinCarbohydrateRatioMaximum = 250.0
@@ -38,10 +40,6 @@ type Calculator struct {
 	Units                    *string                  `json:"units,omitempty" bson:"units,omitempty"`
 }
 
-func Type() string {
-	return "wizard" // TODO: Rename Type to "calculator"
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -58,7 +56,7 @@ func Init() *Calculator {
 
 func (c *Calculator) Init() {
 	c.Base.Init()
-	c.Type = Type()
+	c.Type = Type
 
 	c.BloodGlucoseInput = nil
 	c.BloodGlucoseTarget = nil
@@ -93,8 +91,8 @@ func (c *Calculator) Parse(parser data.ObjectParser) error {
 	if bolusParser := parser.NewChildObjectParser("bolus"); bolusParser.Object() != nil {
 		if bolusType := bolusParser.ParseString("type"); bolusType == nil {
 			bolusParser.AppendError("type", service.ErrorValueNotExists())
-		} else if *bolusType != bolus.Type() {
-			bolusParser.AppendError("type", service.ErrorValueStringNotOneOf(*bolusType, []string{bolus.Type()}))
+		} else if *bolusType != bolus.Type {
+			bolusParser.AppendError("type", service.ErrorValueStringNotOneOf(*bolusType, []string{bolus.Type}))
 		} else {
 			c.Bolus = parser.ParseDatum("bolus")
 		}
@@ -111,7 +109,7 @@ func (c *Calculator) Validate(validator structure.Validator) {
 	c.Base.Validate(validator)
 
 	if c.Type != "" {
-		validator.String("type", &c.Type).EqualTo(Type())
+		validator.String("type", &c.Type).EqualTo(Type)
 	}
 
 	units := c.Units

--- a/data/types/calculator/calculator_test.go
+++ b/data/types/calculator/calculator_test.go
@@ -110,6 +110,10 @@ func CloneCalculator(datum *calculator.Calculator) *calculator.Calculator {
 }
 
 var _ = Describe("Calculator", func() {
+	It("Type is expected", func() {
+		Expect(calculator.Type).To(Equal("wizard"))
+	})
+
 	It("CarbohydrateInputMaximum is expected", func() {
 		Expect(calculator.CarbohydrateInputMaximum).To(Equal(1000.0))
 	})
@@ -132,12 +136,6 @@ var _ = Describe("Calculator", func() {
 
 	It("InsulinOnBoardMinimum is expected", func() {
 		Expect(calculator.InsulinOnBoardMinimum).To(Equal(0.0))
-	})
-
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(calculator.Type()).To(Equal("wizard"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/device/alarm/alarm.go
+++ b/data/types/device/alarm/alarm.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	SubType = "alarm" // TODO: Rename Type to "device/alarm"; remove SubType
+
 	AlarmTypeAutoOff    = "auto_off"
 	AlarmTypeLowInsulin = "low_insulin"
 	AlarmTypeLowPower   = "low_power"
@@ -44,10 +46,6 @@ type Alarm struct {
 	StatusID  *string        `json:"status,omitempty" bson:"status,omitempty"`
 }
 
-func SubType() string {
-	return "alarm" // TODO: Rename Type to "device/alarm"; remove SubType
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -64,7 +62,7 @@ func Init() *Alarm {
 
 func (a *Alarm) Init() {
 	a.Device.Init()
-	a.SubType = SubType()
+	a.SubType = SubType
 
 	a.AlarmType = nil
 	a.Status = nil
@@ -83,12 +81,12 @@ func (a *Alarm) Parse(parser data.ObjectParser) error {
 	if statusParser := parser.NewChildObjectParser("status"); statusParser.Object() != nil {
 		if statusType := statusParser.ParseString("type"); statusType == nil {
 			statusParser.AppendError("type", service.ErrorValueNotExists())
-		} else if *statusType != device.Type() {
-			statusParser.AppendError("type", service.ErrorValueStringNotOneOf(*statusType, []string{device.Type()}))
+		} else if *statusType != device.Type {
+			statusParser.AppendError("type", service.ErrorValueStringNotOneOf(*statusType, []string{device.Type}))
 		} else if statusSubType := statusParser.ParseString("subType"); statusSubType == nil {
 			statusParser.AppendError("subType", service.ErrorValueNotExists())
-		} else if *statusSubType != status.SubType() {
-			statusParser.AppendError("subType", service.ErrorValueStringNotOneOf(*statusSubType, []string{status.SubType()}))
+		} else if *statusSubType != status.SubType {
+			statusParser.AppendError("subType", service.ErrorValueStringNotOneOf(*statusSubType, []string{status.SubType}))
 		} else if datum := parser.ParseDatum("status"); datum != nil {
 			a.Status = (*datum).(*status.Status)
 		}
@@ -105,7 +103,7 @@ func (a *Alarm) Validate(validator structure.Validator) {
 	a.Device.Validate(validator)
 
 	if a.SubType != "" {
-		validator.String("subType", &a.SubType).EqualTo(SubType())
+		validator.String("subType", &a.SubType).EqualTo(SubType)
 	}
 
 	validator.String("alarmType", a.AlarmType).Exists().OneOf(AlarmTypes()...)

--- a/data/types/device/alarm/alarm_test.go
+++ b/data/types/device/alarm/alarm_test.go
@@ -60,6 +60,10 @@ func CloneAlarm(datum *alarm.Alarm) *alarm.Alarm {
 }
 
 var _ = Describe("Change", func() {
+	It("SubType is expected", func() {
+		Expect(alarm.SubType).To(Equal("alarm"))
+	})
+
 	It("AlarmTypeAutoOff is expected", func() {
 		Expect(alarm.AlarmTypeAutoOff).To(Equal("auto_off"))
 	})
@@ -98,12 +102,6 @@ var _ = Describe("Change", func() {
 
 	It("AlarmTypes returns expected", func() {
 		Expect(alarm.AlarmTypes()).To(Equal([]string{"auto_off", "low_insulin", "low_power", "no_delivery", "no_insulin", "no_power", "occlusion", "other", "over_limit"}))
-	})
-
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(alarm.SubType()).To(Equal("alarm"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/device/calibration/calibration.go
+++ b/data/types/device/calibration/calibration.go
@@ -7,15 +7,15 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	SubType = "calibration" // TODO: Rename Type to "device/calibration"; remove SubType
+)
+
 type Calibration struct {
 	device.Device `bson:",inline"`
 
 	Units *string  `json:"units,omitempty" bson:"units,omitempty"`
 	Value *float64 `json:"value,omitempty" bson:"value,omitempty"`
-}
-
-func SubType() string {
-	return "calibration" // TODO: Rename Type to "device/calibration"; remove SubType
 }
 
 func NewDatum() data.Datum {
@@ -34,7 +34,7 @@ func Init() *Calibration {
 
 func (c *Calibration) Init() {
 	c.Device.Init()
-	c.SubType = SubType()
+	c.SubType = SubType
 
 	c.Units = nil
 	c.Value = nil
@@ -59,7 +59,7 @@ func (c *Calibration) Validate(validator structure.Validator) {
 	c.Device.Validate(validator)
 
 	if c.SubType != "" {
-		validator.String("subType", &c.SubType).EqualTo(SubType())
+		validator.String("subType", &c.SubType).EqualTo(SubType)
 	}
 
 	validator.String("units", c.Units).Exists().OneOf(dataBloodGlucose.Units()...)

--- a/data/types/device/calibration/calibration_test.go
+++ b/data/types/device/calibration/calibration_test.go
@@ -69,10 +69,8 @@ func NewTestCalibration(sourceTime interface{}, sourceUnits interface{}, sourceV
 }
 
 var _ = Describe("Calibration", func() {
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(calibration.SubType()).To(Equal("calibration"))
-		})
+	It("SubType is expected", func() {
+		Expect(calibration.SubType).To(Equal("calibration"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/device/device.go
+++ b/data/types/device/device.go
@@ -7,6 +7,10 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "deviceEvent"
+)
+
 type Device struct {
 	types.Base `bson:",inline"`
 
@@ -18,13 +22,9 @@ type Meta struct {
 	SubType string `json:"subType,omitempty"`
 }
 
-func Type() string {
-	return "deviceEvent"
-}
-
 func (d *Device) Init() {
 	d.Base.Init()
-	d.Type = Type()
+	d.Type = Type
 
 	d.SubType = ""
 }
@@ -46,7 +46,7 @@ func (d *Device) Validate(validator structure.Validator) {
 	d.Base.Validate(validator)
 
 	if d.Type != "" {
-		validator.String("type", &d.Type).EqualTo(Type())
+		validator.String("type", &d.Type).EqualTo(Type)
 	}
 
 	validator.String("subType", &d.SubType).Exists().NotEmpty()

--- a/data/types/device/device_test.go
+++ b/data/types/device/device_test.go
@@ -35,10 +35,8 @@ func NewTestDevice(sourceTime interface{}, sourceSubType interface{}) *device.De
 }
 
 var _ = Describe("Device", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(device.Type()).To(Equal("deviceEvent"))
-		})
+	It("Type is expected", func() {
+		Expect(device.Type).To(Equal("deviceEvent"))
 	})
 
 	Context("with new datum", func() {

--- a/data/types/device/prime/prime.go
+++ b/data/types/device/prime/prime.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	SubType = "prime" // TODO: Rename Type to "device/prime"; remove SubType
+
 	TargetCannula              = "cannula"
 	TargetTubing               = "tubing"
 	VolumeTargetCannulaMaximum = 10.0
@@ -29,10 +31,6 @@ type Prime struct {
 	Volume *float64 `json:"volume,omitempty" bson:"volume,omitempty"`
 }
 
-func SubType() string {
-	return "prime" // TODO: Rename Type to "device/prime"; remove SubType
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -49,7 +47,7 @@ func Init() *Prime {
 
 func (p *Prime) Init() {
 	p.Device.Init()
-	p.SubType = SubType()
+	p.SubType = SubType
 
 	p.Target = nil
 	p.Volume = nil
@@ -74,7 +72,7 @@ func (p *Prime) Validate(validator structure.Validator) {
 	p.Device.Validate(validator)
 
 	if p.SubType != "" {
-		validator.String("subType", &p.SubType).EqualTo(SubType())
+		validator.String("subType", &p.SubType).EqualTo(SubType)
 	}
 
 	validator.String("primeTarget", p.Target).Exists().OneOf(Targets()...)

--- a/data/types/device/prime/prime_test.go
+++ b/data/types/device/prime/prime_test.go
@@ -72,6 +72,10 @@ func NewTestPrime(sourceTime interface{}, sourceTarget interface{}, sourceVolume
 }
 
 var _ = Describe("Status", func() {
+	It("SubType is expected", func() {
+		Expect(prime.SubType).To(Equal("prime"))
+	})
+
 	It("TargetCannula is expected", func() {
 		Expect(prime.TargetCannula).To(Equal("cannula"))
 	})
@@ -98,12 +102,6 @@ var _ = Describe("Status", func() {
 
 	It("Targets returns expected", func() {
 		Expect(prime.Targets()).To(Equal([]string{"cannula", "tubing"}))
-	})
-
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(prime.SubType()).To(Equal("prime"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/device/reservoirchange/reservoirchange.go
+++ b/data/types/device/reservoirchange/reservoirchange.go
@@ -10,15 +10,15 @@ import (
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
 
+const (
+	SubType = "reservoirChange" // TODO: Rename Type to "device/reservoirChange"; remove SubType
+)
+
 type ReservoirChange struct {
 	device.Device `bson:",inline"`
 
 	Status   *status.Status `json:"-" bson:"-"`
 	StatusID *string        `json:"status,omitempty" bson:"status,omitempty"`
-}
-
-func SubType() string {
-	return "reservoirChange" // TODO: Rename Type to "device/reservoirChange"; remove SubType
 }
 
 func NewDatum() data.Datum {
@@ -37,7 +37,7 @@ func Init() *ReservoirChange {
 
 func (r *ReservoirChange) Init() {
 	r.Device.Init()
-	r.SubType = SubType()
+	r.SubType = SubType
 
 	r.Status = nil
 	r.StatusID = nil
@@ -53,12 +53,12 @@ func (r *ReservoirChange) Parse(parser data.ObjectParser) error {
 	if statusParser := parser.NewChildObjectParser("status"); statusParser.Object() != nil {
 		if statusType := statusParser.ParseString("type"); statusType == nil {
 			statusParser.AppendError("type", service.ErrorValueNotExists())
-		} else if *statusType != device.Type() {
-			statusParser.AppendError("type", service.ErrorValueStringNotOneOf(*statusType, []string{device.Type()}))
+		} else if *statusType != device.Type {
+			statusParser.AppendError("type", service.ErrorValueStringNotOneOf(*statusType, []string{device.Type}))
 		} else if statusSubType := statusParser.ParseString("subType"); statusSubType == nil {
 			statusParser.AppendError("subType", service.ErrorValueNotExists())
-		} else if *statusSubType != status.SubType() {
-			statusParser.AppendError("subType", service.ErrorValueStringNotOneOf(*statusSubType, []string{status.SubType()}))
+		} else if *statusSubType != status.SubType {
+			statusParser.AppendError("subType", service.ErrorValueStringNotOneOf(*statusSubType, []string{status.SubType}))
 		} else if datum := parser.ParseDatum("status"); datum != nil {
 			r.Status = (*datum).(*status.Status)
 		}
@@ -75,7 +75,7 @@ func (r *ReservoirChange) Validate(validator structure.Validator) {
 	r.Device.Validate(validator)
 
 	if r.SubType != "" {
-		validator.String("subType", &r.SubType).EqualTo(SubType())
+		validator.String("subType", &r.SubType).EqualTo(SubType)
 	}
 
 	if validator.Origin() == structure.OriginExternal {

--- a/data/types/device/reservoirchange/reservoirchange_test.go
+++ b/data/types/device/reservoirchange/reservoirchange_test.go
@@ -58,10 +58,8 @@ func CloneReservoirChange(datum *reservoirchange.ReservoirChange) *reservoirchan
 }
 
 var _ = Describe("Change", func() {
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(reservoirchange.SubType()).To(Equal("reservoirChange"))
-		})
+	It("SubType is expected", func() {
+		Expect(reservoirchange.SubType).To(Equal("reservoirChange"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/device/status/status.go
+++ b/data/types/device/status/status.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	SubType = "status" // TODO: Rename Type to "device/status"; remove SubType; consider device/resumed + device/suspended
+
 	DurationMinimum = 0
 	NameResumed     = "resumed"
 	NameSuspended   = "suspended"
@@ -28,10 +30,6 @@ type Status struct {
 	Reason   *data.Blob `json:"reason,omitempty" bson:"reason,omitempty"`
 }
 
-func SubType() string {
-	return "status" // TODO: Rename Type to "device/status"; remove SubType; consider device/resumed + device/suspended
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -48,7 +46,7 @@ func Init() *Status {
 
 func (s *Status) Init() {
 	s.Device.Init()
-	s.SubType = SubType()
+	s.SubType = SubType
 
 	s.Duration = nil
 	s.Name = nil
@@ -75,7 +73,7 @@ func (s *Status) Validate(validator structure.Validator) {
 	s.Device.Validate(validator)
 
 	if s.SubType != "" {
-		validator.String("subType", &s.SubType).EqualTo(SubType())
+		validator.String("subType", &s.SubType).EqualTo(SubType)
 	}
 
 	validator.Int("duration", s.Duration).GreaterThanOrEqualTo(DurationMinimum) // TODO: .Exists() - Suspend events on Animas do not have duration?

--- a/data/types/device/status/status_test.go
+++ b/data/types/device/status/status_test.go
@@ -48,6 +48,10 @@ func NewTestStatus(sourceTime interface{}, sourceDuration interface{}, sourceNam
 }
 
 var _ = Describe("Status", func() {
+	It("SubType is expected", func() {
+		Expect(status.SubType).To(Equal("status"))
+	})
+
 	It("DurationMinimum is expected", func() {
 		Expect(status.DurationMinimum).To(Equal(0))
 	})
@@ -62,12 +66,6 @@ var _ = Describe("Status", func() {
 
 	It("Names returns expected", func() {
 		Expect(status.Names()).To(Equal([]string{"resumed", "suspended"}))
-	})
-
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(status.SubType()).To(Equal("status"))
-		})
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/device/timechange/timechange.go
+++ b/data/types/device/timechange/timechange.go
@@ -7,14 +7,14 @@ import (
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
 
+const (
+	SubType = "timeChange" // TODO: Rename Type to "device/timeChange"; remove SubType
+)
+
 type TimeChange struct {
 	device.Device `bson:",inline"`
 
 	Change *Change `json:"change,omitempty" bson:"change,omitempty"`
-}
-
-func SubType() string {
-	return "timeChange" // TODO: Rename Type to "device/timeChange"; remove SubType
 }
 
 func NewDatum() data.Datum {
@@ -33,7 +33,7 @@ func Init() *TimeChange {
 
 func (t *TimeChange) Init() {
 	t.Device.Init()
-	t.SubType = SubType()
+	t.SubType = SubType
 
 	t.Change = nil
 }
@@ -56,7 +56,7 @@ func (t *TimeChange) Validate(validator structure.Validator) {
 	t.Device.Validate(validator)
 
 	if t.SubType != "" {
-		validator.String("subType", &t.SubType).EqualTo(SubType())
+		validator.String("subType", &t.SubType).EqualTo(SubType)
 	}
 
 	changeValidator := validator.WithReference("change")

--- a/data/types/device/timechange/timechange_test.go
+++ b/data/types/device/timechange/timechange_test.go
@@ -59,10 +59,8 @@ func NewTestTimeChange(sourceTime interface{}, sourceChange *timechange.Change) 
 }
 
 var _ = Describe("Change", func() {
-	Context("SubType", func() {
-		It("returns the expected sub type", func() {
-			Expect(timechange.SubType()).To(Equal("timeChange"))
-		})
+	It("SubType is expected", func() {
+		Expect(timechange.SubType).To(Equal("timeChange"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/food/food.go
+++ b/data/types/food/food.go
@@ -6,14 +6,14 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "food"
+)
+
 type Food struct {
 	types.Base `bson:",inline"`
 
 	Nutrition *Nutrition `json:"nutrition,omitempty" bson:"nutrition,omitempty"`
-}
-
-func Type() string {
-	return "food"
 }
 
 func NewDatum() data.Datum {
@@ -32,7 +32,7 @@ func Init() *Food {
 
 func (f *Food) Init() {
 	f.Base.Init()
-	f.Type = Type()
+	f.Type = Type
 
 	f.Nutrition = nil
 }
@@ -57,7 +57,7 @@ func (f *Food) Validate(validator structure.Validator) {
 	f.Base.Validate(validator)
 
 	if f.Type != "" {
-		validator.String("type", &f.Type).EqualTo(Type())
+		validator.String("type", &f.Type).EqualTo(Type)
 	}
 
 	if f.Nutrition != nil {

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -39,10 +39,8 @@ func CloneFood(datum *food.Food) *food.Food {
 }
 
 var _ = Describe("Food", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(food.Type()).To(Equal("food"))
-		})
+	It("Type is expected", func() {
+		Expect(food.Type).To(Equal("food"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/insulin/insulin.go
+++ b/data/types/insulin/insulin.go
@@ -6,14 +6,14 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "insulin"
+)
+
 type Insulin struct {
 	types.Base `bson:",inline"`
 
 	Dose *Dose `json:"dose,omitempty" bson:"dose,omitempty"`
-}
-
-func Type() string {
-	return "insulin"
 }
 
 func NewDatum() data.Datum {
@@ -32,7 +32,7 @@ func Init() *Insulin {
 
 func (i *Insulin) Init() {
 	i.Base.Init()
-	i.Type = Type()
+	i.Type = Type
 
 	i.Dose = nil
 }
@@ -57,7 +57,7 @@ func (i *Insulin) Validate(validator structure.Validator) {
 	i.Base.Validate(validator)
 
 	if i.Type != "" {
-		validator.String("type", &i.Type).EqualTo(Type())
+		validator.String("type", &i.Type).EqualTo(Type)
 	}
 
 	if i.Dose != nil {

--- a/data/types/insulin/insulin_test.go
+++ b/data/types/insulin/insulin_test.go
@@ -39,10 +39,8 @@ func CloneInsulin(datum *insulin.Insulin) *insulin.Insulin {
 }
 
 var _ = Describe("Insulin", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(insulin.Type()).To(Equal("insulin"))
-		})
+	It("Type is expected", func() {
+		Expect(insulin.Type).To(Equal("insulin"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/settings/pump/pump.go
+++ b/data/types/settings/pump/pump.go
@@ -6,6 +6,10 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "pumpSettings"
+)
+
 type Pump struct {
 	types.Base `bson:",inline"`
 
@@ -15,10 +19,6 @@ type Pump struct {
 	CarbohydrateRatios   *CarbohydrateRatioArray  `json:"carbRatio,omitempty" bson:"carbRatio,omitempty"`
 	InsulinSensitivities *InsulinSensitivityArray `json:"insulinSensitivity,omitempty" bson:"insulinSensitivity,omitempty"`
 	Units                *Units                   `json:"units,omitempty" bson:"units,omitempty"`
-}
-
-func Type() string {
-	return "pumpSettings"
 }
 
 func NewDatum() data.Datum {
@@ -37,7 +37,7 @@ func Init() *Pump {
 
 func (p *Pump) Init() {
 	p.Base.Init()
-	p.Type = Type()
+	p.Type = Type
 
 	p.ActiveScheduleName = nil
 	p.BasalSchedules = nil
@@ -72,7 +72,7 @@ func (p *Pump) Validate(validator structure.Validator) {
 	p.Base.Validate(validator)
 
 	if p.Type != "" {
-		validator.String("type", &p.Type).EqualTo(Type())
+		validator.String("type", &p.Type).EqualTo(Type)
 	}
 
 	var unitsBloodGlucose *string

--- a/data/types/settings/pump/pump_test.go
+++ b/data/types/settings/pump/pump_test.go
@@ -56,10 +56,8 @@ func ClonePump(datum *pump.Pump) *pump.Pump {
 }
 
 var _ = Describe("Pump", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(pump.Type()).To(Equal("pumpSettings"))
-		})
+	It("Type is expected", func() {
+		Expect(pump.Type).To(Equal("pumpSettings"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/state/reported/reported.go
+++ b/data/types/state/reported/reported.go
@@ -6,14 +6,14 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	Type = "reportedState" // TODO: Change to "state/reported"
+)
+
 type Reported struct {
 	types.Base `bson:",inline"`
 
 	States *StateArray `json:"states,omitempty" bson:"states,omitempty"`
-}
-
-func Type() string {
-	return "reportedState" // TODO: Change to "state/reported"
 }
 
 func NewDatum() data.Datum {
@@ -32,7 +32,7 @@ func Init() *Reported {
 
 func (r *Reported) Init() {
 	r.Base.Init()
-	r.Type = Type()
+	r.Type = Type
 
 	r.States = nil
 }
@@ -57,7 +57,7 @@ func (r *Reported) Validate(validator structure.Validator) {
 	r.Base.Validate(validator)
 
 	if r.Type != "" {
-		validator.String("type", &r.Type).EqualTo(Type())
+		validator.String("type", &r.Type).EqualTo(Type)
 	}
 
 	if r.States != nil {

--- a/data/types/state/reported/reported_test.go
+++ b/data/types/state/reported/reported_test.go
@@ -45,10 +45,8 @@ func CloneReported(datum *reported.Reported) *reported.Reported {
 }
 
 var _ = Describe("Reported", func() {
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(reported.Type()).To(Equal("reportedState"))
-		})
+	It("Type is expected", func() {
+		Expect(reported.Type).To(Equal("reportedState"))
 	})
 
 	Context("NewDatum", func() {

--- a/data/types/upload/upload.go
+++ b/data/types/upload/upload.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	Type = "upload"
+
 	ComputerTimeFormat                   = "2006-01-02T15:04:05"
 	DataSetTypeContinuous                = "continuous"
 	DataSetTypeNormal                    = "normal"
@@ -76,10 +78,6 @@ type Upload struct {
 	Version             *string   `json:"version,omitempty" bson:"version,omitempty"` // TODO: Deprecate in favor of Client.Version
 }
 
-func Type() string {
-	return "upload"
-}
-
 func NewDatum() data.Datum {
 	return New()
 }
@@ -96,7 +94,7 @@ func Init() *Upload {
 
 func (u *Upload) Init() {
 	u.Base.Init()
-	u.Type = Type()
+	u.Type = Type
 
 	u.ByUser = nil
 	u.Client = nil
@@ -142,7 +140,7 @@ func (u *Upload) Validate(validator structure.Validator) {
 	u.Base.Validate(validator)
 
 	if u.Type != "" {
-		validator.String("type", &u.Type).EqualTo(Type())
+		validator.String("type", &u.Type).EqualTo(Type)
 	}
 
 	if u.Client != nil {

--- a/data/types/upload/upload_test.go
+++ b/data/types/upload/upload_test.go
@@ -67,6 +67,10 @@ func CloneUpload(datum *upload.Upload) *upload.Upload {
 }
 
 var _ = Describe("Upload", func() {
+	It("Type is expected", func() {
+		Expect(upload.Type).To(Equal("upload"))
+	})
+
 	It("ComputerTimeFormat is expected", func() {
 		Expect(upload.ComputerTimeFormat).To(Equal("2006-01-02T15:04:05"))
 	})
@@ -129,12 +133,6 @@ var _ = Describe("Upload", func() {
 
 	It("TimeProcessings returns expected", func() {
 		Expect(upload.TimeProcessings()).To(Equal([]string{"across-the-board-timezone", "none", "utc-bootstrapping"}))
-	})
-
-	Context("Type", func() {
-		It("returns the expected type", func() {
-			Expect(upload.Type()).To(Equal("upload"))
-		})
 	})
 
 	Context("NewDatum", func() {


### PR DESCRIPTION
@jh-bate Basically just replacing `Type()`, `SubType()`, and `DeliveryType()` functions, with `Type, `SubType`, and `DeliveryType` constants for simplification. Not sure why I didn't do this in the first place.