### PR TITLE
Log any error with request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Log any error with request
 * Remove duplicate Dexcom device alert settings
 * Allow insulin data type without dose
 * Rename ErrorValueBoolean* to ErrorValueBool* for consistency

--- a/request/request.go
+++ b/request/request.go
@@ -162,3 +162,47 @@ func TraceSessionFromContext(ctx context.Context) string {
 	}
 	return ""
 }
+
+const contextErrorContextKey contextKey = "context-error"
+
+type ContextError struct {
+	err error
+}
+
+func NewContextError() *ContextError {
+	return &ContextError{}
+}
+
+func (c *ContextError) Get() error {
+	return c.err
+}
+
+func (c *ContextError) Set(err error) {
+	c.err = err
+}
+
+func NewContextWithContextError(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextErrorContextKey, NewContextError())
+}
+
+func ContextErrorFromContext(ctx context.Context) *ContextError {
+	if ctx != nil {
+		if contextError, ok := ctx.Value(contextErrorContextKey).(*ContextError); ok {
+			return contextError
+		}
+	}
+	return nil
+}
+
+func GetErrorFromContext(ctx context.Context) error {
+	if contextError := ContextErrorFromContext(ctx); contextError != nil {
+		return contextError.Get()
+	}
+	return nil
+}
+
+func SetErrorToContext(ctx context.Context, err error) {
+	if contextError := ContextErrorFromContext(ctx); contextError != nil {
+		contextError.Set(err)
+	}
+}

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -4,6 +4,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"context"
+
 	"github.com/ant0ine/go-json-rest/rest"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
@@ -63,6 +65,107 @@ var _ = Describe("Request", func() {
 			result, err := request.DecodeRequestPathParameter(req, key, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(value))
+		})
+	})
+
+	Context("ContextError", func() {
+		Context("NewContextError", func() {
+			It("return successfully", func() {
+				Expect(request.NewContextError()).ToNot(BeNil())
+			})
+		})
+
+		Context("with context error", func() {
+			var contextError *request.ContextError
+
+			BeforeEach(func() {
+				contextError = request.NewContextError()
+				Expect(contextError).ToNot(BeNil())
+			})
+
+			It("does not have an error by default", func() {
+				Expect(contextError.Get()).To(BeNil())
+			})
+
+			Context("Get", func() {
+				It("returns the error", func() {
+					err := errorsTest.NewError()
+					contextError.Set(err)
+					Expect(contextError.Get()).To(Equal(err))
+				})
+			})
+
+			Context("Set", func() {
+				It("set the error", func() {
+					err := errorsTest.NewError()
+					contextError.Set(err)
+					Expect(contextError.Get()).To(Equal(err))
+				})
+			})
+		})
+
+		Context("with context", func() {
+			var ctx context.Context
+
+			BeforeEach(func() {
+				ctx = context.Background()
+			})
+
+			Context("NewContextWithContextError", func() {
+				It("returns a context with a context error", func() {
+					Expect(request.ContextErrorFromContext(request.NewContextWithContextError(ctx))).ToNot(BeNil())
+				})
+			})
+
+			Context("ContextErrorFromContext", func() {
+				It("returns nil if it does not exist in the context", func() {
+					Expect(request.ContextErrorFromContext(ctx)).To(BeNil())
+				})
+
+				It("returns the context error if it exists in the context", func() {
+					Expect(request.ContextErrorFromContext(request.NewContextWithContextError(ctx))).ToNot(BeNil())
+				})
+			})
+
+			Context("Get", func() {
+				It("returns nil", func() {
+					request.SetErrorToContext(ctx, errorsTest.NewError())
+					Expect(request.GetErrorFromContext(ctx)).To(BeNil())
+				})
+			})
+
+			Context("Set", func() {
+				It("does not set the error", func() {
+					request.SetErrorToContext(ctx, errorsTest.NewError())
+					Expect(request.GetErrorFromContext(ctx)).To(BeNil())
+				})
+			})
+
+			Context("with context error", func() {
+				BeforeEach(func() {
+					ctx = request.NewContextWithContextError(ctx)
+				})
+
+				It("does not have an error by default", func() {
+					Expect(request.GetErrorFromContext(ctx)).To(BeNil())
+				})
+
+				Context("Get", func() {
+					It("returns the error", func() {
+						err := errorsTest.NewError()
+						request.SetErrorToContext(ctx, err)
+						Expect(request.GetErrorFromContext(ctx)).To(Equal(err))
+					})
+				})
+
+				Context("Set", func() {
+					It("set the error", func() {
+						err := errorsTest.NewError()
+						request.SetErrorToContext(ctx, err)
+						Expect(request.GetErrorFromContext(ctx)).To(Equal(err))
+					})
+				})
+			})
 		})
 	})
 })

--- a/request/responder.go
+++ b/request/responder.go
@@ -110,8 +110,7 @@ func (r *Responder) Error(statusCode int, err error, mutators ...ResponseMutator
 	if err == nil {
 		r.InternalServerError(errors.New("error is missing"))
 	} else {
-		// FUTURE: service.SetRequestErrors(r.req, errs) rather than logger statement below
-		log.LoggerFromContext(r.req.Context()).WithError(err).Warn("Failure during request")
+		SetErrorToContext(r.req.Context(), err)
 		if bytes, marshalErr := json.Marshal(errors.Sanitize(err)); marshalErr != nil {
 			r.InternalServerError(errors.Wrap(marshalErr, "unable to serialize error"))
 		} else {

--- a/service/api/api.go
+++ b/service/api/api.go
@@ -47,6 +47,10 @@ func (a *API) InitializeMiddleware() error {
 	if err != nil {
 		return err
 	}
+	errorMiddleware, err := middleware.NewError()
+	if err != nil {
+		return err
+	}
 	traceMiddleware, err := middleware.NewTrace()
 	if err != nil {
 		return err
@@ -71,17 +75,16 @@ func (a *API) InitializeMiddleware() error {
 
 	middlewareStack := []rest.Middleware{
 		loggerMiddleware,
+		errorMiddleware,
 		traceMiddleware,
 		accessLogMiddleware,
 		statusMiddleware,
 		timerMiddleware,
 		recorderMiddleware,
-		// recoverMiddleware,
+		recoverMiddleware,
 		authMiddleware,
 		gzipMiddleware,
 	}
-
-	_ = recoverMiddleware
 
 	a.api.Use(middlewareStack...)
 

--- a/service/middleware/access_log.go
+++ b/service/middleware/access_log.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ant0ine/go-json-rest/rest"
 
+	"github.com/tidepool-org/platform/request"
 	"github.com/tidepool-org/platform/service"
 )
 
@@ -89,7 +90,7 @@ func (a *AccessLog) MiddlewareFunc(handler rest.HandlerFunc) rest.HandlerFunc {
 				// TODO: Log this to a special logger level "access".
 				// Will need to revamp log package, though.
 
-				logger.WithFields(loggerFields).Warn(message)
+				logger.WithError(request.GetErrorFromContext(req.Context())).WithFields(loggerFields).Warn(message)
 			}
 		}
 	}

--- a/service/middleware/error.go
+++ b/service/middleware/error.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"github.com/ant0ine/go-json-rest/rest"
+
+	"github.com/tidepool-org/platform/request"
+)
+
+type Error struct{}
+
+func NewError() (*Error, error) {
+	return &Error{}, nil
+}
+
+func (e *Error) MiddlewareFunc(handler rest.HandlerFunc) rest.HandlerFunc {
+	return func(res rest.ResponseWriter, req *rest.Request) {
+		if handler != nil && res != nil && req != nil {
+			oldRequest := req.Request
+			defer func() {
+				req.Request = oldRequest
+			}()
+			req.Request = req.WithContext(request.NewContextWithContextError(req.Context()))
+
+			handler(res, req)
+		}
+	}
+}

--- a/service/middleware/error_test.go
+++ b/service/middleware/error_test.go
@@ -1,0 +1,60 @@
+package middleware_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/ant0ine/go-json-rest/rest"
+
+	"github.com/tidepool-org/platform/request"
+	serviceMiddleware "github.com/tidepool-org/platform/service/middleware"
+	testRest "github.com/tidepool-org/platform/test/rest"
+)
+
+var _ = Describe("Error", func() {
+	Context("NewError", func() {
+		It("returns successfully", func() {
+			Expect(serviceMiddleware.NewError()).ToNot(BeNil())
+		})
+	})
+
+	Context("with middleware, request, response, and handler", func() {
+		var middleware *serviceMiddleware.Error
+		var req *rest.Request
+		var res *testRest.ResponseWriter
+		var hndlr rest.HandlerFunc
+
+		BeforeEach(func() {
+			var err error
+			middleware, err = serviceMiddleware.NewError()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(middleware).ToNot(BeNil())
+			req = testRest.NewRequest()
+			res = testRest.NewResponseWriter()
+			hndlr = func(res rest.ResponseWriter, req *rest.Request) {
+				Expect(request.ContextErrorFromContext(req.Context())).ToNot(BeNil())
+			}
+		})
+
+		AfterEach(func() {
+			Expect(request.ContextErrorFromContext(req.Context())).To(BeNil())
+			res.AssertOutputsEmpty()
+		})
+
+		It("is successful", func() {
+			middleware.MiddlewareFunc(hndlr)(res, req)
+		})
+
+		It("does nothing if the handler is nil", func() {
+			middleware.MiddlewareFunc(nil)(res, req)
+		})
+
+		It("does nothing if the response is nil", func() {
+			middleware.MiddlewareFunc(hndlr)(nil, req)
+		})
+
+		It("does nothing if the request is nil", func() {
+			middleware.MiddlewareFunc(hndlr)(res, nil)
+		})
+	})
+})


### PR DESCRIPTION
@jh-bate Add context to store any request errors and log those errors out when logging request access log entry.