### PR TITLE
Fix UTC time usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Do not strip original time zone information using time.UTC()
+* Only convert to UTC when required (eg. time.Format that requires UTC time with or without time zone)
 * Refactor responder to log error if failure to write response
 * Update test ResponseWriter to implement http.ResponseWriter interface
 * Write new line after JSON response

--- a/application/application.go
+++ b/application/application.go
@@ -18,6 +18,11 @@ import (
 	"github.com/tidepool-org/platform/version"
 )
 
+// TEST: Optionally force Local time zone to UTC during local development
+// func init() {
+// 	time.Local = time.UTC
+// }
+
 type Application struct {
 	prefix          string
 	name            string

--- a/auth/restricted_token.go
+++ b/auth/restricted_token.go
@@ -67,7 +67,7 @@ func (r *RestrictedTokenCreate) Validate(validator structure.Validator) {
 
 func (r *RestrictedTokenCreate) Normalize(normalizer structure.Normalizer) {
 	if r.ExpirationTime != nil {
-		r.ExpirationTime = pointer.Time((*r.ExpirationTime).UTC().Truncate(time.Second))
+		r.ExpirationTime = pointer.Time((*r.ExpirationTime).Truncate(time.Second))
 	}
 }
 
@@ -96,7 +96,7 @@ func (r *RestrictedTokenUpdate) Validate(validator structure.Validator) {
 
 func (r *RestrictedTokenUpdate) Normalize(normalizer structure.Normalizer) {
 	if r.ExpirationTime != nil {
-		r.ExpirationTime = pointer.Time((*r.ExpirationTime).UTC().Truncate(time.Second))
+		r.ExpirationTime = pointer.Time((*r.ExpirationTime).Truncate(time.Second))
 	}
 }
 

--- a/data/data_source.go
+++ b/data/data_source.go
@@ -161,13 +161,13 @@ func (d *DataSourceUpdate) Normalize(normalizer structure.Normalizer) {
 		d.Error.Normalize(normalizer.WithReference("error"))
 	}
 	if d.EarliestDataTime != nil {
-		d.EarliestDataTime = pointer.Time((*d.EarliestDataTime).UTC().Truncate(time.Second))
+		d.EarliestDataTime = pointer.Time((*d.EarliestDataTime).Truncate(time.Second))
 	}
 	if d.LatestDataTime != nil {
-		d.LatestDataTime = pointer.Time((*d.LatestDataTime).UTC().Truncate(time.Second))
+		d.LatestDataTime = pointer.Time((*d.LatestDataTime).Truncate(time.Second))
 	}
 	if d.LastImportTime != nil {
-		d.LastImportTime = pointer.Time((*d.LastImportTime).UTC().Truncate(time.Second))
+		d.LastImportTime = pointer.Time((*d.LastImportTime).Truncate(time.Second))
 	}
 }
 

--- a/data/service/api/v1/time.go
+++ b/data/service/api/v1/time.go
@@ -11,7 +11,7 @@ func TimeGet(serviceContext service.Context) {
 	response := struct {
 		Time string `json:"time"`
 	}{
-		Time: time.Now().UTC().Format(time.RFC3339),
+		Time: time.Now().Format(time.RFC3339),
 	}
 	serviceContext.RespondWithStatusAndData(http.StatusOK, response)
 }

--- a/dexcom/client/client.go
+++ b/dexcom/client/client.go
@@ -75,8 +75,8 @@ func (c *Client) sendDexcomRequest(ctx context.Context, startTime time.Time, end
 	requestStartTime := time.Now()
 
 	url = c.client.AppendURLQuery(url, map[string]string{
-		"startDate": startTime.Format(dexcom.DateTimeFormat),
-		"endDate":   endTime.Format(dexcom.DateTimeFormat),
+		"startDate": startTime.UTC().Format(dexcom.DateTimeFormat),
+		"endDate":   endTime.UTC().Format(dexcom.DateTimeFormat),
 	})
 
 	err := c.client.SendOAuthRequest(ctx, method, url, nil, nil, responseBody, tokenSource)

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -30,7 +30,7 @@ const (
 	TaskDurationMaximum           = 5 * time.Minute
 )
 
-var initialDataTime = time.Unix(1420070400, 0).UTC() // 2015-01-01T00:00:00Z
+var initialDataTime = time.Unix(1420070400, 0) // 2015-01-01T00:00:00Z
 
 type Runner struct {
 	logger          log.Logger
@@ -269,13 +269,13 @@ func (t *TaskRunner) updateDataSourceWithDataTime(earliestDataTime time.Time, la
 		return nil
 	}
 
-	dataSourceUpdate.LastImportTime = pointer.Time(time.Now().Truncate(time.Second).UTC())
+	dataSourceUpdate.LastImportTime = pointer.Time(time.Now().Truncate(time.Second))
 	return t.updateDataSource(dataSourceUpdate)
 }
 
 func (t *TaskRunner) updateDataSourceWithLastImportTime() error {
 	dataSourceUpdate := data.NewDataSourceUpdate()
-	dataSourceUpdate.LastImportTime = pointer.Time(time.Now().Truncate(time.Second).UTC())
+	dataSourceUpdate.LastImportTime = pointer.Time(time.Now().Truncate(time.Second))
 	return t.updateDataSource(dataSourceUpdate)
 }
 
@@ -360,7 +360,7 @@ func (t *TaskRunner) fetchSinceLatestDataTime() error {
 		startTime = *t.dataSource.LatestDataTime
 	}
 
-	now := time.Now().Add(-time.Minute).Truncate(time.Second).UTC()
+	now := time.Now().Add(-time.Minute).Truncate(time.Second)
 	for startTime.Before(now) {
 		endTime := startTime.AddDate(0, 0, 90)
 		if endTime.After(now) {
@@ -372,7 +372,7 @@ func (t *TaskRunner) fetchSinceLatestDataTime() error {
 		}
 
 		startTime = startTime.AddDate(0, 0, 90)
-		now = time.Now().Add(-time.Minute).Truncate(time.Second).UTC()
+		now = time.Now().Add(-time.Minute).Truncate(time.Second)
 	}
 	return nil
 }
@@ -627,7 +627,7 @@ func (t *TaskRunner) createDataSet(deviceInfo *DeviceInfo) (*data.DataSet, error
 	dataSetCreate.DeviceModel = deviceInfo.DeviceModel
 	dataSetCreate.DeviceSerialNumber = deviceInfo.DeviceSerialNumber
 	dataSetCreate.DeviceTags = []string{data.DeviceTagCGM}
-	dataSetCreate.Time = time.Now().Truncate(time.Second).UTC()
+	dataSetCreate.Time = time.Now().Truncate(time.Second)
 	dataSetCreate.TimeProcessing = upload.TimeProcessingNone
 
 	dataSet, err := t.DataClient().CreateUserDataSet(t.context, t.providerSession.UserID, dataSetCreate)

--- a/dexcom/fetch/translate.go
+++ b/dexcom/fetch/translate.go
@@ -56,7 +56,7 @@ func translateTime(systemTime time.Time, displayTime time.Time, datum *types.Bas
 	}
 
 	datum.Time = pointer.String(systemTime.Format(types.TimeFormat))
-	datum.DeviceTime = pointer.String(displayTime.Format(types.DeviceTimeFormat))
+	datum.DeviceTime = pointer.String(displayTime.UTC().Format(types.DeviceTimeFormat))
 	datum.TimeZoneOffset = pointer.Int(int(timeZoneOffsetDuration / time.Minute))
 	if clockDriftOffsetDuration != 0 {
 		datum.ClockDriftOffset = pointer.Int(int(clockDriftOffsetDuration / time.Millisecond))

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -58,7 +58,7 @@ func NewTokenFromRawToken(rawToken *oauth2.Token) (*Token, error) {
 		AccessToken:    rawToken.AccessToken,
 		TokenType:      rawToken.TokenType,
 		RefreshToken:   rawToken.RefreshToken,
-		ExpirationTime: rawToken.Expiry.UTC(),
+		ExpirationTime: rawToken.Expiry,
 	}, nil
 }
 
@@ -81,12 +81,10 @@ func (t *Token) Validate(validator structure.Validator) {
 	validator.String("accessToken", &t.AccessToken).NotEmpty()
 }
 
-func (t *Token) Normalize(normalizer structure.Normalizer) {
-	t.ExpirationTime = t.ExpirationTime.UTC()
-}
+func (t *Token) Normalize(normalizer structure.Normalizer) {}
 
 func (t *Token) Expire() {
-	t.ExpirationTime = time.Now().Add(-time.Second).UTC()
+	t.ExpirationTime = time.Now().Add(-time.Second)
 }
 
 func (t *Token) RawToken() *oauth2.Token {

--- a/service/response.go
+++ b/service/response.go
@@ -8,6 +8,6 @@ import (
 
 func AddDateHeader(response rest.ResponseWriter) {
 	if response != nil {
-		response.Header().Set("Date", time.Now().UTC().Format(time.RFC1123))
+		response.Header().Set("Date", time.Now().Format(time.RFC1123))
 	}
 }


### PR DESCRIPTION
* Do not strip original time zone information using time.UTC()
* Only convert to UTC when required (eg. time.Format that requires UTC time with or without time zone)

@jh-bate 