### PR TITLE
Add origin to location common data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add origin to location common data type
 * Add new fields to physical activity data type
 * Add water data type
 * Minor rename of food related constants

--- a/data/types/common/location/gps.go
+++ b/data/types/common/location/gps.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"github.com/tidepool-org/platform/data"
+	dataTypesCommonOrigin "github.com/tidepool-org/platform/data/types/common/origin"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -12,12 +13,13 @@ const (
 )
 
 type GPS struct {
-	Elevation          *Elevation `json:"elevation,omitempty" bson:"elevation,omitempty"`
-	Floor              *int       `json:"floor,omitempty" bson:"floor,omitempty"`
-	HorizontalAccuracy *Accuracy  `json:"horizontalAccuracy,omitempty" bson:"horizontalAccuracy,omitempty"`
-	Latitude           *Latitude  `json:"latitude,omitempty" bson:"latitude,omitempty"`
-	Longitude          *Longitude `json:"longitude,omitempty" bson:"longitude,omitempty"`
-	VerticalAccuracy   *Accuracy  `json:"verticalAccuracy,omitempty" bson:"verticalAccuracy,omitempty"`
+	Elevation          *Elevation                    `json:"elevation,omitempty" bson:"elevation,omitempty"`
+	Floor              *int                          `json:"floor,omitempty" bson:"floor,omitempty"`
+	HorizontalAccuracy *Accuracy                     `json:"horizontalAccuracy,omitempty" bson:"horizontalAccuracy,omitempty"`
+	Latitude           *Latitude                     `json:"latitude,omitempty" bson:"latitude,omitempty"`
+	Longitude          *Longitude                    `json:"longitude,omitempty" bson:"longitude,omitempty"`
+	Origin             *dataTypesCommonOrigin.Origin `json:"origin,omitempty" bson:"origin,omitempty"`
+	VerticalAccuracy   *Accuracy                     `json:"verticalAccuracy,omitempty" bson:"verticalAccuracy,omitempty"`
 }
 
 func ParseGPS(parser data.ObjectParser) *GPS {
@@ -40,6 +42,7 @@ func (g *GPS) Parse(parser data.ObjectParser) {
 	g.HorizontalAccuracy = ParseAccuracy(parser.NewChildObjectParser("horizontalAccuracy"))
 	g.Latitude = ParseLatitude(parser.NewChildObjectParser("latitude"))
 	g.Longitude = ParseLongitude(parser.NewChildObjectParser("longitude"))
+	g.Origin = dataTypesCommonOrigin.ParseOrigin(parser.NewChildObjectParser("origin"))
 	g.VerticalAccuracy = ParseAccuracy(parser.NewChildObjectParser("verticalAccuracy"))
 }
 
@@ -61,6 +64,9 @@ func (g *GPS) Validate(validator structure.Validator) {
 	} else {
 		validator.WithReference("longitude").ReportError(structureValidator.ErrorValueNotExists())
 	}
+	if g.Origin != nil {
+		g.Origin.Validate(validator.WithReference("origin"))
+	}
 	if g.VerticalAccuracy != nil {
 		g.VerticalAccuracy.Validate(validator.WithReference("verticalAccuracy"))
 	}
@@ -78,6 +84,9 @@ func (g *GPS) Normalize(normalizer data.Normalizer) {
 	}
 	if g.Longitude != nil {
 		g.Longitude.Normalize(normalizer.WithReference("longitude"))
+	}
+	if g.Origin != nil {
+		g.Origin.Normalize(normalizer.WithReference("origin"))
 	}
 	if g.VerticalAccuracy != nil {
 		g.VerticalAccuracy.Normalize(normalizer.WithReference("verticalAccuracy"))

--- a/data/types/common/location/gps_test.go
+++ b/data/types/common/location/gps_test.go
@@ -8,6 +8,7 @@ import (
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/types/common/location"
 	testDataTypesCommonLocation "github.com/tidepool-org/platform/data/types/common/location/test"
+	testDataTypesCommonOrigin "github.com/tidepool-org/platform/data/types/common/origin/test"
 	testDataTypes "github.com/tidepool-org/platform/data/types/test"
 	testErrors "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -112,6 +113,16 @@ var _ = Describe("GPS", func() {
 				Entry("longitude valid",
 					func(datum *location.GPS) { datum.Longitude = testDataTypesCommonLocation.NewLongitude() },
 				),
+				Entry("origin missing",
+					func(datum *location.GPS) { datum.Origin = nil },
+				),
+				Entry("origin invalid",
+					func(datum *location.GPS) { datum.Origin.Name = nil },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/origin/name"),
+				),
+				Entry("origin valid",
+					func(datum *location.GPS) { datum.Origin = testDataTypesCommonOrigin.NewOrigin() },
+				),
 				Entry("vertical accuracy missing",
 					func(datum *location.GPS) { datum.VerticalAccuracy = nil },
 				),
@@ -131,6 +142,7 @@ var _ = Describe("GPS", func() {
 						datum.HorizontalAccuracy.Units = nil
 						datum.Latitude.Units = nil
 						datum.Longitude.Units = nil
+						datum.Origin.Name = nil
 						datum.VerticalAccuracy.Units = nil
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/elevation/units"),
@@ -138,6 +150,7 @@ var _ = Describe("GPS", func() {
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/horizontalAccuracy/units"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/latitude/units"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/longitude/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/origin/name"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/verticalAccuracy/units"),
 				),
 			)
@@ -175,6 +188,9 @@ var _ = Describe("GPS", func() {
 				),
 				Entry("does not modify the datum; longitude missing",
 					func(datum *location.GPS) { datum.Longitude = nil },
+				),
+				Entry("does not modify the datum; origin missing",
+					func(datum *location.GPS) { datum.Origin = nil },
 				),
 				Entry("does not modify the datum; vertical accuracy missing",
 					func(datum *location.GPS) { datum.VerticalAccuracy = nil },

--- a/data/types/common/location/test/gps.go
+++ b/data/types/common/location/test/gps.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/tidepool-org/platform/data/types/common/location"
+	testDataTypesCommonOrigin "github.com/tidepool-org/platform/data/types/common/origin/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
@@ -13,6 +14,7 @@ func NewGPS() *location.GPS {
 	datum.HorizontalAccuracy = NewAccuracy(pointer.String("feet"))
 	datum.Latitude = NewLatitude()
 	datum.Longitude = NewLongitude()
+	datum.Origin = testDataTypesCommonOrigin.NewOrigin()
 	datum.VerticalAccuracy = NewAccuracy(pointer.String("feet"))
 	return datum
 }
@@ -27,6 +29,7 @@ func CloneGPS(datum *location.GPS) *location.GPS {
 	clone.HorizontalAccuracy = CloneAccuracy(datum.HorizontalAccuracy)
 	clone.Latitude = CloneLatitude(datum.Latitude)
 	clone.Longitude = CloneLongitude(datum.Longitude)
+	clone.Origin = testDataTypesCommonOrigin.CloneOrigin(datum.Origin)
 	clone.VerticalAccuracy = CloneAccuracy(datum.VerticalAccuracy)
 	return clone
 }


### PR DESCRIPTION
@jh-bate The location common field type can have an origin (which device generated the GPS data) that differs from the device generating the diabetes data.