### PR TITLE
Use "Units" rather than "units" for insulin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Use "Units" rather than "units" for insulin
 * Fix bug in upload data type with check against incorrect type
 * Move mutator to request package; ignore missing mutators in client
 * Rename various New functions in mongo packages to NewStore for consistency

--- a/data/types/insulin/concentration.go
+++ b/data/types/insulin/concentration.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ConcentrationUnitsUnitsPerML        = "units/mL"
+	ConcentrationUnitsUnitsPerML        = "Units/mL"
 	ConcentrationValueUnitsPerMLMaximum = 10000.0
 	ConcentrationValueUnitsPerMLMinimum = 0.0
 )

--- a/data/types/insulin/concentration_test.go
+++ b/data/types/insulin/concentration_test.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("Concentration", func() {
 	It("ConcentrationUnitsUnitsPerML is expected", func() {
-		Expect(insulin.ConcentrationUnitsUnitsPerML).To(Equal("units/mL"))
+		Expect(insulin.ConcentrationUnitsUnitsPerML).To(Equal("Units/mL"))
 	})
 
 	It("ConcentrationValueUnitsPerMLMaximum is expected", func() {
@@ -31,7 +31,7 @@ var _ = Describe("Concentration", func() {
 	})
 
 	It("ConcentrationUnits returns expected", func() {
-		Expect(insulin.ConcentrationUnits()).To(Equal([]string{"units/mL"}))
+		Expect(insulin.ConcentrationUnits()).To(Equal([]string{"Units/mL"}))
 	})
 
 	Context("ParseConcentration", func() {
@@ -65,11 +65,11 @@ var _ = Describe("Concentration", func() {
 				),
 				Entry("units invalid",
 					func(datum *insulin.Concentration) { datum.Units = pointer.String("invalid") },
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/mL"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/mL"}), "/units"),
 				),
-				Entry("units units/mL",
+				Entry("units Units/mL",
 					func(datum *insulin.Concentration) {
-						datum.Units = pointer.String("units/mL")
+						datum.Units = pointer.String("Units/mL")
 						datum.Value = pointer.Float64(0.0)
 					},
 				),
@@ -114,7 +114,7 @@ var _ = Describe("Concentration", func() {
 						datum.Units = pointer.String("invalid")
 						datum.Value = nil
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/mL"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/mL"}), "/units"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/value"),
 				),
 				Entry("units invalid; value out of range (lower)",
@@ -122,58 +122,58 @@ var _ = Describe("Concentration", func() {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(-0.1)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/mL"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/mL"}), "/units"),
 				),
 				Entry("units invalid; value in range (lower)",
 					func(datum *insulin.Concentration) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(0.0)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/mL"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/mL"}), "/units"),
 				),
 				Entry("units invalid; value in range (upper)",
 					func(datum *insulin.Concentration) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(10000.0)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/mL"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/mL"}), "/units"),
 				),
 				Entry("units invalid; value out of range (upper)",
 					func(datum *insulin.Concentration) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(10000.1)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/mL"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/mL"}), "/units"),
 				),
-				Entry("units units/mL; value missing",
+				Entry("units Units/mL; value missing",
 					func(datum *insulin.Concentration) {
-						datum.Units = pointer.String("units/mL")
+						datum.Units = pointer.String("Units/mL")
 						datum.Value = nil
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/value"),
 				),
-				Entry("units units/mL; value out of range (lower)",
+				Entry("units Units/mL; value out of range (lower)",
 					func(datum *insulin.Concentration) {
-						datum.Units = pointer.String("units/mL")
+						datum.Units = pointer.String("Units/mL")
 						datum.Value = pointer.Float64(-0.1)
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 10000.0), "/value"),
 				),
-				Entry("units units/mL; value in range (lower)",
+				Entry("units Units/mL; value in range (lower)",
 					func(datum *insulin.Concentration) {
-						datum.Units = pointer.String("units/mL")
+						datum.Units = pointer.String("Units/mL")
 						datum.Value = pointer.Float64(0.0)
 					},
 				),
-				Entry("units units/mL; value in range (upper)",
+				Entry("units Units/mL; value in range (upper)",
 					func(datum *insulin.Concentration) {
-						datum.Units = pointer.String("units/mL")
+						datum.Units = pointer.String("Units/mL")
 						datum.Value = pointer.Float64(10000.0)
 					},
 				),
-				Entry("units units/mL; value out of range (upper)",
+				Entry("units Units/mL; value out of range (upper)",
 					func(datum *insulin.Concentration) {
-						datum.Units = pointer.String("units/mL")
+						datum.Units = pointer.String("Units/mL")
 						datum.Value = pointer.Float64(10000.1)
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(10000.1, 0.0, 10000.0), "/value"),
@@ -230,8 +230,8 @@ var _ = Describe("Concentration", func() {
 			Expect(maximum).To(Equal(math.MaxFloat64))
 		})
 
-		It("returns expected range for units units/mL", func() {
-			minimum, maximum := insulin.ConcentrationValueRangeForUnits(pointer.String("units/mL"))
+		It("returns expected range for units Units/mL", func() {
+			minimum, maximum := insulin.ConcentrationValueRangeForUnits(pointer.String("Units/mL"))
 			Expect(minimum).To(Equal(0.0))
 			Expect(maximum).To(Equal(10000.0))
 		})

--- a/data/types/insulin/dose.go
+++ b/data/types/insulin/dose.go
@@ -12,7 +12,7 @@ const (
 	DoseFoodMinimum       = 0.0
 	DoseTotalMaximum      = 250.0
 	DoseTotalMinimum      = 0.0
-	DoseUnitsUnits        = "units"
+	DoseUnitsUnits        = "Units"
 )
 
 func DoseUnits() []string {

--- a/data/types/insulin/dose_test.go
+++ b/data/types/insulin/dose_test.go
@@ -62,11 +62,11 @@ var _ = Describe("Dose", func() {
 	})
 
 	It("DoseUnitsUnits is expected", func() {
-		Expect(insulin.DoseUnitsUnits).To(Equal("units"))
+		Expect(insulin.DoseUnitsUnits).To(Equal("Units"))
 	})
 
 	It("DoseUnits returns expected", func() {
-		Expect(insulin.DoseUnits()).To(Equal([]string{"units"}))
+		Expect(insulin.DoseUnits()).To(Equal([]string{"Units"}))
 	})
 
 	Context("ParseDose", func() {
@@ -152,10 +152,10 @@ var _ = Describe("Dose", func() {
 				),
 				Entry("units invalid",
 					func(datum *insulin.Dose) { datum.Units = pointer.String("invalid") },
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 				),
-				Entry("units units",
-					func(datum *insulin.Dose) { datum.Units = pointer.String("units") },
+				Entry("units Units",
+					func(datum *insulin.Dose) { datum.Units = pointer.String("Units") },
 				),
 				Entry("multiple errors",
 					func(datum *insulin.Dose) {

--- a/data/types/settings/pump/basal_rate_maximum.go
+++ b/data/types/settings/pump/basal_rate_maximum.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	BasalRateMaximumUnitsUnitsPerHour        = "units/hour"
+	BasalRateMaximumUnitsUnitsPerHour        = "Units/hour"
 	BasalRateMaximumValueUnitsPerHourMaximum = 100.0
 	BasalRateMaximumValueUnitsPerHourMinimum = 0.0
 )

--- a/data/types/settings/pump/basal_rate_maximum_test.go
+++ b/data/types/settings/pump/basal_rate_maximum_test.go
@@ -36,7 +36,7 @@ func CloneBasalRateMaximum(datum *pump.BasalRateMaximum) *pump.BasalRateMaximum 
 
 var _ = Describe("BasalRateMaximum", func() {
 	It("BasalRateMaximumUnitsUnitsPerHour is expected", func() {
-		Expect(pump.BasalRateMaximumUnitsUnitsPerHour).To(Equal("units/hour"))
+		Expect(pump.BasalRateMaximumUnitsUnitsPerHour).To(Equal("Units/hour"))
 	})
 
 	It("BasalRateMaximumValueUnitsPerHourMaximum is expected", func() {
@@ -48,7 +48,7 @@ var _ = Describe("BasalRateMaximum", func() {
 	})
 
 	It("BasalRateMaximumUnits returns expected", func() {
-		Expect(pump.BasalRateMaximumUnits()).To(Equal([]string{"units/hour"}))
+		Expect(pump.BasalRateMaximumUnits()).To(Equal([]string{"Units/hour"}))
 	})
 
 	Context("ParseBasalRateMaximum", func() {
@@ -82,11 +82,11 @@ var _ = Describe("BasalRateMaximum", func() {
 				),
 				Entry("units invalid",
 					func(datum *pump.BasalRateMaximum) { datum.Units = pointer.String("invalid") },
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/hour"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/hour"}), "/units"),
 				),
-				Entry("units units",
+				Entry("units Units/hour",
 					func(datum *pump.BasalRateMaximum) {
-						datum.Units = pointer.String("units/hour")
+						datum.Units = pointer.String("Units/hour")
 						datum.Value = pointer.Float64(0.0)
 					},
 				),
@@ -131,7 +131,7 @@ var _ = Describe("BasalRateMaximum", func() {
 						datum.Units = pointer.String("invalid")
 						datum.Value = nil
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/hour"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/hour"}), "/units"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/value"),
 				),
 				Entry("units invalid; value out of range (lower)",
@@ -139,58 +139,58 @@ var _ = Describe("BasalRateMaximum", func() {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(-0.1)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/hour"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/hour"}), "/units"),
 				),
 				Entry("units invalid; value in range (lower)",
 					func(datum *pump.BasalRateMaximum) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(0.0)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/hour"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/hour"}), "/units"),
 				),
 				Entry("units invalid; value in range (upper)",
 					func(datum *pump.BasalRateMaximum) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(100.0)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/hour"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/hour"}), "/units"),
 				),
 				Entry("units invalid; value out of range (upper)",
 					func(datum *pump.BasalRateMaximum) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(100.1)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units/hour"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units/hour"}), "/units"),
 				),
-				Entry("units units/hour; value missing",
+				Entry("units Units/hour; value missing",
 					func(datum *pump.BasalRateMaximum) {
-						datum.Units = pointer.String("units/hour")
+						datum.Units = pointer.String("Units/hour")
 						datum.Value = nil
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/value"),
 				),
-				Entry("units units/hour; value out of range (lower)",
+				Entry("units Units/hour; value out of range (lower)",
 					func(datum *pump.BasalRateMaximum) {
-						datum.Units = pointer.String("units/hour")
+						datum.Units = pointer.String("Units/hour")
 						datum.Value = pointer.Float64(-0.1)
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/value"),
 				),
-				Entry("units units/hour; value in range (lower)",
+				Entry("units Units/hour; value in range (lower)",
 					func(datum *pump.BasalRateMaximum) {
-						datum.Units = pointer.String("units/hour")
+						datum.Units = pointer.String("Units/hour")
 						datum.Value = pointer.Float64(0.0)
 					},
 				),
-				Entry("units units/hour; value in range (upper)",
+				Entry("units Units/hour; value in range (upper)",
 					func(datum *pump.BasalRateMaximum) {
-						datum.Units = pointer.String("units/hour")
+						datum.Units = pointer.String("Units/hour")
 						datum.Value = pointer.Float64(100.0)
 					},
 				),
-				Entry("units units/hour; value out of range (upper)",
+				Entry("units Units/hour; value out of range (upper)",
 					func(datum *pump.BasalRateMaximum) {
-						datum.Units = pointer.String("units/hour")
+						datum.Units = pointer.String("Units/hour")
 						datum.Value = pointer.Float64(100.1)
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/value"),
@@ -247,8 +247,8 @@ var _ = Describe("BasalRateMaximum", func() {
 			Expect(maximum).To(Equal(math.MaxFloat64))
 		})
 
-		It("returns expected range for units units/hour", func() {
-			minimum, maximum := pump.BasalRateMaximumValueRangeForUnits(pointer.String("units/hour"))
+		It("returns expected range for units Units/hour", func() {
+			minimum, maximum := pump.BasalRateMaximumValueRangeForUnits(pointer.String("Units/hour"))
 			Expect(minimum).To(Equal(0.0))
 			Expect(maximum).To(Equal(100.0))
 		})

--- a/data/types/settings/pump/basal_temporary.go
+++ b/data/types/settings/pump/basal_temporary.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	BasalTemporaryTypePercent      = "percent"
-	BasalTemporaryTypeUnitsPerHour = "units/hour"
+	BasalTemporaryTypeUnitsPerHour = "Units/hour"
 )
 
 func BasalTemporaryTypes() []string {

--- a/data/types/settings/pump/basal_temporary_test.go
+++ b/data/types/settings/pump/basal_temporary_test.go
@@ -36,11 +36,11 @@ var _ = Describe("BasalTemporary", func() {
 	})
 
 	It("BasalTemporaryTypeUnitsPerHour is expected", func() {
-		Expect(pump.BasalTemporaryTypeUnitsPerHour).To(Equal("units/hour"))
+		Expect(pump.BasalTemporaryTypeUnitsPerHour).To(Equal("Units/hour"))
 	})
 
 	It("BasalTemporaryTypes returns expected", func() {
-		Expect(pump.BasalTemporaryTypes()).To(Equal([]string{"percent", "units/hour"}))
+		Expect(pump.BasalTemporaryTypes()).To(Equal([]string{"percent", "Units/hour"}))
 	})
 
 	Context("ParseBasalTemporary", func() {
@@ -74,13 +74,13 @@ var _ = Describe("BasalTemporary", func() {
 				),
 				Entry("type invalid",
 					func(datum *pump.BasalTemporary) { datum.Type = pointer.String("invalid") },
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"percent", "units/hour"}), "/type"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"percent", "Units/hour"}), "/type"),
 				),
 				Entry("type percent",
 					func(datum *pump.BasalTemporary) { datum.Type = pointer.String("percent") },
 				),
-				Entry("type units/hour",
-					func(datum *pump.BasalTemporary) { datum.Type = pointer.String("units/hour") },
+				Entry("type Units/hour",
+					func(datum *pump.BasalTemporary) { datum.Type = pointer.String("Units/hour") },
 				),
 				Entry("multiple errors",
 					func(datum *pump.BasalTemporary) {

--- a/data/types/settings/pump/bolus_amount_maximum.go
+++ b/data/types/settings/pump/bolus_amount_maximum.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	BolusAmountMaximumUnitsUnits        = "units"
+	BolusAmountMaximumUnitsUnits        = "Units"
 	BolusAmountMaximumValueUnitsMaximum = 100.0
 	BolusAmountMaximumValueUnitsMinimum = 0.0
 )

--- a/data/types/settings/pump/bolus_amount_maximum_test.go
+++ b/data/types/settings/pump/bolus_amount_maximum_test.go
@@ -36,7 +36,7 @@ func CloneBolusAmountMaximum(datum *pump.BolusAmountMaximum) *pump.BolusAmountMa
 
 var _ = Describe("BolusAmountMaximum", func() {
 	It("BolusAmountMaximumUnitsUnits is expected", func() {
-		Expect(pump.BolusAmountMaximumUnitsUnits).To(Equal("units"))
+		Expect(pump.BolusAmountMaximumUnitsUnits).To(Equal("Units"))
 	})
 
 	It("BolusAmountMaximumValueUnitsMaximum is expected", func() {
@@ -48,7 +48,7 @@ var _ = Describe("BolusAmountMaximum", func() {
 	})
 
 	It("BolusAmountMaximumUnits returns expected", func() {
-		Expect(pump.BolusAmountMaximumUnits()).To(Equal([]string{"units"}))
+		Expect(pump.BolusAmountMaximumUnits()).To(Equal([]string{"Units"}))
 	})
 
 	Context("ParseBolusAmountMaximum", func() {
@@ -82,11 +82,11 @@ var _ = Describe("BolusAmountMaximum", func() {
 				),
 				Entry("units invalid",
 					func(datum *pump.BolusAmountMaximum) { datum.Units = pointer.String("invalid") },
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 				),
-				Entry("units units",
+				Entry("units Units",
 					func(datum *pump.BolusAmountMaximum) {
-						datum.Units = pointer.String("units")
+						datum.Units = pointer.String("Units")
 						datum.Value = pointer.Float64(0.0)
 					},
 				),
@@ -131,7 +131,7 @@ var _ = Describe("BolusAmountMaximum", func() {
 						datum.Units = pointer.String("invalid")
 						datum.Value = nil
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/value"),
 				),
 				Entry("units invalid; value out of range (lower)",
@@ -139,58 +139,58 @@ var _ = Describe("BolusAmountMaximum", func() {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(-0.1)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 				),
 				Entry("units invalid; value in range (lower)",
 					func(datum *pump.BolusAmountMaximum) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(0.0)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 				),
 				Entry("units invalid; value in range (upper)",
 					func(datum *pump.BolusAmountMaximum) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(100.0)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 				),
 				Entry("units invalid; value out of range (upper)",
 					func(datum *pump.BolusAmountMaximum) {
 						datum.Units = pointer.String("invalid")
 						datum.Value = pointer.Float64(100.1)
 					},
-					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"units"}), "/units"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"Units"}), "/units"),
 				),
-				Entry("units units; value missing",
+				Entry("units Units; value missing",
 					func(datum *pump.BolusAmountMaximum) {
-						datum.Units = pointer.String("units")
+						datum.Units = pointer.String("Units")
 						datum.Value = nil
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/value"),
 				),
-				Entry("units units; value out of range (lower)",
+				Entry("units Units; value out of range (lower)",
 					func(datum *pump.BolusAmountMaximum) {
-						datum.Units = pointer.String("units")
+						datum.Units = pointer.String("Units")
 						datum.Value = pointer.Float64(-0.1)
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/value"),
 				),
-				Entry("units units; value in range (lower)",
+				Entry("units Units; value in range (lower)",
 					func(datum *pump.BolusAmountMaximum) {
-						datum.Units = pointer.String("units")
+						datum.Units = pointer.String("Units")
 						datum.Value = pointer.Float64(0.0)
 					},
 				),
-				Entry("units units; value in range (upper)",
+				Entry("units Units; value in range (upper)",
 					func(datum *pump.BolusAmountMaximum) {
-						datum.Units = pointer.String("units")
+						datum.Units = pointer.String("Units")
 						datum.Value = pointer.Float64(100.0)
 					},
 				),
-				Entry("units units; value out of range (upper)",
+				Entry("units Units; value out of range (upper)",
 					func(datum *pump.BolusAmountMaximum) {
-						datum.Units = pointer.String("units")
+						datum.Units = pointer.String("Units")
 						datum.Value = pointer.Float64(100.1)
 					},
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/value"),
@@ -247,8 +247,8 @@ var _ = Describe("BolusAmountMaximum", func() {
 			Expect(maximum).To(Equal(math.MaxFloat64))
 		})
 
-		It("returns expected range for units units", func() {
-			minimum, maximum := pump.BolusAmountMaximumValueRangeForUnits(pointer.String("units"))
+		It("returns expected range for units Units", func() {
+			minimum, maximum := pump.BolusAmountMaximumValueRangeForUnits(pointer.String("Units"))
 			Expect(minimum).To(Equal(0.0))
 			Expect(maximum).To(Equal(100.0))
 		})


### PR DESCRIPTION
@jh-bate Apparently, the agreed upon units of insulin is "Units", not "units". So, conforming to accepted standard, per request from Howard.