### PR TITLE
Refactor data factory into specific packages

### DIFF
--- a/.golintignore
+++ b/.golintignore
@@ -19,7 +19,7 @@
 ./data/storeDEPRECATED/store.go:1:1: don't use MixedCaps in package name; storeDEPRECATED should be storedeprecated
 ./data/storeDEPRECATED/store_suite_test.go:1:1: don't use MixedCaps in package name; storeDEPRECATED_test should be storedeprecated_test
 ./data/storeDEPRECATED/store_test.go:1:1: don't use MixedCaps in package name; storeDEPRECATED_test should be storedeprecated_test
-./data/types/device/alarm/alarm.go:27:6: func name will be used as alarm.AlarmTypes by other packages, and that stutters; consider calling this Types
+./data/types/device/alarm/alarm.go:26:6: func name will be used as alarm.AlarmTypes by other packages, and that stutters; consider calling this Types
 ./service/response_test.go:27:30: method WriteJson should be WriteJSON
 ./service/response_test.go:31:30: method EncodeJson should be EncodeJSON
 ./task/task.go:22:6: type name will be used as task.TaskAccessor by other packages, and that stutters; consider calling this Accessor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Refactor data factory into specific packages
 * Refactor data type functions to constants
 
 ## v1.25.0

--- a/data/datum.go
+++ b/data/datum.go
@@ -36,6 +36,10 @@ type Datum interface {
 	SetDeduplicatorDescriptor(deduplicatorDescriptor *DeduplicatorDescriptor)
 }
 
+func DatumAsPointer(datum Datum) *Datum {
+	return &datum
+}
+
 var dataSetIDExpression = regexp.MustCompile("(upid_[0-9a-f]{12}|upid_[0-9a-f]{32}|[0-9a-f]{32})") // TODO: Want just "[0-9a-f]{32}"
 
 func ValidateDataSetID(value string, errorReporter structure.ErrorReporter) {

--- a/data/types/basal/factory/factory.go
+++ b/data/types/basal/factory/factory.go
@@ -1,0 +1,62 @@
+package factory
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/basal"
+	dataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated"
+	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
+	dataTypesBasalSuspend "github.com/tidepool-org/platform/data/types/basal/suspend"
+	dataTypesBasalTemporary "github.com/tidepool-org/platform/data/types/basal/temporary"
+	"github.com/tidepool-org/platform/service"
+)
+
+var deliveryTypes = []string{
+	dataTypesBasalAutomated.DeliveryType,
+	dataTypesBasalScheduled.DeliveryType,
+	dataTypesBasalSuspend.DeliveryType,
+	dataTypesBasalTemporary.DeliveryType,
+}
+
+func NewBasalDatum(parser data.ObjectParser) data.Datum {
+	if parser.Object() == nil {
+		return nil
+	}
+
+	if value := parser.ParseString("type"); value == nil {
+		parser.AppendError("type", service.ErrorValueNotExists())
+		return nil
+	} else if *value != basal.Type {
+		parser.AppendError("type", service.ErrorValueStringNotOneOf(*value, []string{basal.Type}))
+		return nil
+	}
+
+	value := parser.ParseString("deliveryType")
+	if value == nil {
+		parser.AppendError("deliveryType", service.ErrorValueNotExists())
+		return nil
+	}
+
+	switch *value {
+	case dataTypesBasalAutomated.DeliveryType:
+		return dataTypesBasalAutomated.Init()
+	case dataTypesBasalScheduled.DeliveryType:
+		return dataTypesBasalScheduled.Init()
+	case dataTypesBasalSuspend.DeliveryType:
+		return dataTypesBasalSuspend.Init()
+	case dataTypesBasalTemporary.DeliveryType:
+		return dataTypesBasalTemporary.Init()
+	}
+
+	parser.AppendError("deliveryType", service.ErrorValueStringNotOneOf(*value, deliveryTypes))
+	return nil
+}
+
+func ParseBasalDatum(parser data.ObjectParser) *data.Datum {
+	datum := NewBasalDatum(parser)
+	if datum == nil {
+		return nil
+	}
+
+	datum.Parse(parser)
+	return &datum
+}

--- a/data/types/basal/factory/factory_suite_test.go
+++ b/data/types/basal/factory/factory_suite_test.go
@@ -1,0 +1,13 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "data/types/basal/factory")
+}

--- a/data/types/basal/factory/factory_test.go
+++ b/data/types/basal/factory/factory_test.go
@@ -1,0 +1,15 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Change", func() {
+	Context("NewBasalDatum", func() {
+		// TODO
+	})
+
+	Context("ParseBasalDatum", func() {
+		// TODO
+	})
+})

--- a/data/types/bolus/factory/factory.go
+++ b/data/types/bolus/factory/factory.go
@@ -1,0 +1,58 @@
+package factory
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/bolus"
+	dataTypesBolusCombination "github.com/tidepool-org/platform/data/types/bolus/combination"
+	dataTypesBolusExtended "github.com/tidepool-org/platform/data/types/bolus/extended"
+	dataTypesBolusNormal "github.com/tidepool-org/platform/data/types/bolus/normal"
+	"github.com/tidepool-org/platform/service"
+)
+
+var subTypes = []string{
+	dataTypesBolusCombination.SubType,
+	dataTypesBolusExtended.SubType,
+	dataTypesBolusNormal.SubType,
+}
+
+func NewBolusDatum(parser data.ObjectParser) data.Datum {
+	if parser.Object() == nil {
+		return nil
+	}
+
+	if value := parser.ParseString("type"); value == nil {
+		parser.AppendError("type", service.ErrorValueNotExists())
+		return nil
+	} else if *value != bolus.Type {
+		parser.AppendError("type", service.ErrorValueStringNotOneOf(*value, []string{bolus.Type}))
+		return nil
+	}
+
+	value := parser.ParseString("subType")
+	if value == nil {
+		parser.AppendError("subType", service.ErrorValueNotExists())
+		return nil
+	}
+
+	switch *value {
+	case dataTypesBolusCombination.SubType:
+		return dataTypesBolusCombination.Init()
+	case dataTypesBolusExtended.SubType:
+		return dataTypesBolusExtended.Init()
+	case dataTypesBolusNormal.SubType:
+		return dataTypesBolusNormal.Init()
+	}
+
+	parser.AppendError("subType", service.ErrorValueStringNotOneOf(*value, subTypes))
+	return nil
+}
+
+func ParseBolusDatum(parser data.ObjectParser) *data.Datum {
+	datum := NewBolusDatum(parser)
+	if datum == nil {
+		return nil
+	}
+
+	datum.Parse(parser)
+	return &datum
+}

--- a/data/types/bolus/factory/factory_suite_test.go
+++ b/data/types/bolus/factory/factory_suite_test.go
@@ -1,0 +1,13 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "data/types/bolus/factory")
+}

--- a/data/types/bolus/factory/factory_test.go
+++ b/data/types/bolus/factory/factory_test.go
@@ -1,0 +1,15 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Change", func() {
+	Context("NewBolusDatum", func() {
+		// TODO
+	})
+
+	Context("ParseBolusDatum", func() {
+		// TODO
+	})
+})

--- a/data/types/calculator/calculator_test.go
+++ b/data/types/calculator/calculator_test.go
@@ -32,10 +32,6 @@ func NewMeta() interface{} {
 	}
 }
 
-func DatumAsPointer(datum data.Datum) *data.Datum {
-	return &datum
-}
-
 func NewCalculator(units *string) *calculator.Calculator {
 	datum := calculator.New()
 	datum.Base = *testDataTypes.NewBase()
@@ -92,11 +88,11 @@ func CloneCalculator(datum *calculator.Calculator) *calculator.Calculator {
 	if datum.Bolus != nil {
 		switch bolus := (*datum.Bolus).(type) {
 		case *combination.Combination:
-			clone.Bolus = DatumAsPointer(testDataTypesBolusCombination.CloneCombination(bolus))
+			clone.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.CloneCombination(bolus))
 		case *extended.Extended:
-			clone.Bolus = DatumAsPointer(testDataTypesBolusExtended.CloneExtended(bolus))
+			clone.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.CloneExtended(bolus))
 		case *normal.Normal:
-			clone.Bolus = DatumAsPointer(testDataTypesBolusNormal.CloneNormal(bolus))
+			clone.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.CloneNormal(bolus))
 		}
 	}
 	clone.BolusID = test.CloneString(datum.BolusID)
@@ -1252,7 +1248,7 @@ var _ = Describe("Calculator", func() {
 						bolus := testDataTypesBolusCombination.NewCombination()
 						bolus.Extended = nil
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
@@ -1261,7 +1257,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units missing; bolus combination valid",
 					nil,
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 				),
@@ -1270,7 +1266,7 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusExtended.NewExtended()
 						bolus.Extended = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
@@ -1278,7 +1274,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units missing; bolus extended valid",
 					nil,
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusExtended.NewExtended())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.NewExtended())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 				),
@@ -1287,7 +1283,7 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusNormal.NewNormal()
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
@@ -1295,7 +1291,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units missing; bolus normal valid",
 					nil,
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusNormal.NewNormal())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.NewNormal())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 				),
@@ -1315,7 +1311,7 @@ var _ = Describe("Calculator", func() {
 						bolus := testDataTypesBolusCombination.NewCombination()
 						bolus.Extended = nil
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
@@ -1324,7 +1320,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units invalid; bolus combination valid",
 					pointer.String("invalid"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 				),
@@ -1333,7 +1329,7 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusExtended.NewExtended()
 						bolus.Extended = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
@@ -1341,7 +1337,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units invalid; bolus extended valid",
 					pointer.String("invalid"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusExtended.NewExtended())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.NewExtended())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 				),
@@ -1350,7 +1346,7 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusNormal.NewNormal()
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
@@ -1358,7 +1354,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units invalid; bolus normal valid",
 					pointer.String("invalid"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusNormal.NewNormal())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.NewNormal())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 				),
@@ -1377,7 +1373,7 @@ var _ = Describe("Calculator", func() {
 						bolus := testDataTypesBolusCombination.NewCombination()
 						bolus.Extended = nil
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
@@ -1385,7 +1381,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mmol/L; bolus combination valid",
 					pointer.String("mmol/L"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 				),
 				Entry("units mmol/L; bolus extended invalid",
@@ -1393,14 +1389,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusExtended.NewExtended()
 						bolus.Extended = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 				),
 				Entry("units mmol/L; bolus extended valid",
 					pointer.String("mmol/L"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusExtended.NewExtended())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.NewExtended())
 					},
 				),
 				Entry("units mmol/L; bolus normal invalid",
@@ -1408,14 +1404,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusNormal.NewNormal()
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
 				),
 				Entry("units mmol/L; bolus normal valid",
 					pointer.String("mmol/L"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusNormal.NewNormal())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.NewNormal())
 					},
 				),
 				Entry("units mmol/L; bolus id missing",
@@ -1432,7 +1428,7 @@ var _ = Describe("Calculator", func() {
 						bolus := testDataTypesBolusCombination.NewCombination()
 						bolus.Extended = nil
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
@@ -1440,7 +1436,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mmol/l; bolus combination valid",
 					pointer.String("mmol/l"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 				),
 				Entry("units mmol/l; bolus extended invalid",
@@ -1448,14 +1444,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusExtended.NewExtended()
 						bolus.Extended = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 				),
 				Entry("units mmol/l; bolus extended valid",
 					pointer.String("mmol/l"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusExtended.NewExtended())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.NewExtended())
 					},
 				),
 				Entry("units mmol/l; bolus normal invalid",
@@ -1463,14 +1459,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusNormal.NewNormal()
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
 				),
 				Entry("units mmol/l; bolus normal valid",
 					pointer.String("mmol/l"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusNormal.NewNormal())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.NewNormal())
 					},
 				),
 				Entry("units mmol/l; bolus id missing",
@@ -1487,7 +1483,7 @@ var _ = Describe("Calculator", func() {
 						bolus := testDataTypesBolusCombination.NewCombination()
 						bolus.Extended = nil
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
@@ -1495,7 +1491,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mg/dL; bolus combination valid",
 					pointer.String("mg/dL"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 				),
 				Entry("units mg/dL; bolus extended invalid",
@@ -1503,14 +1499,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusExtended.NewExtended()
 						bolus.Extended = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 				),
 				Entry("units mg/dL; bolus extended valid",
 					pointer.String("mg/dL"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusExtended.NewExtended())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.NewExtended())
 					},
 				),
 				Entry("units mg/dL; bolus normal invalid",
@@ -1518,14 +1514,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusNormal.NewNormal()
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
 				),
 				Entry("units mg/dL; bolus normal valid",
 					pointer.String("mg/dL"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusNormal.NewNormal())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.NewNormal())
 					},
 				),
 				Entry("units mg/dL; bolus id missing",
@@ -1542,7 +1538,7 @@ var _ = Describe("Calculator", func() {
 						bolus := testDataTypesBolusCombination.NewCombination()
 						bolus.Extended = nil
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
@@ -1550,7 +1546,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mg/dl; bolus combination valid",
 					pointer.String("mg/dl"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 				),
 				Entry("units mg/dl; bolus extended invalid",
@@ -1558,14 +1554,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusExtended.NewExtended()
 						bolus.Extended = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/extended", NewMeta()),
 				),
 				Entry("units mg/dl; bolus extended valid",
 					pointer.String("mg/dl"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusExtended.NewExtended())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusExtended.NewExtended())
 					},
 				),
 				Entry("units mg/dl; bolus normal invalid",
@@ -1573,14 +1569,14 @@ var _ = Describe("Calculator", func() {
 					func(datum *calculator.Calculator, units *string) {
 						bolus := testDataTypesBolusNormal.NewNormal()
 						bolus.Normal = nil
-						datum.Bolus = DatumAsPointer(bolus)
+						datum.Bolus = data.DatumAsPointer(bolus)
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/bolus/normal", NewMeta()),
 				),
 				Entry("units mg/dl; bolus normal valid",
 					pointer.String("mg/dl"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusNormal.NewNormal())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusNormal.NewNormal())
 					},
 				),
 				Entry("units mg/dl; bolus id missing",
@@ -1608,7 +1604,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units missing; bolus exists",
 					nil,
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/bolus", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
@@ -1637,7 +1633,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units invalid; bolus exists",
 					pointer.String("invalid"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/bolus", NewMeta()),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
@@ -1665,7 +1661,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mmol/L; bolus exists",
 					pointer.String("mmol/L"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/bolus", NewMeta()),
 				),
@@ -1689,7 +1685,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mmol/l; bolus exists",
 					pointer.String("mmol/l"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/bolus", NewMeta()),
 				),
@@ -1713,7 +1709,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mg/dL; bolus exists",
 					pointer.String("mg/dL"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/bolus", NewMeta()),
 				),
@@ -1737,7 +1733,7 @@ var _ = Describe("Calculator", func() {
 				Entry("units mg/dl; bolus exists",
 					pointer.String("mg/dl"),
 					func(datum *calculator.Calculator, units *string) {
-						datum.Bolus = DatumAsPointer(testDataTypesBolusCombination.NewCombination())
+						datum.Bolus = data.DatumAsPointer(testDataTypesBolusCombination.NewCombination())
 					},
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/bolus", NewMeta()),
 				),
@@ -1772,7 +1768,7 @@ var _ = Describe("Calculator", func() {
 			It("normalizes the datum and replaces combination bolus with bolus id", func() {
 				datumBolus := testDataTypesBolusCombination.NewCombination()
 				datum := NewCalculatorWithBolusID(pointer.String("mmol/L"))
-				datum.Bolus = DatumAsPointer(datumBolus)
+				datum.Bolus = data.DatumAsPointer(datumBolus)
 				expectedDatum := CloneCalculator(datum)
 				normalizer := dataNormalizer.New()
 				Expect(normalizer).ToNot(BeNil())
@@ -1787,7 +1783,7 @@ var _ = Describe("Calculator", func() {
 			It("normalizes the datum and replaces extended bolus with bolus id", func() {
 				datumBolus := testDataTypesBolusExtended.NewExtended()
 				datum := NewCalculatorWithBolusID(pointer.String("mmol/L"))
-				datum.Bolus = DatumAsPointer(datumBolus)
+				datum.Bolus = data.DatumAsPointer(datumBolus)
 				expectedDatum := CloneCalculator(datum)
 				normalizer := dataNormalizer.New()
 				Expect(normalizer).ToNot(BeNil())
@@ -1802,7 +1798,7 @@ var _ = Describe("Calculator", func() {
 			It("normalizes the datum and replaces normal bolus with bolus id", func() {
 				datumBolus := testDataTypesBolusNormal.NewNormal()
 				datum := NewCalculatorWithBolusID(pointer.String("mmol/L"))
-				datum.Bolus = DatumAsPointer(datumBolus)
+				datum.Bolus = data.DatumAsPointer(datumBolus)
 				expectedDatum := CloneCalculator(datum)
 				normalizer := dataNormalizer.New()
 				Expect(normalizer).ToNot(BeNil())

--- a/data/types/device/factory/factory.go
+++ b/data/types/device/factory/factory.go
@@ -1,0 +1,70 @@
+package factory
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/device"
+	dataTypesDeviceAlarm "github.com/tidepool-org/platform/data/types/device/alarm"
+	dataTypesDeviceCalibration "github.com/tidepool-org/platform/data/types/device/calibration"
+	dataTypesDevicePrime "github.com/tidepool-org/platform/data/types/device/prime"
+	dataTypesDeviceReservoirchange "github.com/tidepool-org/platform/data/types/device/reservoirchange"
+	dataTypesDeviceStatus "github.com/tidepool-org/platform/data/types/device/status"
+	dataTypesDeviceTimechange "github.com/tidepool-org/platform/data/types/device/timechange"
+	"github.com/tidepool-org/platform/service"
+)
+
+var subTypes = []string{
+	dataTypesDeviceAlarm.SubType,
+	dataTypesDeviceCalibration.SubType,
+	dataTypesDevicePrime.SubType,
+	dataTypesDeviceReservoirchange.SubType,
+	dataTypesDeviceStatus.SubType,
+	dataTypesDeviceTimechange.SubType,
+}
+
+func NewDeviceDatum(parser data.ObjectParser) data.Datum {
+	if parser.Object() == nil {
+		return nil
+	}
+
+	if value := parser.ParseString("type"); value == nil {
+		parser.AppendError("type", service.ErrorValueNotExists())
+		return nil
+	} else if *value != device.Type {
+		parser.AppendError("type", service.ErrorValueStringNotOneOf(*value, []string{device.Type}))
+		return nil
+	}
+
+	value := parser.ParseString("subType")
+	if value == nil {
+		parser.AppendError("subType", service.ErrorValueNotExists())
+		return nil
+	}
+
+	switch *value {
+	case dataTypesDeviceAlarm.SubType:
+		return dataTypesDeviceAlarm.Init()
+	case dataTypesDeviceCalibration.SubType:
+		return dataTypesDeviceCalibration.Init()
+	case dataTypesDevicePrime.SubType:
+		return dataTypesDevicePrime.Init()
+	case dataTypesDeviceReservoirchange.SubType:
+		return dataTypesDeviceReservoirchange.Init()
+	case dataTypesDeviceStatus.SubType:
+		return dataTypesDeviceStatus.Init()
+	case dataTypesDeviceTimechange.SubType:
+		return dataTypesDeviceTimechange.Init()
+	}
+
+	parser.AppendError("subType", service.ErrorValueStringNotOneOf(*value, subTypes))
+	return nil
+}
+
+func ParseDeviceDatum(parser data.ObjectParser) *data.Datum {
+	datum := NewDeviceDatum(parser)
+	if datum == nil {
+		return nil
+	}
+
+	datum.Parse(parser)
+	return &datum
+}

--- a/data/types/device/factory/factory_suite_test.go
+++ b/data/types/device/factory/factory_suite_test.go
@@ -1,0 +1,13 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "data/types/device/factory")
+}

--- a/data/types/device/factory/factory_test.go
+++ b/data/types/device/factory/factory_test.go
@@ -1,0 +1,15 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Change", func() {
+	Context("NewDeviceDatum", func() {
+		// TODO
+	})
+
+	Context("ParseDeviceDatum", func() {
+		// TODO
+	})
+})

--- a/data/types/device/status/status.go
+++ b/data/types/device/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/device"
+	"github.com/tidepool-org/platform/service"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -28,6 +29,40 @@ type Status struct {
 	Duration *int       `json:"duration,omitempty" bson:"duration,omitempty"`
 	Name     *string    `json:"status,omitempty" bson:"status,omitempty"`
 	Reason   *data.Blob `json:"reason,omitempty" bson:"reason,omitempty"`
+}
+
+func NewStatusDatum(parser data.ObjectParser) data.Datum {
+	if parser.Object() == nil {
+		return nil
+	}
+
+	if value := parser.ParseString("type"); value == nil {
+		parser.AppendError("type", service.ErrorValueNotExists())
+		return nil
+	} else if *value != device.Type {
+		parser.AppendError("type", service.ErrorValueStringNotOneOf(*value, []string{device.Type}))
+		return nil
+	}
+
+	if value := parser.ParseString("subType"); value == nil {
+		parser.AppendError("subType", service.ErrorValueNotExists())
+		return nil
+	} else if *value != SubType {
+		parser.AppendError("subType", service.ErrorValueStringNotOneOf(*value, []string{SubType}))
+		return nil
+	}
+
+	return Init()
+}
+
+func ParseStatusDatum(parser data.ObjectParser) *data.Datum {
+	datum := NewStatusDatum(parser)
+	if datum == nil {
+		return nil
+	}
+
+	datum.Parse(parser)
+	return &datum
 }
 
 func NewDatum() data.Datum {

--- a/data/types/device/status/status_test.go
+++ b/data/types/device/status/status_test.go
@@ -68,6 +68,14 @@ var _ = Describe("Status", func() {
 		Expect(status.Names()).To(Equal([]string{"resumed", "suspended"}))
 	})
 
+	Context("NewStatusDatum", func() {
+		// TODO
+	})
+
+	Context("ParseStatusDatum", func() {
+		// TODO
+	})
+
 	Context("NewDatum", func() {
 		It("returns the expected datum", func() {
 			Expect(status.NewDatum()).To(Equal(&status.Status{}))

--- a/data/types/factory/factory.go
+++ b/data/types/factory/factory.go
@@ -1,0 +1,92 @@
+package factory
+
+import (
+	"github.com/tidepool-org/platform/data"
+	dataTypesActivityPhysical "github.com/tidepool-org/platform/data/types/activity/physical"
+	dataTypesBasal "github.com/tidepool-org/platform/data/types/basal"
+	dataTypesBasalFactory "github.com/tidepool-org/platform/data/types/basal/factory"
+	dataTypesBloodGlucoseContinuous "github.com/tidepool-org/platform/data/types/blood/glucose/continuous"
+	dataTypesBloodGlucoseSelfmonitored "github.com/tidepool-org/platform/data/types/blood/glucose/selfmonitored"
+	dataTypesBloodKetone "github.com/tidepool-org/platform/data/types/blood/ketone"
+	dataTypesBolus "github.com/tidepool-org/platform/data/types/bolus"
+	dataTypesBolusFactory "github.com/tidepool-org/platform/data/types/bolus/factory"
+	dataTypesCalculator "github.com/tidepool-org/platform/data/types/calculator"
+	dataTypesDevice "github.com/tidepool-org/platform/data/types/device"
+	dataTypesDeviceFactory "github.com/tidepool-org/platform/data/types/device/factory"
+	dataTypesFood "github.com/tidepool-org/platform/data/types/food"
+	dataTypesInsulin "github.com/tidepool-org/platform/data/types/insulin"
+	dataTypesSettingsPump "github.com/tidepool-org/platform/data/types/settings/pump"
+	dataTypesStateReported "github.com/tidepool-org/platform/data/types/state/reported"
+	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/service"
+)
+
+var types = []string{
+	dataTypesActivityPhysical.Type,
+	dataTypesBasal.Type,
+	dataTypesBloodGlucoseContinuous.Type,
+	dataTypesBloodGlucoseSelfmonitored.Type,
+	dataTypesBloodKetone.Type,
+	dataTypesBolus.Type,
+	dataTypesCalculator.Type,
+	dataTypesDevice.Type,
+	dataTypesFood.Type,
+	dataTypesInsulin.Type,
+	dataTypesSettingsPump.Type,
+	dataTypesStateReported.Type,
+	dataTypesUpload.Type,
+}
+
+func NewDatum(parser data.ObjectParser) data.Datum {
+	if parser.Object() == nil {
+		return nil
+	}
+
+	value := parser.ParseString("type")
+	if value == nil {
+		parser.AppendError("type", service.ErrorValueNotExists())
+		return nil
+	}
+
+	switch *value {
+	case dataTypesActivityPhysical.Type:
+		return dataTypesActivityPhysical.Init()
+	case dataTypesBasal.Type:
+		return dataTypesBasalFactory.NewBasalDatum(parser)
+	case dataTypesBloodGlucoseContinuous.Type:
+		return dataTypesBloodGlucoseContinuous.Init()
+	case dataTypesBloodGlucoseSelfmonitored.Type:
+		return dataTypesBloodGlucoseSelfmonitored.Init()
+	case dataTypesBloodKetone.Type:
+		return dataTypesBloodKetone.Init()
+	case dataTypesBolus.Type:
+		return dataTypesBolusFactory.NewBolusDatum(parser)
+	case dataTypesCalculator.Type:
+		return dataTypesCalculator.Init()
+	case dataTypesDevice.Type:
+		return dataTypesDeviceFactory.NewDeviceDatum(parser)
+	case dataTypesFood.Type:
+		return dataTypesFood.Init()
+	case dataTypesInsulin.Type:
+		return dataTypesInsulin.Init()
+	case dataTypesSettingsPump.Type:
+		return dataTypesSettingsPump.Init()
+	case dataTypesStateReported.Type:
+		return dataTypesStateReported.Init()
+	case dataTypesUpload.Type:
+		return dataTypesUpload.Init()
+	}
+
+	parser.AppendError("type", service.ErrorValueStringNotOneOf(*value, types))
+	return nil
+}
+
+func ParseDatum(parser data.ObjectParser) *data.Datum {
+	datum := NewDatum(parser)
+	if datum == nil {
+		return nil
+	}
+
+	datum.Parse(parser)
+	return &datum
+}

--- a/data/types/factory/factory_suite_test.go
+++ b/data/types/factory/factory_suite_test.go
@@ -1,0 +1,13 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "data/types/factory")
+}

--- a/data/types/factory/factory_test.go
+++ b/data/types/factory/factory_test.go
@@ -1,0 +1,15 @@
+package factory_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Change", func() {
+	Context("NewDatum", func() {
+		// TODO
+	})
+
+	Context("ParseDatum", func() {
+		// TODO
+	})
+})


### PR DESCRIPTION
@jh-bate The old data factory used to be entirely away from the `data/types` package hierarchy which meant that you couldn't use parts within the `data/types` package hierarchy (due to circular dependencies).  

Broke this up into a factory for each type, sub type, and delivery type *into a `factory` package under the relevant `data/types` package*. This allows you to use factories from other data types. For example, the `calculator` type can now use the `basal` type factory.

Also, the factories are simpler to understand. None of the map of func map funcs garbage, which, while perhaps clever, was not really understandable. (Understandable > clever).

(Note: Still avoiding "parsing" tests until I can get the new structure parser installed so I don't have to rewrite a whole bunch of code.)