### PR TITLE
Use pointers for data set fields to match upload fields

### DIFF
--- a/.golintignore
+++ b/.golintignore
@@ -6,9 +6,9 @@
 ./data/data_set.go:85:6: type name will be used as data.DataSetClient by other packages, and that stutters; consider calling this SetClient
 ./data/data_set.go:112:6: type name will be used as data.DataSetFilter by other packages, and that stutters; consider calling this SetFilter
 ./data/data_set.go:141:6: type name will be used as data.DataSetCreate by other packages, and that stutters; consider calling this SetCreate
-./data/data_set.go:219:6: type name will be used as data.DataSetUpdate by other packages, and that stutters; consider calling this SetUpdate
-./data/data_set.go:287:6: type name will be used as data.DataSet by other packages, and that stutters; consider calling this Set
-./data/data_set.go:329:6: type name will be used as data.DataSets by other packages, and that stutters; consider calling this Sets
+./data/data_set.go:205:6: type name will be used as data.DataSetUpdate by other packages, and that stutters; consider calling this SetUpdate
+./data/data_set.go:273:6: type name will be used as data.DataSet by other packages, and that stutters; consider calling this Set
+./data/data_set.go:315:6: type name will be used as data.DataSets by other packages, and that stutters; consider calling this Sets
 ./data/data_source.go:20:6: type name will be used as data.DataSourceAccessor by other packages, and that stutters; consider calling this SourceAccessor
 ./data/data_source.go:34:6: func name will be used as data.DataSourceStates by other packages, and that stutters; consider calling this SourceStates
 ./data/data_source.go:42:6: type name will be used as data.DataSourceFilter by other packages, and that stutters; consider calling this SourceFilter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Use pointers for data set fields to match upload fields
 * Log any error with request
 * Remove duplicate Dexcom device alert settings
 * Allow insulin data type without dose

--- a/data/data_set.go
+++ b/data/data_set.go
@@ -140,17 +140,17 @@ func (d *DataSetFilter) MutateRequest(req *http.Request) error {
 
 type DataSetCreate struct {
 	Client              *DataSetClient `json:"client,omitempty"`
-	DataSetType         string         `json:"dataSetType,omitempty"`
-	DeviceID            string         `json:"deviceId,omitempty"`
-	DeviceManufacturers []string       `json:"deviceManufacturers,omitempty"`
-	DeviceModel         string         `json:"deviceModel,omitempty"`
-	DeviceSerialNumber  string         `json:"deviceSerialNumber,omitempty"`
-	DeviceTags          []string       `json:"deviceTags,omitempty"`
-	Time                time.Time      `json:"time,omitempty"`
+	DataSetType         *string        `json:"dataSetType,omitempty"`
+	DeviceID            *string        `json:"deviceId,omitempty"`
+	DeviceManufacturers *[]string      `json:"deviceManufacturers,omitempty"`
+	DeviceModel         *string        `json:"deviceModel,omitempty"`
+	DeviceSerialNumber  *string        `json:"deviceSerialNumber,omitempty"`
+	DeviceTags          *[]string      `json:"deviceTags,omitempty"`
+	Time                *time.Time     `json:"time,omitempty"`
 	Type                string         `json:"type,omitempty"`
-	TimeProcessing      string         `json:"timeProcessing,omitempty"`
+	TimeProcessing      *string        `json:"timeProcessing,omitempty"`
 	TimeZoneName        *string        `json:"timezone,omitempty"`
-	TimeZoneOffset      int            `json:"timezoneOffset,omitempty"`
+	TimeZoneOffset      *int           `json:"timezoneOffset,omitempty"`
 }
 
 func NewDataSetCreate() *DataSetCreate {
@@ -165,55 +165,41 @@ func (d *DataSetCreate) Parse(parser structure.ObjectParser) {
 		d.Client.Parse(clientParser)
 		clientParser.NotParsed()
 	}
-	if ptr := parser.String("dataSetType"); ptr != nil {
-		d.DataSetType = *ptr
-	}
-	if ptr := parser.String("deviceId"); ptr != nil {
-		d.DeviceID = *ptr
-	}
-	if ptr := parser.StringArray("deviceManufacturers"); ptr != nil {
-		d.DeviceManufacturers = *ptr
-	}
-	if ptr := parser.String("deviceModel"); ptr != nil {
-		d.DeviceModel = *ptr
-	}
-	if ptr := parser.String("deviceSerialNumber"); ptr != nil {
-		d.DeviceSerialNumber = *ptr
-	}
-	if ptr := parser.StringArray("deviceTags"); ptr != nil {
-		d.DeviceTags = *ptr
-	}
-	if ptr := parser.Time("time", TimeFormat); ptr != nil {
-		d.Time = *ptr
-	}
-	if ptr := parser.String("timeProcessing"); ptr != nil {
-		d.TimeProcessing = *ptr
-	}
+	d.DataSetType = parser.String("dataSetType")
+	d.DeviceID = parser.String("deviceId")
+	d.DeviceManufacturers = parser.StringArray("deviceManufacturers")
+	d.DeviceModel = parser.String("deviceModel")
+	d.DeviceSerialNumber = parser.String("deviceSerialNumber")
+	d.DeviceTags = parser.StringArray("deviceTags")
+	d.Time = parser.Time("time", TimeFormat)
+	d.TimeProcessing = parser.String("timeProcessing")
 	d.TimeZoneName = parser.String("timezone")
-	if ptr := parser.Int("timezoneOffset"); ptr != nil {
-		d.TimeZoneOffset = *ptr
-	}
+	d.TimeZoneOffset = parser.Int("timezoneOffset")
 }
 
 func (d *DataSetCreate) Validate(validator structure.Validator) {
 	if d.Client != nil {
 		d.Client.Validate(validator.WithReference("client"))
 	}
-	validator.String("dataSetType", &d.DataSetType).OneOf(DataSetTypes()...)
-	validator.String("deviceId", &d.DeviceID).NotEmpty()
-	validator.StringArray("deviceManufacturers", &d.DeviceManufacturers).NotEmpty()
-	validator.String("deviceModel", &d.DeviceModel).NotEmpty()
-	validator.String("deviceSerialNumber", &d.DeviceSerialNumber).NotEmpty()
-	validator.StringArray("deviceTags", &d.DeviceTags).NotEmpty().EachOneOf(DeviceTags()...)
-	validator.Time("time", &d.Time).NotZero()
-	validator.String("timeProcessing", &d.TimeProcessing).OneOf(TimeProcessings()...)
+	validator.String("dataSetType", d.DataSetType).OneOf(DataSetTypes()...)
+	validator.String("deviceId", d.DeviceID).NotEmpty()
+	validator.StringArray("deviceManufacturers", d.DeviceManufacturers).NotEmpty()
+	validator.String("deviceModel", d.DeviceModel).NotEmpty()
+	validator.String("deviceSerialNumber", d.DeviceSerialNumber).NotEmpty()
+	validator.StringArray("deviceTags", d.DeviceTags).NotEmpty().EachOneOf(DeviceTags()...)
+	validator.Time("time", d.Time).NotZero()
+	validator.String("timeProcessing", d.TimeProcessing).OneOf(TimeProcessings()...)
 	validator.String("timezone", d.TimeZoneName).OneOf(zone.Names()...)
-	validator.Int("timezoneOffset", &d.TimeZoneOffset).InRange(-12*60, 14*60)
+	validator.Int("timezoneOffset", d.TimeZoneOffset).InRange(-12*60, 14*60)
 }
 
 func (d *DataSetCreate) Normalize(normalizer structure.Normalizer) {
-	sort.Strings(d.DeviceManufacturers)
-	sort.Strings(d.DeviceTags)
+	if d.DeviceManufacturers != nil {
+		sort.Strings(*d.DeviceManufacturers)
+	}
+	if d.DeviceTags != nil {
+		sort.Strings(*d.DeviceTags)
+	}
 }
 
 type DataSetUpdate struct {
@@ -287,41 +273,41 @@ var setIDExpression = regexp.MustCompile("^(upid_[0-9a-f]{12}|upid_[0-9a-f]{32}|
 type DataSet struct {
 	Active              bool                    `json:"-" bson:"_active"`
 	Annotations         *BlobArray              `json:"annotations,omitempty" bson:"annotations,omitempty"`
-	ArchivedDataSetID   string                  `json:"-" bson:"archivedDatasetId,omitempty"`
-	ArchivedTime        string                  `json:"-" bson:"archivedTime,omitempty"`
+	ArchivedDataSetID   *string                 `json:"-" bson:"archivedDatasetId,omitempty"`
+	ArchivedTime        *string                 `json:"-" bson:"archivedTime,omitempty"`
 	ByUser              *string                 `json:"byUser,omitempty" bson:"byUser,omitempty"`
 	Client              *DataSetClient          `json:"client,omitempty" bson:"client,omitempty"`
 	ClockDriftOffset    *int                    `json:"clockDriftOffset,omitempty" bson:"clockDriftOffset,omitempty"`
 	ComputerTime        *string                 `json:"computerTime,omitempty" bson:"computerTime,omitempty"`
 	ConversionOffset    *int                    `json:"conversionOffset,omitempty" bson:"conversionOffset,omitempty"`
-	CreatedTime         string                  `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
-	CreatedUserID       string                  `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
+	CreatedTime         *string                 `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
+	CreatedUserID       *string                 `json:"createdUserId,omitempty" bson:"createdUserId,omitempty"`
 	DataSetType         *string                 `json:"dataSetType,omitempty" bson:"dataSetType,omitempty"`
-	DataState           string                  `json:"-" bson:"_dataState,omitempty"` // TODO: Deprecated DataState (after data migration)
+	DataState           *string                 `json:"-" bson:"_dataState,omitempty"` // TODO: Deprecated DataState (after data migration)
 	Deduplicator        *DeduplicatorDescriptor `json:"-" bson:"_deduplicator,omitempty"`
-	DeletedTime         string                  `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
-	DeletedUserID       string                  `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
+	DeletedTime         *string                 `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
+	DeletedUserID       *string                 `json:"deletedUserId,omitempty" bson:"deletedUserId,omitempty"`
 	DeviceID            *string                 `json:"deviceId,omitempty" bson:"deviceId,omitempty"`
 	DeviceManufacturers *[]string               `json:"deviceManufacturers,omitempty" bson:"deviceManufacturers,omitempty"`
 	DeviceModel         *string                 `json:"deviceModel,omitempty" bson:"deviceModel,omitempty"`
 	DeviceSerialNumber  *string                 `json:"deviceSerialNumber,omitempty" bson:"deviceSerialNumber,omitempty"`
 	DeviceTags          *[]string               `json:"deviceTags,omitempty" bson:"deviceTags,omitempty"`
 	DeviceTime          *string                 `json:"deviceTime,omitempty" bson:"deviceTime,omitempty"`
-	GUID                string                  `json:"guid,omitempty" bson:"guid,omitempty"`
-	ID                  string                  `json:"id,omitempty" bson:"id,omitempty"`
-	ModifiedTime        string                  `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
-	ModifiedUserID      string                  `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
+	GUID                *string                 `json:"guid,omitempty" bson:"guid,omitempty"`
+	ID                  *string                 `json:"id,omitempty" bson:"id,omitempty"`
+	ModifiedTime        *string                 `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	ModifiedUserID      *string                 `json:"modifiedUserId,omitempty" bson:"modifiedUserId,omitempty"`
 	Payload             *Blob                   `json:"payload,omitempty" bson:"payload,omitempty"`
 	SchemaVersion       int                     `json:"-" bson:"_schemaVersion,omitempty"`
 	Source              *string                 `json:"source,omitempty" bson:"source,omitempty"`
-	State               string                  `json:"-" bson:"_state,omitempty"`
+	State               *string                 `json:"-" bson:"_state,omitempty"`
 	Time                *string                 `json:"time,omitempty" bson:"time,omitempty"`
 	TimeProcessing      *string                 `json:"timeProcessing,omitempty" bson:"timeProcessing,omitempty"`
 	TimeZoneName        *string                 `json:"timezone,omitempty" bson:"timezone,omitempty"`
 	TimeZoneOffset      *int                    `json:"timezoneOffset,omitempty" bson:"timezoneOffset,omitempty"`
 	Type                string                  `json:"type,omitempty" bson:"type,omitempty"`
-	UploadID            string                  `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
-	UserID              string                  `json:"-" bson:"_userId,omitempty"`
+	UploadID            *string                 `json:"uploadId,omitempty" bson:"uploadId,omitempty"`
+	UserID              *string                 `json:"-" bson:"_userId,omitempty"`
 	Version             *string                 `json:"version,omitempty" bson:"version,omitempty"`
 	VersionInternal     int                     `json:"-" bson:"_version,omitempty"`
 }

--- a/data/service/api/v1/data_set.go
+++ b/data/service/api/v1/data_set.go
@@ -114,7 +114,7 @@ func GetDataSet(dataServiceContext dataService.Context) {
 		return
 	}
 
-	if !details.IsService() && details.UserID() != dataSet.UserID {
+	if !details.IsService() && details.UserID() != *dataSet.UserID {
 		request.MustNewResponder(res, req).Error(http.StatusForbidden, request.ErrorUnauthorized())
 		return
 	}

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -251,7 +251,7 @@ func (t *TaskRunner) getDataSource() error {
 
 func (t *TaskRunner) updateDataSourceWithDataSet(dataSet *data.DataSet) error {
 	dataSourceUpdate := data.NewDataSourceUpdate()
-	dataSourceUpdate.DataSetIDs = pointer.FromStringArray(append(t.dataSource.DataSetIDs, dataSet.UploadID))
+	dataSourceUpdate.DataSetIDs = pointer.FromStringArray(append(t.dataSource.DataSetIDs, *dataSet.UploadID))
 	return t.updateDataSource(dataSourceUpdate)
 }
 
@@ -342,7 +342,7 @@ func (t *TaskRunner) updateDataSet(dataSetUpdate *data.DataSetUpdate) error {
 		return nil
 	}
 
-	dataSet, err := t.DataClient().UpdateDataSet(t.context, t.dataSet.UploadID, dataSetUpdate)
+	dataSet, err := t.DataClient().UpdateDataSet(t.context, *t.dataSet.UploadID, dataSetUpdate)
 	if err != nil {
 		return errors.Wrap(err, "unable to update data set")
 	} else if dataSet == nil {
@@ -621,14 +621,14 @@ func (t *TaskRunner) createDataSet(deviceInfo *DeviceInfo) (*data.DataSet, error
 		Name:    pointer.FromString(DataSetClientName),
 		Version: pointer.FromString(DataSetClientVersion),
 	}
-	dataSetCreate.DataSetType = data.DataSetTypeContinuous
-	dataSetCreate.DeviceID = deviceInfo.DeviceID
-	dataSetCreate.DeviceManufacturers = []string{"Dexcom"}
-	dataSetCreate.DeviceModel = deviceInfo.DeviceModel
-	dataSetCreate.DeviceSerialNumber = deviceInfo.DeviceSerialNumber
-	dataSetCreate.DeviceTags = []string{data.DeviceTagCGM}
-	dataSetCreate.Time = time.Now().Truncate(time.Second)
-	dataSetCreate.TimeProcessing = upload.TimeProcessingNone
+	dataSetCreate.DataSetType = pointer.FromString(data.DataSetTypeContinuous)
+	dataSetCreate.DeviceID = pointer.FromString(deviceInfo.DeviceID)
+	dataSetCreate.DeviceManufacturers = pointer.FromStringArray([]string{"Dexcom"})
+	dataSetCreate.DeviceModel = pointer.FromString(deviceInfo.DeviceModel)
+	dataSetCreate.DeviceSerialNumber = pointer.FromString(deviceInfo.DeviceSerialNumber)
+	dataSetCreate.DeviceTags = pointer.FromStringArray([]string{data.DeviceTagCGM})
+	dataSetCreate.Time = pointer.FromTime(time.Now().Truncate(time.Second))
+	dataSetCreate.TimeProcessing = pointer.FromString(upload.TimeProcessingNone)
 
 	dataSet, err := t.DataClient().CreateUserDataSet(t.context, t.providerSession.UserID, dataSetCreate)
 	if err != nil {
@@ -649,7 +649,7 @@ func (t *TaskRunner) storeDatumArray(datumArray []data.Datum) error {
 			endIndex = length
 		}
 
-		if err := t.DataClient().CreateDataSetsData(t.context, t.dataSet.UploadID, datumArray[startIndex:endIndex]); err != nil {
+		if err := t.DataClient().CreateDataSetsData(t.context, *t.dataSet.UploadID, datumArray[startIndex:endIndex]); err != nil {
 			return errors.Wrap(err, "unable to create data set data")
 		}
 


### PR DESCRIPTION
@jh-bate Just use pointers for the fields of the data set structure. Not sure why I originally had these as non-pointers, but I decided (a while back) that use of pointers for almost all fields in any JSON serialized structs made the most sense.