### PR TITLE
Enable new continuous Tidepool Mobile data set

### DIFF
--- a/.golintignore
+++ b/.golintignore
@@ -5,10 +5,10 @@
 ./data/data_set.go:59:6: func name will be used as data.DataSetStates by other packages, and that stutters; consider calling this SetStates
 ./data/data_set.go:85:6: type name will be used as data.DataSetClient by other packages, and that stutters; consider calling this SetClient
 ./data/data_set.go:112:6: type name will be used as data.DataSetFilter by other packages, and that stutters; consider calling this SetFilter
-./data/data_set.go:141:6: type name will be used as data.DataSetCreate by other packages, and that stutters; consider calling this SetCreate
-./data/data_set.go:205:6: type name will be used as data.DataSetUpdate by other packages, and that stutters; consider calling this SetUpdate
-./data/data_set.go:273:6: type name will be used as data.DataSet by other packages, and that stutters; consider calling this Set
-./data/data_set.go:315:6: type name will be used as data.DataSets by other packages, and that stutters; consider calling this Sets
+./data/data_set.go:147:6: type name will be used as data.DataSetCreate by other packages, and that stutters; consider calling this SetCreate
+./data/data_set.go:211:6: type name will be used as data.DataSetUpdate by other packages, and that stutters; consider calling this SetUpdate
+./data/data_set.go:279:6: type name will be used as data.DataSet by other packages, and that stutters; consider calling this Set
+./data/data_set.go:321:6: type name will be used as data.DataSets by other packages, and that stutters; consider calling this Sets
 ./data/data_source.go:20:6: type name will be used as data.DataSourceAccessor by other packages, and that stutters; consider calling this SourceAccessor
 ./data/data_source.go:34:6: func name will be used as data.DataSourceStates by other packages, and that stutters; consider calling this SourceStates
 ./data/data_source.go:42:6: type name will be used as data.DataSourceFilter by other packages, and that stutters; consider calling this SourceFilter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## HEAD
 
+* Enable continuous data set type for Tidepool Mobile
+* Device and time related upload record fields are optional for continuous data set type
+* Add client name to data set filter
 * Use pointers for data set fields to match upload fields
 * Log any error with request
 * Remove duplicate Dexcom device alert settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+## v1.28.0
+
 * Enable continuous data set type for Tidepool Mobile
 * Device and time related upload record fields are optional for continuous data set type
 * Add client name to data set filter

--- a/data/data_set.go
+++ b/data/data_set.go
@@ -110,8 +110,9 @@ func (d *DataSetClient) Validate(validator structure.Validator) {
 }
 
 type DataSetFilter struct {
-	Deleted  *bool   `json:"deleted,omitempty" bson:"deleted,omitempty"`
-	DeviceID *string `json:"deviceId,omitempty" bson:"deviceId,omitempty"`
+	ClientName *string
+	Deleted    *bool
+	DeviceID   *string
 }
 
 func NewDataSetFilter() *DataSetFilter {
@@ -119,16 +120,21 @@ func NewDataSetFilter() *DataSetFilter {
 }
 
 func (d *DataSetFilter) Parse(parser structure.ObjectParser) {
+	d.ClientName = parser.String("client.name")
 	d.Deleted = parser.Bool("deleted")
 	d.DeviceID = parser.String("deviceId")
 }
 
 func (d *DataSetFilter) Validate(validator structure.Validator) {
+	validator.String("client.name", d.ClientName).NotEmpty()
 	validator.String("deviceId", d.DeviceID).NotEmpty()
 }
 
 func (d *DataSetFilter) MutateRequest(req *http.Request) error {
 	parameters := map[string]string{}
+	if d.ClientName != nil {
+		parameters["client.name"] = *d.ClientName
+	}
 	if d.Deleted != nil {
 		parameters["deleted"] = strconv.FormatBool(*d.Deleted)
 	}

--- a/data/service/api/v1/users_datasets_create.go
+++ b/data/service/api/v1/users_datasets_create.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"net/http"
 
-	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/context"
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/parser"
@@ -91,7 +90,6 @@ func UsersDataSetsCreate(dataServiceContext dataService.Context) {
 	}
 
 	dataSet.DataState = pointer.FromString("open") // TODO: Deprecated DataState (after data migration)
-	dataSet.ID = pointer.FromString(data.NewSetID())
 	dataSet.State = pointer.FromString("open")
 
 	if err = dataServiceContext.DataSession().CreateDataSet(ctx, dataSet); err != nil {

--- a/data/storeDEPRECATED/mongo/mongo.go
+++ b/data/storeDEPRECATED/mongo/mongo.go
@@ -374,6 +374,9 @@ func (d *DataSession) ArchiveDeviceDataUsingHashesFromDataSet(ctx context.Contex
 	if err := d.validateDataSet(dataSet); err != nil {
 		return err
 	}
+	if dataSet.DeviceID == nil || *dataSet.DeviceID == "" {
+		return errors.New("data set device id is missing")
+	}
 
 	if d.IsClosed() {
 		return errors.New("session closed")
@@ -424,6 +427,9 @@ func (d *DataSession) UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.Cont
 	}
 	if err := d.validateDataSet(dataSet); err != nil {
 		return err
+	}
+	if dataSet.DeviceID == nil || *dataSet.DeviceID == "" {
+		return errors.New("data set device id is missing")
 	}
 
 	if d.IsClosed() {
@@ -523,6 +529,9 @@ func (d *DataSession) DeleteOtherDataSetData(ctx context.Context, dataSet *uploa
 
 	if err := d.validateDataSet(dataSet); err != nil {
 		return err
+	}
+	if dataSet.DeviceID == nil || *dataSet.DeviceID == "" {
+		return errors.New("data set device id is missing")
 	}
 
 	if d.IsClosed() {
@@ -629,6 +638,9 @@ func (d *DataSession) ListUserDataSets(ctx context.Context, userID string, filte
 		"_userId": userID,
 		"type":    "upload",
 	}
+	if filter.ClientName != nil {
+		selector["client.name"] = *filter.ClientName
+	}
 	if filter.Deleted == nil || !*filter.Deleted {
 		selector["deletedTime"] = bson.M{"$exists": false}
 	}
@@ -700,9 +712,6 @@ func (d *DataSession) validateDataSet(dataSet *upload.Upload) error {
 	}
 	if *dataSet.UploadID == "" {
 		return errors.New("data set upload id is empty")
-	}
-	if dataSet.DeviceID == nil || *dataSet.DeviceID == "" {
-		return errors.New("data set device id is missing")
 	}
 
 	return nil

--- a/data/types/base_test.go
+++ b/data/types/base_test.go
@@ -885,15 +885,6 @@ var _ = Describe("Base", func() {
 					}
 					Expect(datum).To(Equal(expectedDatum))
 				},
-				Entry("guid missing",
-					func(datum *types.Base) { datum.GUID = nil },
-					func(datum *types.Base, expectedDatum *types.Base) {
-						Expect(datum.GUID).ToNot(BeNil())
-						Expect(datum.GUID).ToNot(Equal(expectedDatum.GUID))
-						expectedDatum.GUID = datum.GUID
-						sort.Strings(*expectedDatum.Tags)
-					},
-				),
 				Entry("id missing",
 					func(datum *types.Base) { datum.ID = nil },
 					func(datum *types.Base, expectedDatum *types.Base) {
@@ -916,12 +907,9 @@ var _ = Describe("Base", func() {
 						*datum = types.New("")
 					},
 					func(datum *types.Base, expectedDatum *types.Base) {
-						Expect(datum.GUID).ToNot(BeNil())
-						Expect(datum.GUID).ToNot(Equal(expectedDatum.GUID))
 						Expect(datum.ID).ToNot(BeNil())
 						Expect(datum.ID).ToNot(Equal(expectedDatum.ID))
 						Expect(datum.SchemaVersion).To(Equal(3))
-						expectedDatum.GUID = datum.GUID
 						expectedDatum.ID = datum.ID
 						expectedDatum.SchemaVersion = datum.SchemaVersion
 					},
@@ -945,12 +933,6 @@ var _ = Describe("Base", func() {
 						Expect(datum).To(Equal(expectedDatum))
 					}
 				},
-				Entry("guid missing",
-					func(datum *types.Base) { datum.GUID = nil },
-					func(datum *types.Base, expectedDatum *types.Base) {
-						sort.Strings(*expectedDatum.Tags)
-					},
-				),
 				Entry("id missing",
 					func(datum *types.Base) { datum.ID = nil },
 					func(datum *types.Base, expectedDatum *types.Base) {

--- a/data/types/upload/upload_test.go
+++ b/data/types/upload/upload_test.go
@@ -266,7 +266,6 @@ var _ = Describe("Upload", func() {
 				Entry("device manufacturers missing",
 					func(datum *upload.Upload) { datum.DeviceManufacturers = nil },
 					structure.Origins(),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceManufacturers", NewMeta()),
 				),
 				Entry("device manufacturers empty",
 					func(datum *upload.Upload) { datum.DeviceManufacturers = pointer.FromStringArray([]string{}) },
@@ -303,7 +302,6 @@ var _ = Describe("Upload", func() {
 				Entry("device model missing",
 					func(datum *upload.Upload) { datum.DeviceModel = nil },
 					structure.Origins(),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceModel", NewMeta()),
 				),
 				Entry("device model empty",
 					func(datum *upload.Upload) { datum.DeviceModel = pointer.FromString("") },
@@ -317,7 +315,6 @@ var _ = Describe("Upload", func() {
 				Entry("device serial number missing",
 					func(datum *upload.Upload) { datum.DeviceSerialNumber = nil },
 					structure.Origins(),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceSerialNumber", NewMeta()),
 				),
 				Entry("device serial number empty",
 					func(datum *upload.Upload) { datum.DeviceSerialNumber = pointer.FromString("") },
@@ -331,7 +328,6 @@ var _ = Describe("Upload", func() {
 				Entry("device tags missing",
 					func(datum *upload.Upload) { datum.DeviceTags = nil },
 					structure.Origins(),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceTags", NewMeta()),
 				),
 				Entry("device tags empty",
 					func(datum *upload.Upload) { datum.DeviceTags = pointer.FromStringArray([]string{}) },
@@ -396,7 +392,6 @@ var _ = Describe("Upload", func() {
 				Entry("time processing missing",
 					func(datum *upload.Upload) { datum.TimeProcessing = nil },
 					structure.Origins(),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/timeProcessing", NewMeta()),
 				),
 				Entry("time processing invalid",
 					func(datum *upload.Upload) { datum.TimeProcessing = pointer.FromString("invalid") },
@@ -448,11 +443,11 @@ var _ = Describe("Upload", func() {
 						datum.Client.Version = nil
 						datum.ComputerTime = pointer.FromString("invalid")
 						datum.DataSetType = pointer.FromString("invalid")
-						datum.DeviceManufacturers = nil
-						datum.DeviceModel = nil
-						datum.DeviceSerialNumber = nil
-						datum.DeviceTags = nil
-						datum.TimeProcessing = nil
+						datum.DeviceManufacturers = pointer.FromStringArray([]string{})
+						datum.DeviceModel = pointer.FromString("")
+						datum.DeviceSerialNumber = pointer.FromString("")
+						datum.DeviceTags = pointer.FromStringArray([]string{})
+						datum.TimeProcessing = pointer.FromString("invalid")
 						datum.Version = pointer.FromString("1.23")
 					},
 					structure.Origins(),
@@ -461,11 +456,11 @@ var _ = Describe("Upload", func() {
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/client/version", &types.Meta{Type: "invalidType"}),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringAsTimeNotValid("invalid", "2006-01-02T15:04:05"), "/computerTime", &types.Meta{Type: "invalidType"}),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"continuous", "normal"}), "/dataSetType", &types.Meta{Type: "invalidType"}),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceManufacturers", &types.Meta{Type: "invalidType"}),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceModel", &types.Meta{Type: "invalidType"}),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceSerialNumber", &types.Meta{Type: "invalidType"}),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/deviceTags", &types.Meta{Type: "invalidType"}),
-					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/timeProcessing", &types.Meta{Type: "invalidType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deviceManufacturers", &types.Meta{Type: "invalidType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deviceModel", &types.Meta{Type: "invalidType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deviceSerialNumber", &types.Meta{Type: "invalidType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deviceTags", &types.Meta{Type: "invalidType"}),
+					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"across-the-board-timezone", "none", "utc-bootstrapping"}), "/timeProcessing", &types.Meta{Type: "invalidType"}),
 					testErrors.WithPointerSourceAndMeta(structureValidator.ErrorLengthNotGreaterThanOrEqualTo(4, 5), "/version", &types.Meta{Type: "invalidType"}),
 				),
 			)
@@ -499,7 +494,7 @@ var _ = Describe("Upload", func() {
 					func(datum *upload.Upload) { datum.UploadID = nil },
 					func(datum *upload.Upload, expectedDatum *upload.Upload) {
 						Expect(datum.UploadID).ToNot(BeNil())
-						Expect(*datum.UploadID).ToNot(BeEmpty())
+						Expect(*datum.UploadID).To(Equal(*datum.ID))
 						expectedDatum.UploadID = datum.UploadID
 						sort.Strings(*expectedDatum.DeviceManufacturers)
 						sort.Strings(*expectedDatum.DeviceTags)


### PR DESCRIPTION
@jh-bate Tidepool Mobile is switching over to use a single, continuous data set for all data (rather than hundreds to thousands over a long period of time). Also, Tidepool Mobile will be adding a number of new data types. Thus, some of the previously required fields are now optional. Also, allow data set query to filter on client name (so that Tidepool Mobile can find its one data set).