### PR TITLE
Fix Dexcom API unexpected data; temporarily modify incoming data to expected values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Fix Dexcom API unexpected data; temporarily modify incoming data to expected values
 * Fix Dexcom API unknown device model failure; allow unknown device model
 * Fix Dexcom API authentication failure; always update provider session, even if error
 * Add additional support Medtronic device models

--- a/data/types/insulin/dose.go
+++ b/data/types/insulin/dose.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	TotalMaximum = 100.0
+	TotalMaximum = 250.0
 	TotalMinimum = 0.0
 	UnitsUnits   = "units"
 )

--- a/data/types/insulin/dose_test.go
+++ b/data/types/insulin/dose_test.go
@@ -34,7 +34,7 @@ func CloneDose(datum *insulin.Dose) *insulin.Dose {
 
 var _ = Describe("Dose", func() {
 	It("TotalMaximum is expected", func() {
-		Expect(insulin.TotalMaximum).To(Equal(100.0))
+		Expect(insulin.TotalMaximum).To(Equal(250.0))
 	})
 
 	It("TotalMinimum is expected", func() {
@@ -80,17 +80,17 @@ var _ = Describe("Dose", func() {
 				),
 				Entry("total out of range (lower)",
 					func(datum *insulin.Dose) { datum.Total = pointer.Float64(-0.1) },
-					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0, 100), "/total"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0, 250), "/total"),
 				),
 				Entry("total in range (lower)",
 					func(datum *insulin.Dose) { datum.Total = pointer.Float64(0.0) },
 				),
 				Entry("total in range (upper)",
-					func(datum *insulin.Dose) { datum.Total = pointer.Float64(100.0) },
+					func(datum *insulin.Dose) { datum.Total = pointer.Float64(250.0) },
 				),
 				Entry("total out of range (upper)",
-					func(datum *insulin.Dose) { datum.Total = pointer.Float64(100.1) },
-					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0, 100), "/total"),
+					func(datum *insulin.Dose) { datum.Total = pointer.Float64(250.1) },
+					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(250.1, 0, 250), "/total"),
 				),
 				Entry("units missing",
 					func(datum *insulin.Dose) { datum.Units = nil },

--- a/dexcom/device.go
+++ b/dexcom/device.go
@@ -179,6 +179,11 @@ func (a *AlertSetting) Validate(validator structure.Validator, existingAlertName
 }
 
 func (a *AlertSetting) validateFixedLow(validator structure.Validator) {
+	// HACK: Dexcom - snooze of 28 is invalid; use snooze of 30 instead (per Dexcom)
+	if a.Snooze == 28 {
+		a.Snooze = 30
+	}
+
 	validator.String("unit", &a.Unit).OneOf(UnitMgdL) // TODO: Add UnitMmolL
 	switch a.Unit {
 	case UnitMgdL:
@@ -228,6 +233,11 @@ func (a *AlertSetting) validateRise(validator structure.Validator) {
 }
 
 func (a *AlertSetting) validateFall(validator structure.Validator) {
+	// HACK: Dexcom - negative value is invalid; use positive value instead (per Dexcom)
+	if a.Value < 0 {
+		a.Value = -a.Value
+	}
+
 	validator.String("unit", &a.Unit).OneOf(UnitMgdLMin) // TODO: UnitMmolLMin
 	switch a.Unit {
 	case UnitMgdLMin:
@@ -255,7 +265,7 @@ var highSnoozes = append(append([]int{0}, generateIntegerRange(15, 240, 5)...), 
 var riseSnoozes = []int{0, 30}
 var fallSnoozes = []int{0, 30}
 var outOfRangeValues = generateFloatRange(20, 240, 5)
-var outOfRangeSnoozes = []int{0, 20, 30}
+var outOfRangeSnoozes = []int{0, 20, 25, 30}
 
 func generateFloatRange(min float64, max float64, step float64) []float64 {
 	r := []float64{}

--- a/dexcom/event.go
+++ b/dexcom/event.go
@@ -95,6 +95,12 @@ func (e *Event) validateCarbs(validator structure.Validator) {
 }
 
 func (e *Event) validateExercise(validator structure.Validator) {
+	// HACK: Dexcom - value of -1 is invalid; ignore unit and value instead (per Dexcom)
+	if e.Value != nil && *e.Value == -1.0 {
+		e.Unit = nil
+		e.Value = nil
+	}
+
 	validator.String("eventSubType", e.EventSubType).OneOf(ExerciseLight, ExerciseMedium, ExerciseHeavy)
 	if e.Unit != nil || e.Value != nil {
 		validator.String("unit", e.Unit).Exists().EqualTo(UnitMinutes)

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -95,7 +95,7 @@ func (r *Runner) Run(ctx context.Context, tsk *task.Task) {
 
 	ctx = log.NewContextWithLogger(ctx, r.Logger())
 
-	// HACK: Skip 2:45am - 3:45am PST to avoid intermittent refresh token failure due to Dexcom backups
+	// HACK: Dexcom - skip 2:45am - 3:45am PST to avoid intermittent refresh token failure due to Dexcom backups (per Dexcom)
 	var skipToAvoidDexcomBackup bool
 	if location, err := time.LoadLocation("America/Los_Angeles"); err != nil {
 		r.Logger().WithError(err).Warn("Unable to load location to detect Dexcom backup")
@@ -383,7 +383,7 @@ func (t *TaskRunner) fetch(startTime time.Time, endTime time.Time) error {
 		return err
 	}
 
-	// HACK: Dexcom API does not guarantee to return a device for G5 Mobile if time range < 24 hours
+	// HACK: Dexcom - does not guarantee to return a device for G5 Mobile if time range < 24 hours (per Dexcom)
 	var deviceInfo *DeviceInfo
 	if endTime.Sub(startTime) > 24*time.Hour {
 		if len(devices) == 0 {


### PR DESCRIPTION
@pazaan Fixes all of the (currently known) unexpected data from the Dexcom API. In some cases it is due to unclear/incomplete documentation. In other cases it directly contradicts the documentation. In any case we have to (temporarily, in some cases) fix it out our end so we end up with valid data and a working Dexcom connection. The turnaround time for getting it fixed at the source is lengthy.

I expect that we will see some additional unexpected data failures since the authentication failure (jn previous PR) was taking precedence over these types of failures.