### PR TITLE
Refactor client request response workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## HEAD
 
+* Add client response inspectors
+* Ensure client data responses uses expected application/json content type header
+* Parse client response body for actual error, default to standard error from status code
+* Forcible drain client response body under all conditions
+* Add ArrayParametersMutator for adding headers with multiple string values
+* Update request values parser to handle generic map
+* Add request ParseDigestMD5Header, ParseMediaTypeHeader, and ParseIntHeader
+* Add request IsStatusCodeRedirection and IsStatusCodeClientError
+* Log any failure or short write during responder response write
 * Update logger to delete an existing field if new field value is nil
 * When deserializing errors an empty error array returns nil
 * Refactor application package to allow dependency injection

--- a/oauth/client/client.go
+++ b/oauth/client/client.go
@@ -51,5 +51,5 @@ func (c *Client) SendOAuthRequest(ctx context.Context, method string, url string
 		return err
 	}
 
-	return c.client.RequestDataWithHTTPClient(ctx, method, url, mutators, requestBody, responseBody, httpClient)
+	return c.client.RequestDataWithHTTPClient(ctx, method, url, mutators, requestBody, responseBody, nil, httpClient)
 }

--- a/platform/client.go
+++ b/platform/client.go
@@ -33,7 +33,7 @@ func NewClient(cfg *Config, authorizeAs AuthorizeAs) (*Client, error) {
 		return nil, errors.Wrap(err, "config is invalid")
 	}
 	if authorizeAs != AuthorizeAsService && authorizeAs != AuthorizeAsUser {
-		return nil, errors.New("authorized as is invalid")
+		return nil, errors.New("authorize as is invalid")
 	}
 
 	clnt, err := client.New(cfg.Config)
@@ -92,20 +92,20 @@ func (c *Client) HTTPClient() *http.Client {
 	return c.httpClient
 }
 
-func (c *Client) RequestStream(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}) (io.ReadCloser, error) {
+func (c *Client) RequestStream(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}, inspectors ...request.ResponseInspector) (io.ReadCloser, error) {
 	clientMutators, err := c.Mutators(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.RequestStreamWithHTTPClient(ctx, method, url, append(mutators, clientMutators...), requestBody, c.HTTPClient())
+	return c.RequestStreamWithHTTPClient(ctx, method, url, append(mutators, clientMutators...), requestBody, inspectors, c.HTTPClient())
 }
 
-func (c *Client) RequestData(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}, responseBody interface{}) error {
+func (c *Client) RequestData(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}, responseBody interface{}, inspectors ...request.ResponseInspector) error {
 	clientMutators, err := c.Mutators(ctx)
 	if err != nil {
 		return err
 	}
 
-	return c.RequestDataWithHTTPClient(ctx, method, url, append(mutators, clientMutators...), requestBody, responseBody, c.HTTPClient())
+	return c.RequestDataWithHTTPClient(ctx, method, url, append(mutators, clientMutators...), requestBody, responseBody, inspectors, c.HTTPClient())
 }

--- a/platform/client_test.go
+++ b/platform/client_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/tidepool-org/platform/auth"
 	authTest "github.com/tidepool-org/platform/auth/test"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/platform"
 	"github.com/tidepool-org/platform/request"
 	"github.com/tidepool-org/platform/test"
@@ -41,7 +43,7 @@ var _ = Describe("Client", func() {
 			address = testHTTP.NewAddress()
 			userAgent = testHTTP.NewUserAgent()
 			serviceSecret = authTest.NewServiceSecret()
-			ctx = context.Background()
+			ctx = log.NewContextWithLogger(context.Background(), logTest.NewLogger())
 		})
 
 		JustBeforeEach(func() {
@@ -67,9 +69,9 @@ var _ = Describe("Client", func() {
 				Expect(clnt).To(BeNil())
 			})
 
-			It("returns an error if authorized as is invalid", func() {
+			It("returns an error if authorize as is invalid", func() {
 				clnt, err := platform.NewClient(cfg, platform.AuthorizeAs(-1))
-				Expect(err).To(MatchError("authorized as is invalid"))
+				Expect(err).To(MatchError("authorize as is invalid"))
 				Expect(clnt).To(BeNil())
 			})
 
@@ -80,7 +82,7 @@ var _ = Describe("Client", func() {
 			})
 		})
 
-		Context("with new client authorized as service", func() {
+		Context("with new client authorize as service", func() {
 			var clnt *platform.Client
 
 			JustBeforeEach(func() {
@@ -220,7 +222,7 @@ var _ = Describe("Client", func() {
 						})
 					})
 
-					Context("with a successful response 200 with additional mutators", func() {
+					Context("with a successful response 200 with additional mutators and inspectors", func() {
 						var headerKey string
 						var headerValue string
 
@@ -240,7 +242,8 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							reader, err = clnt.RequestStream(ctx, method, url, mutators, nil)
+							inspector := request.NewHeadersInspector()
+							reader, err = clnt.RequestStream(ctx, method, url, mutators, nil, inspector)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(reader).ToNot(BeNil())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
@@ -282,7 +285,7 @@ var _ = Describe("Client", func() {
 						})
 					})
 
-					Context("with a successful response 200 with additional mutators", func() {
+					Context("with a successful response 200 with additional mutators and inspectors", func() {
 						var headerKey string
 						var headerValue string
 
@@ -302,7 +305,8 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							Expect(clnt.RequestData(ctx, method, url, mutators, nil, nil)).To(Succeed())
+							inspector := request.NewHeadersInspector()
+							Expect(clnt.RequestData(ctx, method, url, mutators, nil, nil, inspector)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
 					})
@@ -310,7 +314,7 @@ var _ = Describe("Client", func() {
 			})
 		})
 
-		Context("with new client authorized as user", func() {
+		Context("with new client authorize as user", func() {
 			var sessionToken string
 			var clnt *platform.Client
 
@@ -433,7 +437,7 @@ var _ = Describe("Client", func() {
 						})
 					})
 
-					Context("with a successful response 200 with additional mutators", func() {
+					Context("with a successful response 200 with additional mutators and inspectors", func() {
 						var headerKey string
 						var headerValue string
 
@@ -453,7 +457,8 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							reader, err = clnt.RequestStream(ctx, method, url, mutators, nil)
+							inspector := request.NewHeadersInspector()
+							reader, err = clnt.RequestStream(ctx, method, url, mutators, nil, inspector)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(reader).ToNot(BeNil())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
@@ -495,7 +500,7 @@ var _ = Describe("Client", func() {
 						})
 					})
 
-					Context("with a successful response 200 with additional mutators", func() {
+					Context("with a successful response 200 with additional mutators and inspectors", func() {
 						var headerKey string
 						var headerValue string
 
@@ -515,7 +520,8 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							Expect(clnt.RequestData(ctx, method, url, mutators, nil, nil)).To(Succeed())
+							inspector := request.NewHeadersInspector()
+							Expect(clnt.RequestData(ctx, method, url, mutators, nil, nil, inspector)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
 					})

--- a/request/inspector.go
+++ b/request/inspector.go
@@ -1,0 +1,28 @@
+package request
+
+import (
+	"net/http"
+
+	"github.com/tidepool-org/platform/errors"
+)
+
+type ResponseInspector interface {
+	InspectResponse(res *http.Response) error
+}
+
+type HeadersInspector struct {
+	Headers http.Header
+}
+
+func NewHeadersInspector() *HeadersInspector {
+	return &HeadersInspector{}
+}
+
+func (h *HeadersInspector) InspectResponse(res *http.Response) error {
+	if res == nil {
+		return errors.New("response is missing")
+	}
+
+	h.Headers = res.Header
+	return nil
+}

--- a/request/inspector_test.go
+++ b/request/inspector_test.go
@@ -1,0 +1,69 @@
+package request_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"net/http"
+
+	"github.com/tidepool-org/platform/request"
+	"github.com/tidepool-org/platform/test"
+	testHttp "github.com/tidepool-org/platform/test/http"
+)
+
+var _ = Describe("Inspector", func() {
+	Context("HeadersInspector", func() {
+		Context("NewHeadersInspector", func() {
+			It("returns successfully", func() {
+				Expect(request.NewHeadersInspector()).ToNot(BeNil())
+			})
+		})
+
+		Context("with new headers inspector", func() {
+			var inspector *request.HeadersInspector
+
+			BeforeEach(func() {
+				inspector = request.NewHeadersInspector()
+				Expect(inspector).ToNot(BeNil())
+			})
+
+			It("has no headers before inspection", func() {
+				Expect(inspector.Headers).To(BeNil())
+			})
+
+			Context("InspectResponse", func() {
+				var headers http.Header
+				var res *http.Response
+
+				BeforeEach(func() {
+					headers = http.Header{}
+					for _, key := range test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(1, 3, testHttp.NewHeaderKey) {
+						headers[key] = test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(0, 2, testHttp.NewHeaderValue)
+					}
+					res = &http.Response{Header: headers}
+				})
+
+				It("returns an error if the response is missing", func() {
+					Expect(inspector.InspectResponse(nil)).To(MatchError("response is missing"))
+				})
+
+				It("captures nil headers", func() {
+					res.Header = nil
+					Expect(inspector.InspectResponse(res)).To(Succeed())
+					Expect(inspector.Headers).To(BeNil())
+				})
+
+				It("captures empty headers", func() {
+					res.Header = http.Header{}
+					Expect(inspector.InspectResponse(res)).To(Succeed())
+					Expect(inspector.Headers).To(BeEmpty())
+				})
+
+				It("captures non-empty headers", func() {
+					Expect(inspector.InspectResponse(res)).To(Succeed())
+					Expect(inspector.Headers).To(Equal(headers))
+				})
+			})
+		})
+	})
+})

--- a/request/mutator.go
+++ b/request/mutator.go
@@ -102,3 +102,32 @@ func (p *ParametersMutator) MutateRequest(req *http.Request) error {
 
 	return nil
 }
+
+type ArrayParametersMutator struct {
+	Parameters map[string][]string
+}
+
+func NewArrayParametersMutator(parameters map[string][]string) *ArrayParametersMutator {
+	return &ArrayParametersMutator{
+		Parameters: parameters,
+	}
+}
+
+func (p *ArrayParametersMutator) MutateRequest(req *http.Request) error {
+	if req == nil {
+		return errors.New("request is missing")
+	}
+
+	query := req.URL.Query()
+	for key, values := range p.Parameters {
+		if key == "" {
+			return errors.New("key is missing")
+		}
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+	req.URL.RawQuery = query.Encode()
+
+	return nil
+}

--- a/request/mutator_test.go
+++ b/request/mutator_test.go
@@ -4,11 +4,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"math/rand"
 	"net/http"
 
 	"github.com/tidepool-org/platform/request"
-	testHTTP "github.com/tidepool-org/platform/test/http"
+	"github.com/tidepool-org/platform/test"
+	testHttp "github.com/tidepool-org/platform/test/http"
 )
 
 var _ = Describe("Mutator", func() {
@@ -17,8 +17,8 @@ var _ = Describe("Mutator", func() {
 		var value string
 
 		BeforeEach(func() {
-			key = testHTTP.NewHeaderKey()
-			value = testHTTP.NewHeaderValue()
+			key = testHttp.NewHeaderKey()
+			value = testHttp.NewHeaderValue()
 		})
 
 		Context("NewHeaderMutator", func() {
@@ -47,7 +47,7 @@ var _ = Describe("Mutator", func() {
 				var request *http.Request
 
 				BeforeEach(func() {
-					request = testHTTP.NewRequest()
+					request = testHttp.NewRequest()
 				})
 
 				It("returns an error if the request is missing", func() {
@@ -66,8 +66,8 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the header even if there are already headers", func() {
-					existingKey := testHTTP.NewHeaderKey()
-					existingValue := testHTTP.NewHeaderValue()
+					existingKey := testHttp.NewHeaderKey()
+					existingValue := testHttp.NewHeaderValue()
 					request.Header.Add(existingKey, existingValue)
 					Expect(mutator.MutateRequest(request)).To(Succeed())
 					Expect(request.Header).To(HaveLen(2))
@@ -76,7 +76,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the header even if there are already headers with the same key", func() {
-					existingValue := testHTTP.NewHeaderValue()
+					existingValue := testHttp.NewHeaderValue()
 					request.Header.Add(key, existingValue)
 					Expect(mutator.MutateRequest(request)).To(Succeed())
 					Expect(request.Header).To(HaveLen(1))
@@ -91,8 +91,8 @@ var _ = Describe("Mutator", func() {
 		var value string
 
 		BeforeEach(func() {
-			key = testHTTP.NewParameterKey()
-			value = testHTTP.NewParameterValue()
+			key = testHttp.NewParameterKey()
+			value = testHttp.NewParameterValue()
 		})
 
 		Context("NewParameterMutator", func() {
@@ -121,7 +121,7 @@ var _ = Describe("Mutator", func() {
 				var request *http.Request
 
 				BeforeEach(func() {
-					request = testHTTP.NewRequest()
+					request = testHttp.NewRequest()
 				})
 
 				It("returns an error if the request is missing", func() {
@@ -140,8 +140,8 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the parameter even if there are already parameters", func() {
-					existingKey := testHTTP.NewParameterKey()
-					existingValue := testHTTP.NewParameterValue()
+					existingKey := testHttp.NewParameterKey()
+					existingValue := testHttp.NewParameterValue()
 					query := request.URL.Query()
 					query.Add(existingKey, existingValue)
 					request.URL.RawQuery = query.Encode()
@@ -152,7 +152,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the parameter even if there are already parameters with the same key", func() {
-					existingValue := testHTTP.NewParameterValue()
+					existingValue := testHttp.NewParameterValue()
 					query := request.URL.Query()
 					query.Add(key, existingValue)
 					request.URL.RawQuery = query.Encode()
@@ -169,8 +169,8 @@ var _ = Describe("Mutator", func() {
 
 		BeforeEach(func() {
 			parameters = map[string]string{}
-			for index := rand.Intn(3); index >= 0; index-- {
-				parameters[testHTTP.NewParameterKey()] = testHTTP.NewParameterValue()
+			for index := test.RandomIntFromRange(0, 3); index >= 0; index-- {
+				parameters[testHttp.NewParameterKey()] = testHttp.NewParameterValue()
 			}
 		})
 
@@ -196,7 +196,7 @@ var _ = Describe("Mutator", func() {
 				var request *http.Request
 
 				BeforeEach(func() {
-					request = testHTTP.NewRequest()
+					request = testHttp.NewRequest()
 				})
 
 				It("returns an error if the request is missing", func() {
@@ -204,7 +204,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("returns an error if a key is missing", func() {
-					mutator.Parameters[""] = testHTTP.NewParameterValue()
+					mutator.Parameters[""] = testHttp.NewParameterValue()
 					Expect(mutator.MutateRequest(request)).To(MatchError("key is missing"))
 				})
 
@@ -217,8 +217,8 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the parameters even if there are already parameters", func() {
-					existingKey := testHTTP.NewParameterKey()
-					existingValue := testHTTP.NewParameterValue()
+					existingKey := testHttp.NewParameterKey()
+					existingValue := testHttp.NewParameterValue()
 					query := request.URL.Query()
 					query.Add(existingKey, existingValue)
 					request.URL.RawQuery = query.Encode()
@@ -235,7 +235,7 @@ var _ = Describe("Mutator", func() {
 					for existingKey = range parameters {
 						break
 					}
-					existingValue := testHTTP.NewParameterValue()
+					existingValue := testHttp.NewParameterValue()
 					query := request.URL.Query()
 					query.Add(existingKey, existingValue)
 					request.URL.RawQuery = query.Encode()
@@ -246,6 +246,95 @@ var _ = Describe("Mutator", func() {
 							Expect(request.URL.Query()).To(HaveKeyWithValue(key, []string{existingValue, value}))
 						} else {
 							Expect(request.URL.Query()).To(HaveKeyWithValue(key, []string{value}))
+						}
+					}
+				})
+			})
+		})
+	})
+
+	Context("ArrayParametersMutator", func() {
+		var parameters map[string][]string
+
+		BeforeEach(func() {
+			parameters = map[string][]string{}
+			for index := test.RandomIntFromRange(0, 3); index >= 0; index-- {
+				parameters[testHttp.NewParameterKey()] = test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(1, 3, testHttp.NewParameterValue)
+			}
+		})
+
+		Context("NewArrayParametersMutator", func() {
+			It("returns successfully", func() {
+				Expect(request.NewArrayParametersMutator(parameters)).ToNot(BeNil())
+			})
+		})
+
+		Context("with new parameters mutator", func() {
+			var mutator *request.ArrayParametersMutator
+
+			BeforeEach(func() {
+				mutator = request.NewArrayParametersMutator(parameters)
+				Expect(mutator).ToNot(BeNil())
+			})
+
+			It("remembers the parameters", func() {
+				Expect(mutator.Parameters).To(Equal(parameters))
+			})
+
+			Context("MutateRequest", func() {
+				var request *http.Request
+
+				BeforeEach(func() {
+					request = testHttp.NewRequest()
+				})
+
+				It("returns an error if the request is missing", func() {
+					Expect(mutator.MutateRequest(nil)).To(MatchError("request is missing"))
+				})
+
+				It("returns an error if a key is missing", func() {
+					mutator.Parameters[""] = test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(1, 3, testHttp.NewParameterValue)
+					Expect(mutator.MutateRequest(request)).To(MatchError("key is missing"))
+				})
+
+				It("adds the parameters", func() {
+					Expect(mutator.MutateRequest(request)).To(Succeed())
+					Expect(request.URL.Query()).To(HaveLen(len(parameters)))
+					for key, value := range parameters {
+						Expect(request.URL.Query()).To(HaveKeyWithValue(key, value))
+					}
+				})
+
+				It("adds the parameters even if there are already parameters", func() {
+					existingKey := testHttp.NewParameterKey()
+					existingValue := test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(1, 3, testHttp.NewParameterValue)
+					query := request.URL.Query()
+					query[existingKey] = existingValue
+					request.URL.RawQuery = query.Encode()
+					Expect(mutator.MutateRequest(request)).To(Succeed())
+					Expect(request.URL.Query()).To(HaveLen(1 + len(parameters)))
+					Expect(request.URL.Query()).To(HaveKeyWithValue(existingKey, existingValue))
+					for key, value := range parameters {
+						Expect(request.URL.Query()).To(HaveKeyWithValue(key, value))
+					}
+				})
+
+				It("adds the parameters even if there are already parameters with the same key", func() {
+					var existingKey string
+					for existingKey = range parameters {
+						break
+					}
+					existingValue := test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(1, 3, testHttp.NewParameterValue)
+					query := request.URL.Query()
+					query[existingKey] = existingValue
+					request.URL.RawQuery = query.Encode()
+					Expect(mutator.MutateRequest(request)).To(Succeed())
+					Expect(request.URL.Query()).To(HaveLen(len(parameters)))
+					for key, value := range parameters {
+						if key == existingKey {
+							Expect(request.URL.Query()).To(HaveKeyWithValue(key, append(existingValue, value...)))
+						} else {
+							Expect(request.URL.Query()).To(HaveKeyWithValue(key, value))
 						}
 					}
 				})

--- a/request/request.go
+++ b/request/request.go
@@ -36,6 +36,14 @@ func IsStatusCodeSuccess(statusCode int) bool {
 	return statusCode >= 200 && statusCode <= 299
 }
 
+func IsStatusCodeRedirection(statusCode int) bool {
+	return statusCode >= 300 && statusCode <= 399
+}
+
+func IsStatusCodeClientError(statusCode int) bool {
+	return statusCode >= 400 && statusCode <= 499
+}
+
 type Method string
 
 const (

--- a/request/responder.go
+++ b/request/responder.go
@@ -69,8 +69,10 @@ func (r *Responder) Bytes(statusCode int, bytes []byte, mutators ...ResponseMuta
 		r.InternalServerError(err)
 	} else {
 		r.res.WriteHeader(statusCode)
-		if _, err = r.res.(http.ResponseWriter).Write(bytes); err != nil {
-			log.LoggerFromContext(r.req.Context()).WithError(err).Error("Unable to write bytes")
+		if bytesWritten, writeErr := r.res.(http.ResponseWriter).Write(bytes); writeErr != nil {
+			log.LoggerFromContext(r.req.Context()).WithError(writeErr).Error("Unable to write bytes")
+		} else if bytesLength := len(bytes); bytesWritten != bytesLength {
+			log.LoggerFromContext(r.req.Context()).WithFields(log.Fields{"bytesWritten": bytesWritten, "bytesLength": bytesLength}).Error("Bytes written does not equal bytes length")
 		}
 	}
 }

--- a/request/test/response_inspector.go
+++ b/request/test/response_inspector.go
@@ -1,0 +1,38 @@
+package test
+
+import "net/http"
+
+type ResponseInspector struct {
+	InspectResponseInvocations int
+	InspectResponseInputs      []*http.Response
+	InspectResponseStub        func(res *http.Response) error
+	InspectResponseOutputs     []error
+	InspectResponseOutput      *error
+}
+
+func NewResponseInspector() *ResponseInspector {
+	return &ResponseInspector{}
+}
+
+func (r *ResponseInspector) InspectResponse(res *http.Response) error {
+	r.InspectResponseInvocations++
+	r.InspectResponseInputs = append(r.InspectResponseInputs, res)
+	if r.InspectResponseStub != nil {
+		return r.InspectResponseStub(res)
+	}
+	if len(r.InspectResponseOutputs) > 0 {
+		output := r.InspectResponseOutputs[0]
+		r.InspectResponseOutputs = r.InspectResponseOutputs[1:]
+		return output
+	}
+	if r.InspectResponseOutput != nil {
+		return *r.InspectResponseOutput
+	}
+	panic("InspectResponse has no output")
+}
+
+func (r *ResponseInspector) AssertOutputsEmpty() {
+	if len(r.InspectResponseOutputs) > 0 {
+		panic("InspectResponseOutputs is not empty")
+	}
+}

--- a/request/values_parser.go
+++ b/request/values_parser.go
@@ -1,7 +1,6 @@
 package request
 
 import (
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -13,15 +12,15 @@ import (
 
 type Values struct {
 	base   *structureBase.Base
-	values *url.Values
+	values *map[string][]string
 	parsed map[string]int
 }
 
-func NewValues(values *url.Values) *Values {
+func NewValues(values *map[string][]string) *Values {
 	return NewValuesParser(structureBase.New().WithSource(structure.NewParameterSource()), values)
 }
 
-func NewValuesParser(base *structureBase.Base, values *url.Values) *Values {
+func NewValuesParser(base *structureBase.Base, values *map[string][]string) *Values {
 	var parsed map[string]int
 	if values != nil {
 		parsed = make(map[string]int, len(*values))


### PR DESCRIPTION
* Add client response inspectors
* Ensure client data responses uses expected application/json content type header
* Parse client response body for actual error, default to standard error from status code
* Forcible drain client response body under all conditions
* Add ArrayParametersMutator for adding headers with multiple string values
* Update request values parser to handle generic map
* Add request ParseDigestMD5Header, ParseMediaTypeHeader, and ParseIntHeader
* Add request IsStatusCodeRedirection and IsStatusCodeClientError
* Log any failure or short write during responder response write

@jh-bate