### PR TITLE
Allow travis build on personal repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: go
 go:
   - 1.9.2
 
+go_import_path: github.com/tidepool-org/platform
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
This little change allows anyone to use travis-ci on golang repository. If you don't make this change the travis build on personal repository returns the below dependency error 

```
go build 
services/auth/auth.go:6:2: cannot find package "github.com/tidepool-org/platform/application" in any of: 
...
```