### PR TITLE
Add expected duration to status device event data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add expected duration to status device event data model
 * Add bolus calculator enabled field to pump settings data model
 * Add tzdata to development Docker images
 * Validate data time zone against known time zones

--- a/data/types/device/status/test/status.go
+++ b/data/types/device/status/test/status.go
@@ -15,6 +15,7 @@ func NewStatus() *status.Status {
 	datum.Device = *testDataTypesDevice.NewDevice()
 	datum.SubType = "status"
 	datum.Duration = pointer.Int(test.RandomIntFromRange(status.DurationMinimum, math.MaxInt32))
+	datum.DurationExpected = pointer.Int(test.RandomIntFromRange(*datum.Duration, math.MaxInt32))
 	datum.Name = pointer.String(test.RandomStringFromArray(status.Names()))
 	datum.Reason = testData.NewBlob()
 	return datum
@@ -27,6 +28,7 @@ func CloneStatus(datum *status.Status) *status.Status {
 	clone := status.New()
 	clone.Device = *testDataTypesDevice.CloneDevice(&datum.Device)
 	clone.Duration = test.CloneInt(datum.Duration)
+	clone.DurationExpected = test.CloneInt(datum.DurationExpected)
 	clone.Name = test.CloneString(datum.Name)
 	clone.Reason = testData.CloneBlob(datum.Reason)
 	return clone


### PR DESCRIPTION
@jh-bate Add `expectedDuration` to `deviceEvent/status` data model. Missed the first go around.