### PR TITLE
Rename various to more generic form in blob service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Rename various to more generic form in blob service
 * Cleanup blob service and tests
 * Replace blob.NewID with blobTest.RandomID in tests
 * Update error test helper functions

--- a/blob/client/client.go
+++ b/blob/client/client.go
@@ -50,12 +50,12 @@ func (c *Client) List(ctx context.Context, userID string, filter *blob.Filter, p
 	}
 
 	url := c.client.ConstructURL("v1", "users", userID, "blobs")
-	blbs := blob.Blobs{}
-	if err := c.client.RequestData(ctx, http.MethodGet, url, []request.RequestMutator{filter, pagination}, nil, &blbs); err != nil {
+	result := blob.Blobs{}
+	if err := c.client.RequestData(ctx, http.MethodGet, url, []request.RequestMutator{filter, pagination}, nil, &result); err != nil {
 		return nil, err
 	}
 
-	return blbs, nil
+	return result, nil
 }
 
 func (c *Client) Create(ctx context.Context, userID string, create *blob.Create) (*blob.Blob, error) {
@@ -82,12 +82,12 @@ func (c *Client) Create(ctx context.Context, userID string, create *blob.Create)
 	}
 
 	url := c.client.ConstructURL("v1", "users", userID, "blobs")
-	blb := &blob.Blob{}
-	if err := c.client.RequestData(ctx, http.MethodPost, url, mutators, create.Body, blb); err != nil {
+	result := &blob.Blob{}
+	if err := c.client.RequestData(ctx, http.MethodPost, url, mutators, create.Body, result); err != nil {
 		return nil, err
 	}
 
-	return blb, nil
+	return result, nil
 }
 
 func (c *Client) Get(ctx context.Context, id string) (*blob.Blob, error) {
@@ -101,15 +101,15 @@ func (c *Client) Get(ctx context.Context, id string) (*blob.Blob, error) {
 	}
 
 	url := c.client.ConstructURL("v1", "blobs", id)
-	blb := &blob.Blob{}
-	if err := c.client.RequestData(ctx, http.MethodGet, url, nil, nil, blb); err != nil {
+	result := &blob.Blob{}
+	if err := c.client.RequestData(ctx, http.MethodGet, url, nil, nil, result); err != nil {
 		if request.IsErrorResourceNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
 
-	return blb, nil
+	return result, nil
 }
 
 func (c *Client) GetContent(ctx context.Context, id string) (*blob.Content, error) {

--- a/blob/client/client_test.go
+++ b/blob/client/client_test.go
@@ -117,39 +117,39 @@ var _ = Describe("Client", func() {
 
 							It("returns an error when the context is missing", func() {
 								ctx = nil
-								blbs, err := client.List(ctx, userID, filter, pagination)
+								result, err := client.List(ctx, userID, filter, pagination)
 								errorsTest.ExpectEqual(err, errors.New("context is missing"))
-								Expect(blbs).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 
 							It("returns an error when the user id is missing", func() {
 								userID = ""
-								blbs, err := client.List(ctx, userID, filter, pagination)
+								result, err := client.List(ctx, userID, filter, pagination)
 								errorsTest.ExpectEqual(err, errors.New("user id is missing"))
-								Expect(blbs).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 
 							It("returns an error when the user id is invalid", func() {
 								userID = "invalid"
-								blbs, err := client.List(ctx, userID, filter, pagination)
+								result, err := client.List(ctx, userID, filter, pagination)
 								errorsTest.ExpectEqual(err, errors.New("user id is invalid"))
-								Expect(blbs).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 
 							It("returns an error when the filter is invalid", func() {
 								filter = blob.NewFilter()
 								filter.MediaType = pointer.FromStringArray([]string{""})
-								blbs, err := client.List(ctx, userID, filter, pagination)
+								result, err := client.List(ctx, userID, filter, pagination)
 								errorsTest.ExpectEqual(err, errors.New("filter is invalid"))
-								Expect(blbs).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 
 							It("returns an error when the pagination is invalid", func() {
 								pagination = page.NewPagination()
 								pagination.Page = -1
-								blbs, err := client.List(ctx, userID, filter, pagination)
+								result, err := client.List(ctx, userID, filter, pagination)
 								errorsTest.ExpectEqual(err, errors.New("pagination is invalid"))
-								Expect(blbs).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 						})
 
@@ -168,9 +168,9 @@ var _ = Describe("Client", func() {
 								})
 
 								It("returns an error", func() {
-									blbs, err := client.List(ctx, userID, filter, pagination)
+									result, err := client.List(ctx, userID, filter, pagination)
 									errorsTest.ExpectEqual(err, request.ErrorUnauthenticated())
-									Expect(blbs).To(BeNil())
+									Expect(result).To(BeNil())
 								})
 							})
 
@@ -180,48 +180,48 @@ var _ = Describe("Client", func() {
 								})
 
 								It("returns an error", func() {
-									blbs, err := client.List(ctx, userID, filter, pagination)
+									result, err := client.List(ctx, userID, filter, pagination)
 									errorsTest.ExpectEqual(err, request.ErrorUnauthorized())
-									Expect(blbs).To(BeNil())
+									Expect(result).To(BeNil())
 								})
 							})
 
-							When("the server responds with a user not found error", func() {
+							When("the server responds with a not found error", func() {
 								BeforeEach(func() {
 									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNotFound, errors.NewSerializable(request.ErrorResourceNotFoundWithID(userID)), responseHeaders))
 								})
 
 								It("returns an error", func() {
-									blbs, err := client.List(ctx, userID, filter, pagination)
+									result, err := client.List(ctx, userID, filter, pagination)
 									errorsTest.ExpectEqual(err, request.ErrorResourceNotFoundWithID(userID))
-									Expect(blbs).To(BeNil())
+									Expect(result).To(BeNil())
 								})
 							})
 
-							When("the server responds with no blobs", func() {
+							When("the server responds with no result", func() {
 								BeforeEach(func() {
 									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, blob.Blobs{}, responseHeaders))
 								})
 
 								It("returns successfully", func() {
-									blbs, err := client.List(ctx, userID, filter, pagination)
+									result, err := client.List(ctx, userID, filter, pagination)
 									Expect(err).ToNot(HaveOccurred())
-									Expect(blbs).To(Equal(blob.Blobs{}))
+									Expect(result).To(Equal(blob.Blobs{}))
 								})
 							})
 
-							When("the server responds with blobs", func() {
-								var responseBlobs blob.Blobs
+							When("the server responds with result", func() {
+								var responseResult blob.Blobs
 
 								BeforeEach(func() {
-									responseBlobs = blobTest.RandomBlobs(1, 4)
-									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseBlobs, responseHeaders))
+									responseResult = blobTest.RandomBlobs(1, 4)
+									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseResult, responseHeaders))
 								})
 
 								It("returns successfully", func() {
-									blbs, err := client.List(ctx, userID, filter, pagination)
+									result, err := client.List(ctx, userID, filter, pagination)
 									Expect(err).ToNot(HaveOccurred())
-									blobTest.ExpectEqualBlobs(blbs, responseBlobs)
+									blobTest.ExpectEqualBlobs(result, responseResult)
 								})
 							})
 						})
@@ -275,37 +275,37 @@ var _ = Describe("Client", func() {
 
 						It("returns an error when the context is missing", func() {
 							ctx = nil
-							blb, err := client.Create(ctx, userID, create)
+							result, err := client.Create(ctx, userID, create)
 							errorsTest.ExpectEqual(err, errors.New("context is missing"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 
 						It("returns an error when the user id is missing", func() {
 							userID = ""
-							blb, err := client.Create(ctx, userID, create)
+							result, err := client.Create(ctx, userID, create)
 							errorsTest.ExpectEqual(err, errors.New("user id is missing"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 
 						It("returns an error when the user id is invalid", func() {
 							userID = "invalid"
-							blb, err := client.Create(ctx, userID, create)
+							result, err := client.Create(ctx, userID, create)
 							errorsTest.ExpectEqual(err, errors.New("user id is invalid"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 
 						It("returns an error when the create is missing", func() {
 							create = nil
-							blb, err := client.Create(ctx, userID, create)
+							result, err := client.Create(ctx, userID, create)
 							errorsTest.ExpectEqual(err, errors.New("create is missing"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 
 						It("returns an error when the create is invalid", func() {
 							create.Body = nil
-							blb, err := client.Create(ctx, userID, create)
+							result, err := client.Create(ctx, userID, create)
 							errorsTest.ExpectEqual(err, errors.New("create is invalid"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 					})
 
@@ -328,9 +328,9 @@ var _ = Describe("Client", func() {
 								})
 
 								It("returns an error", func() {
-									blb, err := client.Create(ctx, userID, create)
+									result, err := client.Create(ctx, userID, create)
 									errorsTest.ExpectEqual(err, request.ErrorUnauthenticated())
-									Expect(blb).To(BeNil())
+									Expect(result).To(BeNil())
 								})
 							})
 
@@ -340,36 +340,36 @@ var _ = Describe("Client", func() {
 								})
 
 								It("returns an error", func() {
-									blb, err := client.Create(ctx, userID, create)
+									result, err := client.Create(ctx, userID, create)
 									errorsTest.ExpectEqual(err, request.ErrorUnauthorized())
-									Expect(blb).To(BeNil())
+									Expect(result).To(BeNil())
 								})
 							})
 
-							When("the server responds with a user not found error", func() {
+							When("the server responds with a not found error", func() {
 								BeforeEach(func() {
 									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNotFound, errors.NewSerializable(request.ErrorResourceNotFoundWithID(userID)), responseHeaders))
 								})
 
 								It("returns an error", func() {
-									blb, err := client.Create(ctx, userID, create)
+									result, err := client.Create(ctx, userID, create)
 									errorsTest.ExpectEqual(err, request.ErrorResourceNotFoundWithID(userID))
-									Expect(blb).To(BeNil())
+									Expect(result).To(BeNil())
 								})
 							})
 
-							When("the server responds with the blob", func() {
-								var responseBlob *blob.Blob
+							When("the server responds with the result", func() {
+								var responseResult *blob.Blob
 
 								BeforeEach(func() {
-									responseBlob = blobTest.RandomBlob()
-									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseBlob, responseHeaders))
+									responseResult = blobTest.RandomBlob()
+									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseResult, responseHeaders))
 								})
 
 								It("returns successfully", func() {
-									blb, err := client.Create(ctx, userID, create)
+									result, err := client.Create(ctx, userID, create)
 									Expect(err).ToNot(HaveOccurred())
-									blobTest.ExpectEqualBlob(blb, responseBlob)
+									blobTest.ExpectEqualBlob(result, responseResult)
 								})
 							})
 						})
@@ -408,23 +408,23 @@ var _ = Describe("Client", func() {
 
 						It("returns an error when the context is missing", func() {
 							ctx = nil
-							blb, err := client.Get(ctx, id)
+							result, err := client.Get(ctx, id)
 							errorsTest.ExpectEqual(err, errors.New("context is missing"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 
 						It("returns an error when the id is missing", func() {
 							id = ""
-							blb, err := client.Get(ctx, id)
+							result, err := client.Get(ctx, id)
 							errorsTest.ExpectEqual(err, errors.New("id is missing"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 
 						It("returns an error when the id is invalid", func() {
 							id = "invalid"
-							blb, err := client.Get(ctx, id)
+							result, err := client.Get(ctx, id)
 							errorsTest.ExpectEqual(err, errors.New("id is invalid"))
-							Expect(blb).To(BeNil())
+							Expect(result).To(BeNil())
 						})
 					})
 
@@ -443,9 +443,9 @@ var _ = Describe("Client", func() {
 							})
 
 							It("returns an error", func() {
-								blb, err := client.Get(ctx, id)
+								result, err := client.Get(ctx, id)
 								errorsTest.ExpectEqual(err, request.ErrorUnauthenticated())
-								Expect(blb).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 						})
 
@@ -455,9 +455,9 @@ var _ = Describe("Client", func() {
 							})
 
 							It("returns an error", func() {
-								blb, err := client.Get(ctx, id)
+								result, err := client.Get(ctx, id)
 								errorsTest.ExpectEqual(err, request.ErrorUnauthorized())
-								Expect(blb).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 						})
 
@@ -466,25 +466,25 @@ var _ = Describe("Client", func() {
 								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNotFound, errors.NewSerializable(request.ErrorResourceNotFoundWithID(id)), responseHeaders))
 							})
 
-							It("returns successfully without blob", func() {
-								blb, err := client.Get(ctx, id)
+							It("returns successfully without result", func() {
+								result, err := client.Get(ctx, id)
 								Expect(err).ToNot(HaveOccurred())
-								Expect(blb).To(BeNil())
+								Expect(result).To(BeNil())
 							})
 						})
 
-						When("the server responds with the blob", func() {
-							var responseBlob *blob.Blob
+						When("the server responds with the result", func() {
+							var responseResult *blob.Blob
 
 							BeforeEach(func() {
-								responseBlob = blobTest.RandomBlob()
-								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseBlob, responseHeaders))
+								responseResult = blobTest.RandomBlob()
+								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseResult, responseHeaders))
 							})
 
-							It("returns successfully with blob", func() {
-								blb, err := client.Get(ctx, id)
+							It("returns successfully with result", func() {
+								result, err := client.Get(ctx, id)
 								Expect(err).ToNot(HaveOccurred())
-								blobTest.ExpectEqualBlob(blb, responseBlob)
+								blobTest.ExpectEqualBlob(result, responseResult)
 							})
 						})
 					})

--- a/blob/service/api/v1/v1.go
+++ b/blob/service/api/v1/v1.go
@@ -60,12 +60,12 @@ func (r *Router) List(res rest.ResponseWriter, req *rest.Request) {
 		return
 	}
 
-	blbs, err := r.provider.BlobClient().List(req.Context(), userID, filter, pagination)
+	result, err := r.provider.BlobClient().List(req.Context(), userID, filter, pagination)
 	if responder.RespondIfError(err) {
 		return
 	}
 
-	responder.Data(http.StatusOK, blbs)
+	responder.Data(http.StatusOK, result)
 }
 
 func (r *Router) Create(res rest.ResponseWriter, req *rest.Request) {
@@ -98,7 +98,7 @@ func (r *Router) Create(res rest.ResponseWriter, req *rest.Request) {
 	create.DigestMD5 = digestMD5
 	create.MediaType = mediaType
 
-	blb, err := r.provider.BlobClient().Create(req.Context(), userID, create)
+	result, err := r.provider.BlobClient().Create(req.Context(), userID, create)
 	if err != nil {
 		if errors.Code(err) == blob.ErrorCodeDigestsNotEqual {
 			responder.Error(http.StatusBadRequest, err)
@@ -108,7 +108,7 @@ func (r *Router) Create(res rest.ResponseWriter, req *rest.Request) {
 		}
 	}
 
-	responder.Data(http.StatusCreated, blb)
+	responder.Data(http.StatusCreated, result)
 }
 
 func (r *Router) Get(res rest.ResponseWriter, req *rest.Request) {
@@ -122,15 +122,15 @@ func (r *Router) Get(res rest.ResponseWriter, req *rest.Request) {
 		return
 	}
 
-	blb, err := r.provider.BlobClient().Get(req.Context(), id)
+	result, err := r.provider.BlobClient().Get(req.Context(), id)
 	if responder.RespondIfError(err) {
 		return
-	} else if blb == nil {
+	} else if result == nil {
 		responder.Error(http.StatusNotFound, request.ErrorResourceNotFoundWithID(id))
 		return
 	}
 
-	responder.Data(http.StatusOK, blb)
+	responder.Data(http.StatusOK, result)
 }
 
 func (r *Router) GetContent(res rest.ResponseWriter, req *rest.Request) {

--- a/blob/service/api/v1/v1_test.go
+++ b/blob/service/api/v1/v1_test.go
@@ -487,13 +487,13 @@ var _ = Describe("V1", func() {
 									})
 
 									It("responds successfully", func() {
-										blb := blobTest.RandomBlob()
-										client.CreateOutputs = []blobTest.CreateOutput{{Blob: blb, Error: nil}}
+										responseResult := blobTest.RandomBlob()
+										client.CreateOutputs = []blobTest.CreateOutput{{Blob: responseResult, Error: nil}}
 										res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 										handlerFunc(res, req)
 										Expect(res.WriteHeaderInputs).To(Equal([]int{http.StatusCreated}))
 										Expect(res.WriteInputs).To(HaveLen(1))
-										Expect(json.Marshal(blb)).To(MatchJSON(res.WriteInputs[0]))
+										Expect(json.Marshal(responseResult)).To(MatchJSON(res.WriteInputs[0]))
 									})
 								}
 
@@ -619,13 +619,13 @@ var _ = Describe("V1", func() {
 							})
 
 							It("responds successfully", func() {
-								blb := blobTest.RandomBlob()
-								client.GetOutputs = []blobTest.GetOutput{{Blob: blb, Error: nil}}
+								responseResult := blobTest.RandomBlob()
+								client.GetOutputs = []blobTest.GetOutput{{Blob: responseResult, Error: nil}}
 								res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 								handlerFunc(res, req)
 								Expect(res.WriteHeaderInputs).To(Equal([]int{http.StatusOK}))
 								Expect(res.WriteInputs).To(HaveLen(1))
-								Expect(json.Marshal(blb)).To(MatchJSON(res.WriteInputs[0]))
+								Expect(json.Marshal(responseResult)).To(MatchJSON(res.WriteInputs[0]))
 							})
 						})
 					})

--- a/blob/store/structured/mongo/mongo_test.go
+++ b/blob/store/structured/mongo/mongo_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Mongo", func() {
 			})
 		})
 
-		Context("NewBlobsSession", func() {
+		Context("NewSession", func() {
 			It("returns a new session", func() {
 				session = store.NewSession()
 				Expect(session).ToNot(BeNil())
@@ -175,96 +175,96 @@ var _ = Describe("Mongo", func() {
 
 					It("returns an error when the context is missing", func() {
 						ctx = nil
-						blbs, err := session.List(ctx, userID, filter, pagination)
+						result, err := session.List(ctx, userID, filter, pagination)
 						errorsTest.ExpectEqual(err, errors.New("context is missing"))
-						Expect(blbs).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the user id is missing", func() {
 						userID = ""
-						blbs, err := session.List(ctx, userID, filter, pagination)
+						result, err := session.List(ctx, userID, filter, pagination)
 						errorsTest.ExpectEqual(err, errors.New("user id is missing"))
-						Expect(blbs).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the user id is invalid", func() {
 						userID = "invalid"
-						blbs, err := session.List(ctx, userID, filter, pagination)
+						result, err := session.List(ctx, userID, filter, pagination)
 						errorsTest.ExpectEqual(err, errors.New("user id is invalid"))
-						Expect(blbs).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the filter is invalid", func() {
 						filter.MediaType = pointer.FromStringArray([]string{""})
-						blbs, err := session.List(ctx, userID, filter, pagination)
+						result, err := session.List(ctx, userID, filter, pagination)
 						errorsTest.ExpectEqual(err, errors.New("filter is invalid"))
-						Expect(blbs).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the pagination is invalid", func() {
 						pagination.Page = -1
-						blbs, err := session.List(ctx, userID, filter, pagination)
+						result, err := session.List(ctx, userID, filter, pagination)
 						errorsTest.ExpectEqual(err, errors.New("pagination is invalid"))
-						Expect(blbs).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the session is closed", func() {
 						session.Close()
-						blbs, err := session.List(ctx, userID, filter, pagination)
+						result, err := session.List(ctx, userID, filter, pagination)
 						errorsTest.ExpectEqual(err, errors.New("session closed"))
-						Expect(blbs).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					Context("with data", func() {
 						var mediaType string
-						var allBlobs blob.Blobs
+						var allResult blob.Blobs
 
 						BeforeEach(func() {
 							mediaType = netTest.RandomMediaType()
-							allBlobs = blob.Blobs{}
-							for index, randomBlob := range blobTest.RandomBlobs(4, 4) {
+							allResult = blob.Blobs{}
+							for index, randomResult := range blobTest.RandomBlobs(4, 4) {
 								if index < 2 {
-									randomBlob.Status = pointer.FromString(blob.StatusAvailable)
+									randomResult.Status = pointer.FromString(blob.StatusAvailable)
 								} else {
-									randomBlob.Status = pointer.FromString(blob.StatusCreated)
+									randomResult.Status = pointer.FromString(blob.StatusCreated)
 								}
 								if index%2 == 0 {
-									randomBlob.MediaType = pointer.FromString(mediaType)
+									randomResult.MediaType = pointer.FromString(mediaType)
 								}
-								userBlob := blobTest.CloneBlob(randomBlob)
-								userBlob.ID = pointer.FromString(blobTest.RandomID())
-								userBlob.UserID = pointer.FromString(userID)
-								allBlobs = append(allBlobs, randomBlob, userBlob)
+								userResult := blobTest.CloneBlob(randomResult)
+								userResult.ID = pointer.FromString(blobTest.RandomID())
+								userResult.UserID = pointer.FromString(userID)
+								allResult = append(allResult, randomResult, userResult)
 							}
-							rand.Shuffle(len(allBlobs), func(i, j int) { allBlobs[i], allBlobs[j] = allBlobs[j], allBlobs[i] })
-							Expect(mgoCollection.Insert(AsInterfaceArray(allBlobs)...)).To(Succeed())
+							rand.Shuffle(len(allResult), func(i, j int) { allResult[i], allResult[j] = allResult[j], allResult[i] })
+							Expect(mgoCollection.Insert(AsInterfaceArray(allResult)...)).To(Succeed())
 						})
 
-						It("returns no blobs when the user id is unknown", func() {
+						It("returns no result when the user id is unknown", func() {
 							userID = userTest.RandomID()
 							Expect(session.List(ctx, userID, filter, pagination)).To(SatisfyAll(Not(BeNil()), BeEmpty()))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 0})
 						})
 
-						It("returns expected blobs when the filter is missing", func() {
+						It("returns expected result when the filter is missing", func() {
 							filter = nil
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID && *b.Status == blob.StatusAvailable },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "pagination": pagination, "count": 2})
 						})
 
-						It("returns expected blobs when the filter media type is missing", func() {
+						It("returns expected result when the filter media type is missing", func() {
 							filter.MediaType = nil
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID && *b.Status == blob.StatusAvailable },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 2})
 						})
 
-						It("returns expected blobs when the filter media type is specified", func() {
+						It("returns expected result when the filter media type is specified", func() {
 							filter.MediaType = pointer.FromStringArray([]string{netTest.RandomMediaType(), mediaType})
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool {
 									return *b.UserID == userID && *b.MediaType == mediaType && *b.Status == blob.StatusAvailable
 								},
@@ -272,42 +272,42 @@ var _ = Describe("Mongo", func() {
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 1})
 						})
 
-						It("returns expected blobs when the filter status is missing", func() {
+						It("returns expected result when the filter status is missing", func() {
 							filter.Status = nil
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID && *b.Status == blob.StatusAvailable },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 2})
 						})
 
-						It("returns expected blobs when the filter status is set to available", func() {
+						It("returns expected result when the filter status is set to available", func() {
 							filter.Status = pointer.FromStringArray([]string{blob.StatusAvailable})
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID && *b.Status == blob.StatusAvailable },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 2})
 						})
 
-						It("returns expected blobs when the filter status is set to created", func() {
+						It("returns expected result when the filter status is set to created", func() {
 							filter.Status = pointer.FromStringArray([]string{blob.StatusCreated})
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID && *b.Status == blob.StatusCreated },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 2})
 						})
 
-						It("returns expected blobs when the filter status is set to both available and created", func() {
+						It("returns expected result when the filter status is set to both available and created", func() {
 							filter.Status = pointer.FromStringArray(blob.Statuses())
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 4})
 						})
 
-						It("returns expected blobs when the filter media type and status available are specified", func() {
+						It("returns expected result when the filter media type and status available are specified", func() {
 							filter.MediaType = pointer.FromStringArray([]string{netTest.RandomMediaType(), mediaType})
 							filter.Status = pointer.FromStringArray([]string{blob.StatusAvailable})
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool {
 									return *b.UserID == userID && *b.MediaType == mediaType && *b.Status == blob.StatusAvailable
 								},
@@ -315,10 +315,10 @@ var _ = Describe("Mongo", func() {
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 1})
 						})
 
-						It("returns expected blobs when the filter media type and status created are specified", func() {
+						It("returns expected result when the filter media type and status created are specified", func() {
 							filter.MediaType = pointer.FromStringArray([]string{netTest.RandomMediaType(), mediaType})
 							filter.Status = pointer.FromStringArray([]string{blob.StatusCreated})
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool {
 									return *b.UserID == userID && *b.MediaType == mediaType && *b.Status == blob.StatusCreated
 								},
@@ -326,20 +326,20 @@ var _ = Describe("Mongo", func() {
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 1})
 						})
 
-						It("returns expected blobs when the pagination is missing", func() {
+						It("returns expected result when the pagination is missing", func() {
 							filter.Status = pointer.FromStringArray(blob.Statuses())
 							pagination = nil
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID },
 							)))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "count": 4})
 						})
 
-						It("returns expected blobs when the pagination limits blobs", func() {
+						It("returns expected result when the pagination limits result", func() {
 							filter.Status = pointer.FromStringArray(blob.Statuses())
 							pagination.Page = 1
 							pagination.Size = 2
-							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allBlobs,
+							Expect(session.List(ctx, userID, filter, pagination)).To(Equal(SelectAndSort(allResult,
 								func(b *blob.Blob) bool { return *b.UserID == userID },
 							)[2:4]))
 							logger.AssertDebug("List", log.Fields{"userId": userID, "filter": filter, "pagination": pagination, "count": 2})
@@ -356,47 +356,47 @@ var _ = Describe("Mongo", func() {
 
 					It("returns an error when the context is missing", func() {
 						ctx = nil
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						errorsTest.ExpectEqual(err, errors.New("context is missing"))
-						Expect(blb).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the user id is missing", func() {
 						userID = ""
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						errorsTest.ExpectEqual(err, errors.New("user id is missing"))
-						Expect(blb).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the user id is invalid", func() {
 						userID = "invalid"
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						errorsTest.ExpectEqual(err, errors.New("user id is invalid"))
-						Expect(blb).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the create is missing", func() {
 						create = nil
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						errorsTest.ExpectEqual(err, errors.New("create is missing"))
-						Expect(blb).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the create is invalid", func() {
 						create.MediaType = pointer.FromString("")
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						errorsTest.ExpectEqual(err, errors.New("create is invalid"))
-						Expect(blb).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
 					It("returns an error when the session is closed", func() {
 						session.Close()
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						errorsTest.ExpectEqual(err, errors.New("session closed"))
-						Expect(blb).To(BeNil())
+						Expect(result).To(BeNil())
 					})
 
-					It("returns the blob after creating", func() {
+					It("returns the result after creating", func() {
 						matchAllFields := MatchAllFields(Fields{
 							"ID":           PointTo(Not(BeEmpty())),
 							"UserID":       PointTo(Equal(userID)),
@@ -407,18 +407,18 @@ var _ = Describe("Mongo", func() {
 							"CreatedTime":  PointTo(BeTemporally("~", time.Now(), time.Second)),
 							"ModifiedTime": BeNil(),
 						})
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(blb).ToNot(BeNil())
-						Expect(*blb).To(matchAllFields)
-						blbs := blob.Blobs{}
-						Expect(mgoCollection.Find(bson.M{"id": blb.ID}).All(&blbs)).To(Succeed())
-						Expect(blbs).To(HaveLen(1))
-						Expect(*blbs[0]).To(matchAllFields)
-						logger.AssertDebug("Create", log.Fields{"userId": userID, "create": create, "id": *blbs[0].ID})
+						Expect(result).ToNot(BeNil())
+						Expect(*result).To(matchAllFields)
+						storeResult := blob.Blobs{}
+						Expect(mgoCollection.Find(bson.M{"id": result.ID}).All(&storeResult)).To(Succeed())
+						Expect(storeResult).To(HaveLen(1))
+						Expect(*storeResult[0]).To(matchAllFields)
+						logger.AssertDebug("Create", log.Fields{"userId": userID, "create": create, "id": *storeResult[0].ID})
 					})
 
-					It("returns the blob after creating without media type", func() {
+					It("returns the result after creating without media type", func() {
 						create.MediaType = nil
 						matchAllFields := MatchAllFields(Fields{
 							"ID":           PointTo(Not(BeEmpty())),
@@ -430,15 +430,15 @@ var _ = Describe("Mongo", func() {
 							"CreatedTime":  PointTo(BeTemporally("~", time.Now(), time.Second)),
 							"ModifiedTime": BeNil(),
 						})
-						blb, err := session.Create(ctx, userID, create)
+						result, err := session.Create(ctx, userID, create)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(blb).ToNot(BeNil())
-						Expect(*blb).To(matchAllFields)
-						blbs := blob.Blobs{}
-						Expect(mgoCollection.Find(bson.M{"id": blb.ID}).All(&blbs)).To(Succeed())
-						Expect(blbs).To(HaveLen(1))
-						Expect(*blbs[0]).To(matchAllFields)
-						logger.AssertDebug("Create", log.Fields{"userId": userID, "create": create, "id": *blbs[0].ID})
+						Expect(result).ToNot(BeNil())
+						Expect(*result).To(matchAllFields)
+						storeResult := blob.Blobs{}
+						Expect(mgoCollection.Find(bson.M{"id": result.ID}).All(&storeResult)).To(Succeed())
+						Expect(storeResult).To(HaveLen(1))
+						Expect(*storeResult[0]).To(matchAllFields)
+						logger.AssertDebug("Create", log.Fields{"userId": userID, "create": create, "id": *storeResult[0].ID})
 					})
 				})
 			})
@@ -452,42 +452,42 @@ var _ = Describe("Mongo", func() {
 
 				It("returns an error when the context is missing", func() {
 					ctx = nil
-					blb, err := session.Get(ctx, id)
+					result, err := session.Get(ctx, id)
 					errorsTest.ExpectEqual(err, errors.New("context is missing"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the id is missing", func() {
 					id = ""
-					blb, err := session.Get(ctx, id)
+					result, err := session.Get(ctx, id)
 					errorsTest.ExpectEqual(err, errors.New("id is missing"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the id is invalid", func() {
 					id = "invalid"
-					blb, err := session.Get(ctx, id)
+					result, err := session.Get(ctx, id)
 					errorsTest.ExpectEqual(err, errors.New("id is invalid"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the session is closed", func() {
 					session.Close()
-					blb, err := session.Get(ctx, id)
+					result, err := session.Get(ctx, id)
 					errorsTest.ExpectEqual(err, errors.New("session closed"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				Context("with data", func() {
-					var allBlobs blob.Blobs
-					var blb *blob.Blob
+					var allResult blob.Blobs
+					var result *blob.Blob
 
 					BeforeEach(func() {
-						allBlobs = blobTest.RandomBlobs(4, 4)
-						blb = allBlobs[0]
-						blb.ID = pointer.FromString(id)
-						rand.Shuffle(len(allBlobs), func(i, j int) { allBlobs[i], allBlobs[j] = allBlobs[j], allBlobs[i] })
-						Expect(mgoCollection.Insert(AsInterfaceArray(allBlobs)...)).To(Succeed())
+						allResult = blobTest.RandomBlobs(4, 4)
+						result = allResult[0]
+						result.ID = pointer.FromString(id)
+						rand.Shuffle(len(allResult), func(i, j int) { allResult[i], allResult[j] = allResult[j], allResult[i] })
+						Expect(mgoCollection.Insert(AsInterfaceArray(allResult)...)).To(Succeed())
 					})
 
 					AfterEach(func() {
@@ -499,8 +499,8 @@ var _ = Describe("Mongo", func() {
 						Expect(session.Get(ctx, id)).To(BeNil())
 					})
 
-					It("returns the blob when the id exists", func() {
-						Expect(session.Get(ctx, id)).To(Equal(blb))
+					It("returns the result when the id exists", func() {
+						Expect(session.Get(ctx, id)).To(Equal(result))
 					})
 				})
 			})
@@ -516,78 +516,78 @@ var _ = Describe("Mongo", func() {
 
 				It("returns an error when the context is missing", func() {
 					ctx = nil
-					blb, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, update)
 					errorsTest.ExpectEqual(err, errors.New("context is missing"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the id is missing", func() {
 					id = ""
-					blb, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, update)
 					errorsTest.ExpectEqual(err, errors.New("id is missing"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the id is invalid", func() {
 					id = "invalid"
-					blb, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, update)
 					errorsTest.ExpectEqual(err, errors.New("id is invalid"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the update is missing", func() {
 					update = nil
-					blb, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, update)
 					errorsTest.ExpectEqual(err, errors.New("update is missing"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the update is invalid", func() {
 					update.DigestMD5 = pointer.FromString("")
-					blb, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, update)
 					errorsTest.ExpectEqual(err, errors.New("update is invalid"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the session is closed", func() {
 					session.Close()
-					blb, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, update)
 					errorsTest.ExpectEqual(err, errors.New("session closed"))
-					Expect(blb).To(BeNil())
+					Expect(result).To(BeNil())
 				})
 
 				Context("with data", func() {
-					var originalBlb *blob.Blob
+					var originalResult *blob.Blob
 
 					BeforeEach(func() {
-						originalBlb = blobTest.RandomBlob()
-						originalBlb.ID = pointer.FromString(id)
-						Expect(mgoCollection.Insert(originalBlb)).To(Succeed())
+						originalResult = blobTest.RandomBlob()
+						originalResult.ID = pointer.FromString(id)
+						Expect(mgoCollection.Insert(originalResult)).To(Succeed())
 					})
 
 					AfterEach(func() {
 						logger.AssertDebug("Update", log.Fields{"id": id, "update": update})
 					})
 
-					It("returns updated blob when the id exists", func() {
+					It("returns updated result when the id exists", func() {
 						matchAllFields := MatchAllFields(Fields{
 							"ID":           PointTo(Equal(id)),
-							"UserID":       Equal(originalBlb.UserID),
+							"UserID":       Equal(originalResult.UserID),
 							"DigestMD5":    Equal(update.DigestMD5),
 							"MediaType":    Equal(update.MediaType),
 							"Size":         Equal(update.Size),
 							"Status":       Equal(update.Status),
-							"CreatedTime":  PointTo(Not(BeZero())),
+							"CreatedTime":  Equal(originalResult.CreatedTime),
 							"ModifiedTime": PointTo(BeTemporally("~", time.Now(), time.Second)),
 						})
-						blb, err := session.Update(ctx, id, update)
+						result, err := session.Update(ctx, id, update)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(blb).ToNot(BeNil())
-						Expect(*blb).To(matchAllFields)
-						blbs := blob.Blobs{}
-						Expect(mgoCollection.Find(bson.M{"id": id}).All(&blbs)).To(Succeed())
-						Expect(blbs).To(HaveLen(1))
-						Expect(*blbs[0]).To(matchAllFields)
+						Expect(result).ToNot(BeNil())
+						Expect(*result).To(matchAllFields)
+						storeResult := blob.Blobs{}
+						Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
+						Expect(storeResult).To(HaveLen(1))
+						Expect(*storeResult[0]).To(matchAllFields)
 					})
 
 					It("returns nil when the id does not exist", func() {
@@ -600,8 +600,8 @@ var _ = Describe("Mongo", func() {
 							update = blobStoreStructured.NewUpdate()
 						})
 
-						It("returns original blob when the id exists", func() {
-							Expect(session.Update(ctx, id, update)).To(Equal(originalBlb))
+						It("returns original result when the id exists", func() {
+							Expect(session.Update(ctx, id, update)).To(Equal(originalResult))
 						})
 
 						It("returns nil when the id does not exist", func() {
@@ -648,19 +648,19 @@ var _ = Describe("Mongo", func() {
 				})
 
 				Context("with data", func() {
-					var blb *blob.Blob
+					var result *blob.Blob
 
 					BeforeEach(func() {
-						blb = blobTest.RandomBlob()
-						blb.ID = pointer.FromString(id)
-						Expect(mgoCollection.Insert(blb)).To(Succeed())
+						result = blobTest.RandomBlob()
+						result.ID = pointer.FromString(id)
+						Expect(mgoCollection.Insert(result)).To(Succeed())
 					})
 
 					AfterEach(func() {
 						logger.AssertDebug("Delete", log.Fields{"id": id})
 					})
 
-					It("returns true and deletes the blob when the id exists", func() {
+					It("returns true and deletes the result when the id exists", func() {
 						Expect(session.Delete(ctx, id)).To(BeTrue())
 						Expect(mgoCollection.Find(bson.M{"id": id}).Count()).To(Equal(0))
 					})

--- a/blob/test/blob.go
+++ b/blob/test/blob.go
@@ -127,24 +127,24 @@ func NewObjectFromBlob(datum *blob.Blob, objectFormat test.ObjectFormat) map[str
 	return object
 }
 
-func ExpectEqualBlob(actualBlob *blob.Blob, expectedBlob *blob.Blob) {
-	gomega.Expect(actualBlob).ToNot(gomega.BeNil())
-	gomega.Expect(expectedBlob).ToNot(gomega.BeNil())
-	gomega.Expect(actualBlob.ID).To(gomega.Equal(expectedBlob.ID))
-	gomega.Expect(actualBlob.UserID).To(gomega.Equal(expectedBlob.UserID))
-	gomega.Expect(actualBlob.DigestMD5).To(gomega.Equal(expectedBlob.DigestMD5))
-	gomega.Expect(actualBlob.MediaType).To(gomega.Equal(expectedBlob.MediaType))
-	gomega.Expect(actualBlob.Size).To(gomega.Equal(expectedBlob.Size))
-	gomega.Expect(actualBlob.Status).To(gomega.Equal(expectedBlob.Status))
-	if actualBlob.CreatedTime != nil && expectedBlob.CreatedTime != nil {
-		gomega.Expect(actualBlob.CreatedTime.Local()).To(gomega.Equal(expectedBlob.CreatedTime.Local()))
+func ExpectEqualBlob(actual *blob.Blob, expected *blob.Blob) {
+	gomega.Expect(actual).ToNot(gomega.BeNil())
+	gomega.Expect(expected).ToNot(gomega.BeNil())
+	gomega.Expect(actual.ID).To(gomega.Equal(expected.ID))
+	gomega.Expect(actual.UserID).To(gomega.Equal(expected.UserID))
+	gomega.Expect(actual.DigestMD5).To(gomega.Equal(expected.DigestMD5))
+	gomega.Expect(actual.MediaType).To(gomega.Equal(expected.MediaType))
+	gomega.Expect(actual.Size).To(gomega.Equal(expected.Size))
+	gomega.Expect(actual.Status).To(gomega.Equal(expected.Status))
+	if actual.CreatedTime != nil && expected.CreatedTime != nil {
+		gomega.Expect(actual.CreatedTime.Local()).To(gomega.Equal(expected.CreatedTime.Local()))
 	} else {
-		gomega.Expect(actualBlob.CreatedTime).To(gomega.Equal(expectedBlob.CreatedTime))
+		gomega.Expect(actual.CreatedTime).To(gomega.Equal(expected.CreatedTime))
 	}
-	if actualBlob.ModifiedTime != nil && expectedBlob.ModifiedTime != nil {
-		gomega.Expect(actualBlob.ModifiedTime.Local()).To(gomega.Equal(expectedBlob.ModifiedTime.Local()))
+	if actual.ModifiedTime != nil && expected.ModifiedTime != nil {
+		gomega.Expect(actual.ModifiedTime.Local()).To(gomega.Equal(expected.ModifiedTime.Local()))
 	} else {
-		gomega.Expect(actualBlob.ModifiedTime).To(gomega.Equal(expectedBlob.ModifiedTime))
+		gomega.Expect(actual.ModifiedTime).To(gomega.Equal(expected.ModifiedTime))
 	}
 }
 
@@ -156,9 +156,9 @@ func RandomBlobs(minimumLength int, maximumLength int) blob.Blobs {
 	return datum
 }
 
-func ExpectEqualBlobs(actualBlobs blob.Blobs, expectedBlobs blob.Blobs) {
-	gomega.Expect(actualBlobs).To(gomega.HaveLen(len(expectedBlobs)))
-	for index := range expectedBlobs {
-		ExpectEqualBlob(actualBlobs[index], expectedBlobs[index])
+func ExpectEqualBlobs(actual blob.Blobs, expected blob.Blobs) {
+	gomega.Expect(actual).To(gomega.HaveLen(len(expected)))
+	for index := range expected {
+		ExpectEqualBlob(actual[index], expected[index])
 	}
 }


### PR DESCRIPTION
@jh-bate Simple variable name renames in order to make it more amenable as a template service.