### PR TITLE
Fix Dexcom API unknown device model failure; allow unknown device model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Fix Dexcom API unknown device model failure; allow unknown device model
 * Fix Dexcom API authentication failure; always update provider session, even if error
 * Add additional support Medtronic device models
 

--- a/dexcom/device.go
+++ b/dexcom/device.go
@@ -94,7 +94,7 @@ func (d *Device) Parse(parser structure.ObjectParser) {
 }
 
 func (d *Device) Validate(validator structure.Validator) {
-	validator.String("model", &d.Model).OneOf(ModelG5MobileApp, ModelG5Receiver, ModelG4WithShareReceiver, ModelG4Receiver)
+	validator.String("model", &d.Model).OneOf(ModelG5MobileApp, ModelG5Receiver, ModelG4WithShareReceiver, ModelG4Receiver, ModelUnknown)
 	validator.Time("lastUploadDate", &d.LastUploadDate).NotZero()
 	existingAlertNames := &[]string{}
 	validator = validator.WithReference("alertSettings")

--- a/dexcom/dexcom.go
+++ b/dexcom/dexcom.go
@@ -33,6 +33,7 @@ const (
 	ModelG5Receiver          = "G5 Receiver"
 	ModelG4WithShareReceiver = "G4 with Share Receiver"
 	ModelG4Receiver          = "G4 Receiver"
+	ModelUnknown             = "Unknown"
 
 	StatusHigh             = "high"
 	StatusLow              = "low"

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -398,7 +398,7 @@ func (t *TaskRunner) fetch(startTime time.Time, endTime time.Time) error {
 			return nil
 		} else if deviceInfo, err = NewDeviceInfoFromDataSet(t.dataSet); err != nil {
 			return err
-		} else if !deviceInfo.IsG5Mobile() {
+		} else if !deviceInfo.IsDeviceModelG5Mobile() && !deviceInfo.IsDeviceModelUnknown() {
 			deviceInfo = NewDeviceInfoFromMultiple()
 		}
 	}
@@ -760,6 +760,9 @@ func NewDeviceInfoFromDevice(device *dexcom.Device) (*DeviceInfo, error) {
 	case dexcom.ModelG4Receiver:
 		deviceModel = "G4Receiver"
 		deviceIDPrefix = "DexG4Rec_"
+	case dexcom.ModelUnknown:
+		deviceModel = "Unknown"
+		deviceIDPrefix = "DexUnknown_"
 	default:
 		return nil, errors.New("unknown device model")
 	}
@@ -780,8 +783,12 @@ func (d *DeviceInfo) IsEmpty() bool {
 	return d.DeviceID == "" && d.DeviceModel == "" && d.DeviceSerialNumber == ""
 }
 
-func (d *DeviceInfo) IsG5Mobile() bool {
+func (d *DeviceInfo) IsDeviceModelG5Mobile() bool {
 	return d.DeviceModel == "G5Mobile"
+}
+
+func (d *DeviceInfo) IsDeviceModelUnknown() bool {
+	return d.DeviceModel == "Unknown"
 }
 
 func (d *DeviceInfo) Merge(deviceInfo *DeviceInfo) (*DeviceInfo, error) {


### PR DESCRIPTION
@pazaan Allow "Unknown" as a Dexcom device model. Unfortunately, we need to support this. I also note that this comes down from HealthKit via Tidepool Mobile, as well.