### PR TITLE
Refactor blood value and precision normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Refactor blood glucose and ketone value and precision normalization
 * Refactor data factory into specific packages
 * Refactor data type functions to constants
 * Add tests for missing upload id

--- a/data/blood/glucose/glucose.go
+++ b/data/blood/glucose/glucose.go
@@ -20,7 +20,9 @@ const (
 	MgdLMaximum float64 = 1000.0
 
 	MmolLToMgdLConversionFactor float64 = 18.01559
-	MmolLToMgdLPrecisionFactor  float64 = 100000.0
+
+	MmolLPrecisionFactor float64 = 100000.0
+	MgdLPrecisionFactor  float64 = 1.0
 )
 
 func Units() []string {
@@ -52,10 +54,23 @@ func NormalizeUnits(units *string) *string {
 func NormalizeValueForUnits(value *float64, units *string) *float64 {
 	if value != nil && units != nil {
 		switch *units {
+		case MmolL, Mmoll:
+			// TODO: Normalize mmol/L values to standard precision
+			// return NormalizePrecisionForUnits(value, units)
 		case MgdL, Mgdl:
-			intValue := int(*value/MmolLToMgdLConversionFactor*MmolLToMgdLPrecisionFactor + 0.5)
-			floatValue := float64(intValue) / MmolLToMgdLPrecisionFactor
-			return &floatValue
+			return NormalizePrecisionForUnits(pointer.Float64(*NormalizePrecisionForUnits(value, units)/MmolLToMgdLConversionFactor), pointer.String(MmolL))
+		}
+	}
+	return value
+}
+
+func NormalizePrecisionForUnits(value *float64, units *string) *float64 {
+	if value != nil && units != nil {
+		switch *units {
+		case MmolL, Mmoll:
+			return pointer.Float64(float64(int(*value*MmolLPrecisionFactor+0.5)) / MmolLPrecisionFactor)
+		case MgdL, Mgdl:
+			return pointer.Float64(float64(int(*value*MgdLPrecisionFactor+0.5)) / MgdLPrecisionFactor)
 		}
 	}
 	return value

--- a/data/blood/ketone/ketone.go
+++ b/data/blood/ketone/ketone.go
@@ -12,6 +12,8 @@ const (
 
 	MmolLMinimum = 0.0
 	MmolLMaximum = 10.0
+
+	MmolLPrecisionFactor float64 = 100000.0
 )
 
 func Units() []string {
@@ -39,5 +41,22 @@ func NormalizeUnits(units *string) *string {
 }
 
 func NormalizeValueForUnits(value *float64, units *string) *float64 {
+	if value != nil && units != nil {
+		switch *units {
+		case MmolL, Mmoll:
+			// TODO: Normalize mmol/L values to standard precision
+			// return NormalizePrecisionForUnits(value, units)
+		}
+	}
+	return value
+}
+
+func NormalizePrecisionForUnits(value *float64, units *string) *float64 {
+	if value != nil && units != nil {
+		switch *units {
+		case MmolL, Mmoll:
+			return pointer.Float64(float64(int(*value*MmolLPrecisionFactor+0.5)) / MmolLPrecisionFactor)
+		}
+	}
 	return value
 }

--- a/data/blood/ketone/ketone_test.go
+++ b/data/blood/ketone/ketone_test.go
@@ -66,22 +66,53 @@ var _ = Describe("Ketone", func() {
 		Entry("returns unchanged units for mg/dl", pointer.String("mg/dl"), pointer.String("mg/dl")),
 	)
 
-	DescribeTable("NormalizeValueForUnits",
-		func(value *float64, units *string, expectedValue *float64) {
-			actualValue := ketone.NormalizeValueForUnits(value, units)
-			if expectedValue == nil {
-				Expect(actualValue).To(BeNil())
-			} else {
-				Expect(actualValue).ToNot(BeNil())
-				Expect(*actualValue).To(Equal(*expectedValue))
+	Context("NormalizeValueForUnits", func() {
+		DescribeTable("given value and units",
+			func(value *float64, units *string, expectedValue *float64) {
+				actualValue := ketone.NormalizeValueForUnits(value, units)
+				if expectedValue == nil {
+					Expect(actualValue).To(BeNil())
+				} else {
+					Expect(actualValue).ToNot(BeNil())
+					Expect(*actualValue).To(Equal(*expectedValue))
+				}
+			},
+			Entry("returns nil for nil value", nil, pointer.String("mmol/L"), nil),
+			Entry("returns unchanged value for nil units", pointer.Float64(10.123456789012345), nil, pointer.Float64(10.123456789012345)),
+			Entry("returns unchanged value for unknown units", pointer.Float64(10.123456789012345), pointer.String("unknown"), pointer.Float64(10.123456789012345)),
+			Entry("returns unchanged value for mmol/L units", pointer.Float64(10.123456789012345), pointer.String("mmol/L"), pointer.Float64(10.123456789012345)),
+			Entry("returns unchanged value for mmol/l units", pointer.Float64(10.123456789012345), pointer.String("mmol/l"), pointer.Float64(10.123456789012345)),
+			Entry("returns unchanged value for mg/dL units", pointer.Float64(180.123456789012345), pointer.String("mg/dL"), pointer.Float64(180.123456789012345)),
+			Entry("returns unchanged value for mg/dl units", pointer.Float64(180.123456789012345), pointer.String("mg/dl"), pointer.Float64(180.123456789012345)),
+		)
+
+		It("properly normalizes a range of mmol/L values", func() {
+			for value := ketone.MmolLMinimum; value <= ketone.MmolLMaximum; value += 0.1 {
+				normalizedValue := ketone.NormalizeValueForUnits(pointer.Float64(float64(value)), pointer.String("mmol/L"))
+				Expect(normalizedValue).ToNot(BeNil())
+				Expect(*normalizedValue).To(Equal(value))
 			}
-		},
-		Entry("returns nil for nil value", nil, pointer.String("mmol/L"), nil),
-		Entry("returns unchanged value for nil units", pointer.Float64(10.0), nil, pointer.Float64(10.0)),
-		Entry("returns unchanged value for unknown units", pointer.Float64(10.0), pointer.String("unknown"), pointer.Float64(10.0)),
-		Entry("returns unchanged value for mmol/L units", pointer.Float64(10.0), pointer.String("mmol/L"), pointer.Float64(10.0)),
-		Entry("returns unchanged value for mmol/l units", pointer.Float64(10.0), pointer.String("mmol/l"), pointer.Float64(10.0)),
-		Entry("returns unchanged value for mg/dL units", pointer.Float64(180.0), pointer.String("mg/dL"), pointer.Float64(180.0)),
-		Entry("returns unchanged value for mg/dl units", pointer.Float64(180.0), pointer.String("mg/dl"), pointer.Float64(180.0)),
-	)
+		})
+	})
+
+	Context("NormalizePrecisionForUnits", func() {
+		DescribeTable("given value and units",
+			func(value *float64, units *string, expectedValue *float64) {
+				actualValue := ketone.NormalizePrecisionForUnits(value, units)
+				if expectedValue == nil {
+					Expect(actualValue).To(BeNil())
+				} else {
+					Expect(actualValue).ToNot(BeNil())
+					Expect(*actualValue).To(Equal(*expectedValue))
+				}
+			},
+			Entry("returns nil for nil value", nil, pointer.String("mmol/L"), nil),
+			Entry("returns unchanged value for nil units", pointer.Float64(10.123456789012345), nil, pointer.Float64(10.123456789012345)),
+			Entry("returns unchanged value for unknown units", pointer.Float64(10.123456789012345), pointer.String("unknown"), pointer.Float64(10.123456789012345)),
+			Entry("returns value with limited precision for mmol/L units", pointer.Float64(10.123456789012345), pointer.String("mmol/L"), pointer.Float64(10.12346)),
+			Entry("returns value with limited precision for mmol/l units", pointer.Float64(10.123456789012345), pointer.String("mmol/l"), pointer.Float64(10.12346)),
+			Entry("returns unchanged value for mg/dL units", pointer.Float64(180.123456789012345), pointer.String("mg/dL"), pointer.Float64(180.123456789012345)),
+			Entry("returns unchanged value for mg/dl units", pointer.Float64(180.123456789012345), pointer.String("mg/dl"), pointer.Float64(180.123456789012345)),
+		)
+	})
 })


### PR DESCRIPTION
@jh-bate Separate out units normalization from value precision normalization and be consistent about it. (There will be another commit coming later that will remove the TODOs and enable the precision calculation for raw `mmol/L` values.)