### PR TITLE
Refactor request responder for more flexible responses; use direct http.ResponseWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Refactor request responder for more flexible responses; use direct http.ResponseWriter
 * Minor test refactor and cleanup
 * Add shortcuts for request error comparisons
 * Add streamed response from client in addition to existing data response

--- a/auth/service/api/status_get_test.go
+++ b/auth/service/api/status_get_test.go
@@ -4,6 +4,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"encoding/json"
+
 	"github.com/ant0ine/go-json-rest/rest"
 
 	"github.com/tidepool-org/platform/auth/service"
@@ -48,14 +50,13 @@ var _ = Describe("StatusGet", func() {
 			BeforeEach(func() {
 				sts = &service.Status{}
 				svc.StatusOutputs = []*service.Status{sts}
-				response.WriteJsonOutputs = []error{nil}
 				response.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 			})
 
 			It("returns successfully", func() {
 				rtr.StatusGet(response, request)
-				Expect(response.WriteJsonInputs).To(HaveLen(1))
-				Expect(response.WriteJsonInputs[0]).To(Equal(sts))
+				Expect(response.WriteInputs).To(HaveLen(1))
+				Expect(json.Marshal(sts)).To(MatchJSON(response.WriteInputs[0]))
 			})
 		})
 	})

--- a/auth/service/api/v1/oauth.go
+++ b/auth/service/api/v1/oauth.go
@@ -189,7 +189,7 @@ func (r *Router) oauthProviderRestrictedToken(req *http.Request, prvdr oauth.Pro
 }
 
 func (r *Router) htmlOnRedirect(res rest.ResponseWriter, req *rest.Request) {
-	request.MustNewResponder(res, req).HTML(http.StatusOK, htmlOnRedirect)
+	request.MustNewResponder(res, req).String(http.StatusOK, htmlOnRedirect, request.NewHeaderMutator("Content-Type", "text/html"))
 }
 
 func (r *Router) htmlOnError(res rest.ResponseWriter, req *rest.Request, err error, messages ...string) {
@@ -197,7 +197,11 @@ func (r *Router) htmlOnError(res rest.ResponseWriter, req *rest.Request, err err
 		messages = append(messages, unexpectedError)
 	}
 	log.LoggerFromContext(req.Context()).WithError(err).WithField("messages", messages).Error("Unexpected failure during OAuth workflow")
-	request.MustNewResponder(res, req).HTML(request.StatusCodeForError(err), strings.Replace(htmlOnError, "{{ MESSAGES }}", strings.Join(messages, " "), -1))
+	request.MustNewResponder(res, req).String(
+		request.StatusCodeForError(err),
+		strings.Replace(htmlOnError, "{{ MESSAGES }}", strings.Join(messages, " "), -1),
+		request.NewHeaderMutator("Content-Type", "text/html"),
+	)
 }
 
 func (r *Router) providerCookie(prvdr provider.Provider, value string, maxAge int) *http.Cookie {

--- a/errors/test/errors.go
+++ b/errors/test/errors.go
@@ -83,3 +83,9 @@ func ExpectErrorDetails(err error, code string, title string, detail string) {
 	gomega.Expect(bytesErr).ToNot(gomega.HaveOccurred())
 	gomega.Expect(bytes).To(gomega.MatchJSON(fmt.Sprintf(`{"code": %q, "title": %q, "detail": %q}`, code, title, detail)))
 }
+
+func ExpectErrorJSON(err error, actualJSON []byte) {
+	expectedJSON, err := json.Marshal(errors.Sanitize(err))
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(actualJSON).To(gomega.MatchJSON(expectedJSON))
+}

--- a/request/responder.go
+++ b/request/responder.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -14,8 +16,8 @@ type Sanitizable interface {
 }
 
 type Responder struct {
-	response rest.ResponseWriter
-	request  *rest.Request
+	res rest.ResponseWriter
+	req *rest.Request
 }
 
 func MustNewResponder(res rest.ResponseWriter, req *rest.Request) *Responder {
@@ -23,7 +25,6 @@ func MustNewResponder(res rest.ResponseWriter, req *rest.Request) *Responder {
 	if err != nil {
 		panic(err)
 	}
-
 	return responder
 }
 
@@ -34,75 +35,124 @@ func NewResponder(res rest.ResponseWriter, req *rest.Request) (*Responder, error
 	if req == nil {
 		return nil, errors.New("request is missing")
 	}
-
 	return &Responder{
-		response: res,
-		request:  req,
+		res: res,
+		req: req,
 	}, nil
 }
 
 func (r *Responder) SetCookie(cookie *http.Cookie) {
 	if cookie != nil {
-		http.SetCookie(r.response.(http.ResponseWriter), cookie)
+		http.SetCookie(r.res.(http.ResponseWriter), cookie)
 	}
 }
 
-func (r *Responder) Redirect(statusCode int, url string) {
-	http.Redirect(r.response.(http.ResponseWriter), r.request.Request, url, statusCode)
-}
-
-func (r *Responder) Empty(statusCode int) {
-	r.response.WriteHeader(statusCode)
-}
-
-func (r *Responder) HTML(statusCode int, html string) {
-	r.writeRaw("text/html", statusCode, []byte(html))
-}
-
-func (r *Responder) Data(statusCode int, data interface{}) {
-	if data == nil {
-		r.Error(http.StatusInternalServerError, errors.ErrorInternal(errors.New("data is missing")))
-	} else if err := r.sanitize(data); err != nil {
-		r.Error(http.StatusInternalServerError, errors.ErrorInternal(errors.Wrap(err, "unable to sanitize data")))
+func (r *Responder) Redirect(statusCode int, url string, mutators ...ResponseMutator) {
+	if err := r.mutateResponse(mutators); err != nil {
+		r.InternalServerError(err)
 	} else {
-		r.writeJSON(statusCode, data)
+		http.Redirect(r.res.(http.ResponseWriter), r.req.Request, url, statusCode)
 	}
 }
 
-func (r *Responder) Error(statusCode int, err error) {
+func (r *Responder) Empty(statusCode int, mutators ...ResponseMutator) {
+	// FUTURE: rest.ResponseWriter sets unnecessary/incorrect Content-Type header
+	if err := r.mutateResponse(mutators); err != nil {
+		r.InternalServerError(err)
+	} else {
+		r.res.WriteHeader(statusCode)
+	}
+}
+
+func (r *Responder) Bytes(statusCode int, bytes []byte, mutators ...ResponseMutator) {
+	if err := r.mutateResponse(mutators); err != nil {
+		r.InternalServerError(err)
+	} else {
+		r.res.WriteHeader(statusCode)
+		if _, err = r.res.(http.ResponseWriter).Write(bytes); err != nil {
+			log.LoggerFromContext(r.req.Context()).WithError(err).Error("Unable to write bytes")
+		}
+	}
+}
+
+func (r *Responder) String(statusCode int, str string, mutators ...ResponseMutator) {
+	r.Bytes(statusCode, []byte(str), mutators...)
+}
+
+func (r *Responder) Reader(statusCode int, reader io.Reader, mutators ...ResponseMutator) {
+	if reader == nil {
+		r.InternalServerError(errors.New("reader is missing"))
+	} else if err := r.mutateResponse(mutators); err != nil {
+		r.InternalServerError(err)
+	} else {
+		r.res.WriteHeader(statusCode)
+		if _, err = io.Copy(r.res.(io.Writer), reader); err != nil {
+			log.LoggerFromContext(r.req.Context()).WithError(err).Error("Unable to copy bytes from reader")
+		}
+	}
+}
+
+func (r *Responder) Data(statusCode int, data interface{}, mutators ...ResponseMutator) {
+	if data == nil {
+		r.InternalServerError(errors.New("data is missing"))
+	} else if sanitizeErr := r.sanitize(data); sanitizeErr != nil {
+		r.InternalServerError(errors.Wrap(sanitizeErr, "unable to sanitize data"))
+	} else if bytes, marshalErr := json.Marshal(data); marshalErr != nil {
+		r.InternalServerError(errors.Wrap(marshalErr, "unable to serialize data"))
+	} else {
+		r.Bytes(statusCode, append(bytes, newLine...), append(mutators, NewHeaderMutator("Content-Type", "application/json; charset=utf-8"))...)
+	}
+}
+
+func (r *Responder) Error(statusCode int, err error, mutators ...ResponseMutator) {
 	if err == nil {
-		err = errors.ErrorInternal(errors.New("error is missing"))
+		r.InternalServerError(errors.New("error is missing"))
+	} else {
+		// FUTURE: service.SetRequestErrors(r.req, errs) rather than logger statement below
+		log.LoggerFromContext(r.req.Context()).WithError(err).Warn("Failure during request")
+		if bytes, marshalErr := json.Marshal(errors.Sanitize(err)); marshalErr != nil {
+			r.InternalServerError(errors.Wrap(marshalErr, "unable to serialize error"))
+		} else {
+			r.Bytes(statusCode, append(bytes, newLine...), append(mutators, NewHeaderMutator("Content-Type", "application/json; charset=utf-8"))...)
+		}
 	}
-
-	// service.SetRequestErrors(r.request, errs) // TODO:
-	log.LoggerFromContext(r.request.Context()).WithError(err).Warn("Failure during request")
-
-	r.writeJSON(statusCode, errors.Sanitize(err))
 }
 
-func (r *Responder) sanitize(data interface{}) error {
-	if sanitizable, ok := data.(Sanitizable); ok {
-		return sanitizable.Sanitize(DetailsFromContext(r.request.Context()))
+func (r *Responder) InternalServerError(err error, mutators ...ResponseMutator) {
+	if err == nil {
+		err = ErrorInternalServerError(errors.New("error is missing"))
+	} else if !IsErrorInternalServerError(err) {
+		err = ErrorInternalServerError(err)
+	}
+	r.Error(http.StatusInternalServerError, err, mutators...)
+}
+
+func (r *Responder) RespondIfError(err error, mutators ...ResponseMutator) bool {
+	if err == nil {
+		return false
+	}
+	if statusCode := StatusCodeForError(err); statusCode != http.StatusInternalServerError {
+		r.Error(statusCode, err, mutators...)
+	} else {
+		r.InternalServerError(err, mutators...)
+	}
+	return true
+}
+
+func (r *Responder) mutateResponse(mutators []ResponseMutator) error {
+	for _, mutator := range mutators {
+		if err := mutator.MutateResponse(r.res.(http.ResponseWriter)); err != nil {
+			return errors.Wrap(err, "unable to mutate response")
+		}
 	}
 	return nil
 }
 
-func (r *Responder) writeJSON(statusCode int, object interface{}) {
-	r.response.Header().Set("Content-Type", "application/json; charset=utf-8")
-	r.response.WriteHeader(statusCode)
-	if err := r.response.WriteJson(object); err != nil {
-		log.LoggerFromContext(r.request.Context()).WithError(err).Error("Unable to write JSON")
-	} else if _, err = r.response.(http.ResponseWriter).Write(_NewLine); err != nil {
-		log.LoggerFromContext(r.request.Context()).WithError(err).Error("Unable to write new line")
+func (r *Responder) sanitize(data interface{}) error {
+	if sanitizable, ok := data.(Sanitizable); ok {
+		return sanitizable.Sanitize(DetailsFromContext(r.req.Context()))
 	}
+	return nil
 }
 
-func (r *Responder) writeRaw(contentType string, statusCode int, bytes []byte) {
-	r.response.Header().Set("Content-Type", contentType)
-	r.response.WriteHeader(statusCode)
-	if _, err := r.response.(http.ResponseWriter).Write(bytes); err != nil {
-		log.LoggerFromContext(r.request.Context()).WithError(err).Error("Unable to write bytes")
-	}
-}
-
-var _NewLine = []byte("\n")
+var newLine = []byte("\n")

--- a/request/responder_test.go
+++ b/request/responder_test.go
@@ -1,1 +1,585 @@
 package request_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ant0ine/go-json-rest/rest"
+
+	"github.com/tidepool-org/platform/errors"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/log"
+	logNull "github.com/tidepool-org/platform/log/null"
+	"github.com/tidepool-org/platform/request"
+	"github.com/tidepool-org/platform/test"
+	testHTTP "github.com/tidepool-org/platform/test/http"
+	testRest "github.com/tidepool-org/platform/test/rest"
+)
+
+type Data struct {
+	Value         interface{} `json:"value"`
+	SanitizeError error       `json:"-"`
+}
+
+func NewData() *Data {
+	return &Data{
+		Value: testHTTP.NewHeaderValue(),
+	}
+}
+
+func (d *Data) Sanitize(details request.Details) error {
+	return d.SanitizeError
+}
+
+type Error struct {
+	Value interface{} `json:"value"`
+}
+
+func NewError() *Error {
+	return &Error{
+		Value: testHTTP.NewHeaderValue(),
+	}
+}
+
+func (e *Error) Error() string {
+	return "error"
+}
+
+var _ = Describe("Responder", func() {
+	var res *testRest.ResponseWriter
+	var req *rest.Request
+
+	BeforeEach(func() {
+		res = testRest.NewResponseWriter()
+		req = testRest.NewRequest()
+		req.Method = "POST"
+		req.Request = req.WithContext(log.NewContextWithLogger(req.Context(), logNull.NewLogger()))
+	})
+
+	AfterEach(func() {
+		res.Expectations()
+	})
+
+	Context("MustNewResponder", func() {
+		It("panics if the response is missing", func() {
+			Expect(func() { request.MustNewResponder(nil, req) }).To(Panic())
+		})
+
+		It("panics if the response is missing", func() {
+			Expect(func() { request.MustNewResponder(res, nil) }).To(Panic())
+		})
+
+		It("succeeds", func() {
+			Expect(request.MustNewResponder(res, req)).ToNot(BeNil())
+		})
+	})
+
+	Context("NewResponder", func() {
+		It("returns an error if the response is missing", func() {
+			responder, err := request.NewResponder(nil, req)
+			Expect(err).To(MatchError("response is missing"))
+			Expect(responder).To(BeNil())
+		})
+
+		It("returns an error if the request is missing", func() {
+			responder, err := request.NewResponder(res, nil)
+			Expect(err).To(MatchError("request is missing"))
+			Expect(responder).To(BeNil())
+		})
+
+		It("succeeds", func() {
+			Expect(request.NewResponder(res, req)).ToNot(BeNil())
+		})
+	})
+
+	Context("with new responder", func() {
+		var responder *request.Responder
+
+		BeforeEach(func() {
+			var err error
+			responder, err = request.NewResponder(res, req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(responder).ToNot(BeNil())
+		})
+
+		Context("SetCookie", func() {
+			It("does nothing if cookie is nil", func() {
+				responder.SetCookie(nil)
+				Expect(res.HeaderImpl).To(BeEmpty())
+			})
+
+			It("adds the expected header if the cookie is not nil", func() {
+				cookie := http.Cookie{
+					Name:  testHTTP.NewHeaderKey(),
+					Value: testHTTP.NewHeaderValue(),
+				}
+				responder.SetCookie(&cookie)
+				Expect(res.HeaderImpl).To(HaveKey("Set-Cookie"))
+				Expect(res.HeaderImpl["Set-Cookie"]).To(ConsistOf(
+					fmt.Sprintf("%s=%s", cookie.Name, cookie.Value),
+				))
+			})
+
+			It("adds the expected header for multiple cookies", func() {
+				cookie1 := http.Cookie{
+					Name:  testHTTP.NewHeaderKey(),
+					Value: testHTTP.NewHeaderValue(),
+				}
+				cookie2 := http.Cookie{
+					Name:  testHTTP.NewHeaderKey(),
+					Value: testHTTP.NewHeaderValue(),
+				}
+				responder.SetCookie(&cookie1)
+				responder.SetCookie(&cookie2)
+				Expect(res.HeaderImpl).To(HaveKey("Set-Cookie"))
+				Expect(res.HeaderImpl["Set-Cookie"]).To(ConsistOf(
+					fmt.Sprintf("%s=%s", cookie1.Name, cookie1.Value),
+					fmt.Sprintf("%s=%s", cookie2.Name, cookie2.Value),
+				))
+			})
+		})
+
+		Context("Redirect", func() {
+			var url string
+
+			BeforeEach(func() {
+				url = testHTTP.NewURLString()
+			})
+
+			It("responds with successful redirect", func() {
+				responder.Redirect(http.StatusPermanentRedirect, url)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Location": []string{url},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{308}))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.Redirect(http.StatusPermanentRedirect, url, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful redirect with mutator", func() {
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.Redirect(http.StatusPermanentRedirect, url, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Location":        []string{url},
+					headerMutator.Key: []string{headerMutator.Value}},
+				))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{308}))
+			})
+		})
+
+		Context("Empty", func() {
+			It("responds with successful empty response", func() {
+				responder.Empty(http.StatusOK)
+				Expect(res.HeaderImpl).To(BeEmpty())
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.Empty(http.StatusOK, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful empty response with mutator", func() {
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.Empty(http.StatusOK, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{headerMutator.Key: []string{headerMutator.Value}}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+			})
+		})
+
+		Context("Bytes", func() {
+			var byts []byte
+
+			BeforeEach(func() {
+				byts = []byte(test.NewVariableString(0, 64, test.CharsetText))
+			})
+
+			It("responds with successful non-empty response", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Bytes(http.StatusOK, byts)
+				Expect(res.HeaderImpl).To(BeEmpty())
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(Equal([][]byte{byts}))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.Bytes(http.StatusOK, byts, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response with mutator", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.Bytes(http.StatusOK, byts, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{headerMutator.Key: []string{headerMutator.Value}}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(Equal([][]byte{byts}))
+			})
+		})
+
+		Context("String", func() {
+			var str string
+
+			BeforeEach(func() {
+				str = test.NewVariableString(0, 64, test.CharsetText)
+			})
+
+			It("responds with successful non-empty response", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.String(http.StatusOK, str)
+				Expect(res.HeaderImpl).To(BeEmpty())
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(Equal([][]byte{[]byte(str)}))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.String(http.StatusOK, str, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response with mutator", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.String(http.StatusOK, str, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{headerMutator.Key: []string{headerMutator.Value}}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(Equal([][]byte{[]byte(str)}))
+			})
+		})
+
+		Context("Reader", func() {
+			var byts []byte
+			var reader io.Reader
+
+			BeforeEach(func() {
+				byts = []byte(test.NewVariableString(0, 64, test.CharsetText))
+				reader = bytes.NewReader(byts)
+			})
+
+			It("responds with an internal server error if the reader is missing", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Reader(http.StatusOK, nil)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Reader(http.StatusOK, reader)
+				Expect(res.HeaderImpl).To(BeEmpty())
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(Equal([][]byte{byts}))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.Reader(http.StatusOK, reader, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response with mutator", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.Reader(http.StatusOK, reader, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{headerMutator.Key: []string{headerMutator.Value}}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(Equal([][]byte{byts}))
+			})
+		})
+
+		Context("Data", func() {
+			var data *Data
+
+			BeforeEach(func() {
+				data = NewData()
+			})
+
+			It("responds with an internal server error if the data is missing", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Data(http.StatusOK, nil)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with an internal server error if the data cannot be sanitized", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				data.SanitizeError = errors.New("sanitize error")
+				responder.Data(http.StatusOK, data)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with an internal server error if the data cannot be marshalled", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				data.Value = func() {}
+				responder.Data(http.StatusOK, data)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Data(http.StatusOK, data)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				Expect(json.Marshal(data)).To(MatchJSON(res.WriteInputs[0]))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.Data(http.StatusOK, data, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response with mutator", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.Data(http.StatusOK, data, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type":    []string{"application/json; charset=utf-8"},
+					headerMutator.Key: []string{headerMutator.Value},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{200}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				Expect(json.Marshal(data)).To(MatchJSON(res.WriteInputs[0]))
+			})
+		})
+
+		Context("Error", func() {
+			var err *Error
+
+			BeforeEach(func() {
+				err = NewError()
+			})
+
+			It("responds with an internal server error if the error is missing", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Error(http.StatusBadRequest, nil)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with an internal server error if the error cannot be marshalled", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				err.Value = func() {}
+				responder.Error(http.StatusBadRequest, err)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.Error(http.StatusBadRequest, err)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{400}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				Expect(json.Marshal(err)).To(MatchJSON(res.WriteInputs[0]))
+			})
+
+			It("responds with an internal server error if there is an error with the mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				invalidMutator := request.NewHeaderMutator("", "")
+				responder.Data(http.StatusBadRequest, err, invalidMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response with mutator", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.Data(http.StatusBadRequest, err, headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type":    []string{"application/json; charset=utf-8"},
+					headerMutator.Key: []string{headerMutator.Value},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{400}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				Expect(json.Marshal(err)).To(MatchJSON(res.WriteInputs[0]))
+			})
+		})
+
+		Context("InternalServerError", func() {
+			It("responds with an internal server error if the error is missing", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.InternalServerError(nil)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with an internal server error if the error is not an internal service error", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.InternalServerError(request.ErrorUnauthenticated())
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with an internal server error if the error is an internal service error", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				responder.InternalServerError(request.ErrorInternalServerError(nil))
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with an internal server error if the error is an internal service error with mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				responder.InternalServerError(request.ErrorInternalServerError(nil), headerMutator)
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type":    []string{"application/json; charset=utf-8"},
+					headerMutator.Key: []string{headerMutator.Value},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+		})
+
+		Context("RespondIfError", func() {
+			It("returns false if error is missing", func() {
+				Expect(responder.RespondIfError(nil)).To(BeFalse())
+			})
+
+			It("responds with successful non-empty response if the error is associated with a status code", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				Expect(responder.RespondIfError(request.ErrorUnauthenticated())).To(BeTrue())
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{401}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorUnauthenticated(), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response if the error is associated with a status code with mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				Expect(responder.RespondIfError(request.ErrorUnauthenticated(), headerMutator)).To(BeTrue())
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type":    []string{"application/json; charset=utf-8"},
+					headerMutator.Key: []string{headerMutator.Value},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{401}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorUnauthenticated(), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response if the error is not associated with a status code", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				Expect(responder.RespondIfError(request.ErrorJSONMalformed())).To(BeTrue())
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type": []string{"application/json; charset=utf-8"},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+
+			It("responds with successful non-empty response if the error is not associated with a status code with mutators", func() {
+				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
+				headerMutator := request.NewHeaderMutator(testHTTP.NewHeaderKey(), testHTTP.NewHeaderValue())
+				Expect(responder.RespondIfError(request.ErrorJSONMalformed(), headerMutator)).To(BeTrue())
+				Expect(res.HeaderImpl).To(Equal(http.Header{
+					"Content-Type":    []string{"application/json; charset=utf-8"},
+					headerMutator.Key: []string{headerMutator.Value},
+				}))
+				Expect(res.WriteHeaderInputs).To(Equal([]int{500}))
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorInternalServerError(nil), res.WriteInputs[0])
+			})
+		})
+	})
+})

--- a/service/api/auth_test.go
+++ b/service/api/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ant0ine/go-json-rest/rest"
 
 	testAuth "github.com/tidepool-org/platform/auth/test"
-	testErrors "github.com/tidepool-org/platform/errors/test"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/log"
 	logNull "github.com/tidepool-org/platform/log/null"
 	"github.com/tidepool-org/platform/request"
@@ -48,7 +48,7 @@ var _ = Describe("Auth", func() {
 			Expect(requireFunc).ToNot(BeNil())
 			requireFunc(res, req)
 			Expect(res.WriteHeaderInputs).To(BeEmpty())
-			Expect(res.WriteJsonInputs).To(BeEmpty())
+			Expect(res.WriteInputs).To(BeEmpty())
 		})
 
 		Context("with handlerFunc func", func() {
@@ -62,22 +62,21 @@ var _ = Describe("Auth", func() {
 			It("does nothing if response is nil", func() {
 				requireFunc(nil, req)
 				Expect(res.WriteHeaderInputs).To(BeEmpty())
-				Expect(res.WriteJsonInputs).To(BeEmpty())
+				Expect(res.WriteInputs).To(BeEmpty())
 			})
 
 			It("does nothing if request is nil", func() {
 				requireFunc(res, nil)
 				Expect(res.WriteHeaderInputs).To(BeEmpty())
-				Expect(res.WriteJsonInputs).To(BeEmpty())
+				Expect(res.WriteInputs).To(BeEmpty())
 			})
 
 			It("responds with unauthenticated error if details are missing", func() {
-				res.WriteJsonOutputs = []error{nil}
 				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 				requireFunc(res, req)
 				Expect(res.WriteHeaderInputs).To(Equal([]int{401}))
-				Expect(res.WriteJsonInputs).To(HaveLen(1))
-				testErrors.ExpectEqual(res.WriteJsonInputs[0].(error), request.ErrorUnauthenticated())
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorUnauthenticated(), res.WriteInputs[0])
 			})
 
 			Context("with server details", func() {
@@ -88,7 +87,7 @@ var _ = Describe("Auth", func() {
 				It("responds successfully", func() {
 					requireFunc(res, req)
 					Expect(res.WriteHeaderInputs).To(Equal([]int{0}))
-					Expect(res.WriteJsonInputs).To(BeEmpty())
+					Expect(res.WriteInputs).To(BeEmpty())
 				})
 			})
 
@@ -100,7 +99,7 @@ var _ = Describe("Auth", func() {
 				It("responds successfully", func() {
 					requireFunc(res, req)
 					Expect(res.WriteHeaderInputs).To(Equal([]int{0}))
-					Expect(res.WriteJsonInputs).To(BeEmpty())
+					Expect(res.WriteInputs).To(BeEmpty())
 				})
 			})
 		})
@@ -112,7 +111,7 @@ var _ = Describe("Auth", func() {
 			Expect(requireFunc).ToNot(BeNil())
 			requireFunc(res, req)
 			Expect(res.WriteHeaderInputs).To(BeEmpty())
-			Expect(res.WriteJsonInputs).To(BeEmpty())
+			Expect(res.WriteInputs).To(BeEmpty())
 		})
 
 		Context("with handlerFunc func", func() {
@@ -126,22 +125,21 @@ var _ = Describe("Auth", func() {
 			It("does nothing if response is nil", func() {
 				requireFunc(nil, req)
 				Expect(res.WriteHeaderInputs).To(BeEmpty())
-				Expect(res.WriteJsonInputs).To(BeEmpty())
+				Expect(res.WriteInputs).To(BeEmpty())
 			})
 
 			It("does nothing if request is nil", func() {
 				requireFunc(res, nil)
 				Expect(res.WriteHeaderInputs).To(BeEmpty())
-				Expect(res.WriteJsonInputs).To(BeEmpty())
+				Expect(res.WriteInputs).To(BeEmpty())
 			})
 
 			It("responds with unauthenticated error if details are missing", func() {
-				res.WriteJsonOutputs = []error{nil}
 				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 				requireFunc(res, req)
 				Expect(res.WriteHeaderInputs).To(Equal([]int{401}))
-				Expect(res.WriteJsonInputs).To(HaveLen(1))
-				testErrors.ExpectEqual(res.WriteJsonInputs[0].(error), request.ErrorUnauthenticated())
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorUnauthenticated(), res.WriteInputs[0])
 			})
 
 			Context("with server details", func() {
@@ -152,7 +150,7 @@ var _ = Describe("Auth", func() {
 				It("responds successfully", func() {
 					requireFunc(res, req)
 					Expect(res.WriteHeaderInputs).To(Equal([]int{0}))
-					Expect(res.WriteJsonInputs).To(BeEmpty())
+					Expect(res.WriteInputs).To(BeEmpty())
 				})
 			})
 
@@ -162,12 +160,11 @@ var _ = Describe("Auth", func() {
 				})
 
 				It("responds with unauthorized error", func() {
-					res.WriteJsonOutputs = []error{nil}
 					res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 					requireFunc(res, req)
 					Expect(res.WriteHeaderInputs).To(Equal([]int{403}))
-					Expect(res.WriteJsonInputs).To(HaveLen(1))
-					testErrors.ExpectEqual(res.WriteJsonInputs[0].(error), request.ErrorUnauthorized())
+					Expect(res.WriteInputs).To(HaveLen(1))
+					errorsTest.ExpectErrorJSON(request.ErrorUnauthorized(), res.WriteInputs[0])
 				})
 			})
 		})
@@ -179,7 +176,7 @@ var _ = Describe("Auth", func() {
 			Expect(requireFunc).ToNot(BeNil())
 			requireFunc(res, req)
 			Expect(res.WriteHeaderInputs).To(BeEmpty())
-			Expect(res.WriteJsonInputs).To(BeEmpty())
+			Expect(res.WriteInputs).To(BeEmpty())
 		})
 
 		Context("with handlerFunc func", func() {
@@ -193,22 +190,21 @@ var _ = Describe("Auth", func() {
 			It("does nothing if response is nil", func() {
 				requireFunc(nil, req)
 				Expect(res.WriteHeaderInputs).To(BeEmpty())
-				Expect(res.WriteJsonInputs).To(BeEmpty())
+				Expect(res.WriteInputs).To(BeEmpty())
 			})
 
 			It("does nothing if request is nil", func() {
 				requireFunc(res, nil)
 				Expect(res.WriteHeaderInputs).To(BeEmpty())
-				Expect(res.WriteJsonInputs).To(BeEmpty())
+				Expect(res.WriteInputs).To(BeEmpty())
 			})
 
 			It("responds with unauthenticated error if details are missing", func() {
-				res.WriteJsonOutputs = []error{nil}
 				res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 				requireFunc(res, req)
 				Expect(res.WriteHeaderInputs).To(Equal([]int{401}))
-				Expect(res.WriteJsonInputs).To(HaveLen(1))
-				testErrors.ExpectEqual(res.WriteJsonInputs[0].(error), request.ErrorUnauthenticated())
+				Expect(res.WriteInputs).To(HaveLen(1))
+				errorsTest.ExpectErrorJSON(request.ErrorUnauthenticated(), res.WriteInputs[0])
 			})
 
 			Context("with server details", func() {
@@ -217,12 +213,11 @@ var _ = Describe("Auth", func() {
 				})
 
 				It("responds with unauthorized error", func() {
-					res.WriteJsonOutputs = []error{nil}
 					res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 					requireFunc(res, req)
 					Expect(res.WriteHeaderInputs).To(Equal([]int{403}))
-					Expect(res.WriteJsonInputs).To(HaveLen(1))
-					testErrors.ExpectEqual(res.WriteJsonInputs[0].(error), request.ErrorUnauthorized())
+					Expect(res.WriteInputs).To(HaveLen(1))
+					errorsTest.ExpectErrorJSON(request.ErrorUnauthorized(), res.WriteInputs[0])
 				})
 			})
 
@@ -234,7 +229,7 @@ var _ = Describe("Auth", func() {
 				It("responds successfully", func() {
 					requireFunc(res, req)
 					Expect(res.WriteHeaderInputs).To(Equal([]int{0}))
-					Expect(res.WriteJsonInputs).To(BeEmpty())
+					Expect(res.WriteInputs).To(BeEmpty())
 				})
 			})
 		})

--- a/service/middleware/auth_test.go
+++ b/service/middleware/auth_test.go
@@ -152,7 +152,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if multiple values", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						req.Header.Add("X-Tidepool-Service-Secret", serviceSecret)
 						middlewareFunc(res, req)
@@ -160,7 +159,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if the server secret does not match", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						req.Header.Set("X-Tidepool-Service-Secret", testAuth.NewServiceSecret())
 						middlewareFunc(res, req)
@@ -191,7 +189,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if multiple values", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 						middlewareFunc(res, req)
@@ -199,7 +196,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if not valid header", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						req.Header.Set("Authorization", accessToken)
 						middlewareFunc(res, req)
@@ -207,7 +203,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if not Bearer token", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						req.Header.Set("Authorization", fmt.Sprintf("NotBearer %s", accessToken))
 						middlewareFunc(res, req)
@@ -261,7 +256,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if multiple values", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						req.Header.Add("X-Tidepool-Session-Token", sessionToken)
 						middlewareFunc(res, req)
@@ -338,7 +332,6 @@ var _ = Describe("Auth", func() {
 					})
 
 					It("returns unauthorized if multiple values", func() {
-						res.WriteJsonOutputs = []error{nil}
 						res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 						query := req.URL.Query()
 						query.Add("restricted_token", restrictedToken)


### PR DESCRIPTION
@jh-bate Update responder functionality to be more generally useful and not specific to JSON responses.