### PR TITLE
Fix Dexcom API authentication failure; always update provider session, even if error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Fix Dexcom API authentication failure; always update provider session, even if error
 * Add additional support Medtronic device models
 
 ## v1.24.0

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -423,11 +423,10 @@ func (t *TaskRunner) fetch(startTime time.Time, endTime time.Time) error {
 
 func (t *TaskRunner) fetchDevices(startTime time.Time, endTime time.Time) ([]*dexcom.Device, error) {
 	response, err := t.DexcomClient().GetDevices(t.context, startTime, endTime, t.tokenSource)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get devices")
+	if updateErr := t.updateProviderSession(); updateErr != nil {
+		return nil, updateErr
 	}
-
-	if err = t.updateProviderSession(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -492,11 +491,10 @@ func (t *TaskRunner) fetchData(startTime time.Time, endTime time.Time) ([]data.D
 
 func (t *TaskRunner) fetchCalibrations(startTime time.Time, endTime time.Time) ([]data.Datum, error) {
 	response, err := t.DexcomClient().GetCalibrations(t.context, startTime, endTime, t.tokenSource)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get calibrations")
+	if updateErr := t.updateProviderSession(); updateErr != nil {
+		return nil, updateErr
 	}
-
-	if err = t.updateProviderSession(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -517,11 +515,10 @@ func (t *TaskRunner) fetchCalibrations(startTime time.Time, endTime time.Time) (
 
 func (t *TaskRunner) fetchEGVs(startTime time.Time, endTime time.Time) ([]data.Datum, error) {
 	response, err := t.DexcomClient().GetEGVs(t.context, startTime, endTime, t.tokenSource)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get egvs")
+	if updateErr := t.updateProviderSession(); updateErr != nil {
+		return nil, updateErr
 	}
-
-	if err = t.updateProviderSession(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -542,11 +539,10 @@ func (t *TaskRunner) fetchEGVs(startTime time.Time, endTime time.Time) ([]data.D
 
 func (t *TaskRunner) fetchEvents(startTime time.Time, endTime time.Time) ([]data.Datum, error) {
 	response, err := t.DexcomClient().GetEvents(t.context, startTime, endTime, t.tokenSource)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get events")
+	if updateErr := t.updateProviderSession(); updateErr != nil {
+		return nil, updateErr
 	}
-
-	if err = t.updateProviderSession(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/oauth/token/source.go
+++ b/oauth/token/source.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/oauth"
+	"github.com/tidepool-org/platform/request"
 )
 
 type Source struct {
@@ -65,6 +66,9 @@ func (s *Source) RefreshedToken() (*oauth.Token, error) {
 
 	tknSrcTkn, err := s.tokenSource.Token()
 	if err != nil {
+		if oauth.IsRefreshTokenError(err) {
+			err = errors.Wrap(request.ErrorUnauthenticated(), err.Error())
+		}
 		return nil, errors.Wrap(err, "unable to get token")
 	}
 

--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -266,6 +266,10 @@ func (q *Queue) completeTask(ctx context.Context, tsk *task.Task) {
 	if err != nil {
 		logger.WithError(err).Error("Failure to update state during complete task")
 	}
+
+	if tsk.HasError() {
+		logger.WithError(tsk.Error.Error).Error("Error occurred while running task")
+	}
 }
 
 func (q *Queue) computeState(tsk *task.Task) {


### PR DESCRIPTION
@pazaan Update the provider session (the OAuth tokens) and return any error *before* checking for any error from the actual Dexcom API. This covers the case where the access token is refreshed successfully, but the subsequent API call (to get devices, egvs, etc) fails (for whatever reason, including expected data). The access token will now be correctly stored in the database after *any* successful token refresh.

Also, log any error (transient or not) that occurs when running the task.