### PR TITLE
Add request condition revision to enforce specific update and delete operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add request condition revision to enforce specific update and delete operations
 * Refactor data source service client into separate package
 * Refactor blob service client into separate package
 * Move EnsureAuthorized functions from user client to auth client

--- a/request/condition.go
+++ b/request/condition.go
@@ -1,0 +1,31 @@
+package request
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/tidepool-org/platform/structure"
+)
+
+type Condition struct {
+	Revision *int
+}
+
+func NewCondition() *Condition {
+	return &Condition{}
+}
+
+func (c *Condition) Parse(parser structure.ObjectParser) {
+	c.Revision = parser.Int("revision")
+}
+
+func (c *Condition) Validate(validator structure.Validator) {
+	validator.Int("revision", c.Revision).GreaterThanOrEqualTo(0)
+}
+
+func (c *Condition) MutateRequest(req *http.Request) error {
+	if c.Revision != nil {
+		return NewParameterMutator("revision", strconv.Itoa(*c.Revision)).MutateRequest(req)
+	}
+	return nil
+}

--- a/request/condition_test.go
+++ b/request/condition_test.go
@@ -1,0 +1,142 @@
+package request_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/tidepool-org/platform/errors"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/request"
+	requestTest "github.com/tidepool-org/platform/request/test"
+	structureParser "github.com/tidepool-org/platform/structure/parser"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/test"
+	testHttp "github.com/tidepool-org/platform/test/http"
+)
+
+var _ = Describe("Condition", func() {
+	Context("NewCondition", func() {
+		It("returns successfully with default values", func() {
+			condition := request.NewCondition()
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Revision).To(BeNil())
+		})
+	})
+
+	Context("Condition", func() {
+		Context("Parse", func() {
+			DescribeTable("parses the datum",
+				func(mutator func(object map[string]interface{}, expectedDatum *request.Condition), expectedErrors ...error) {
+					expectedDatum := requestTest.RandomCondition()
+					object := requestTest.NewObjectFromCondition(expectedDatum, test.ObjectFormatJSON)
+					mutator(object, expectedDatum)
+					datum := &request.Condition{}
+					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					Expect(datum).To(Equal(expectedDatum))
+				},
+				Entry("succeeds",
+					func(object map[string]interface{}, expectedDatum *request.Condition) {},
+				),
+				Entry("revision missing",
+					func(object map[string]interface{}, expectedDatum *request.Condition) {
+						delete(object, "revision")
+						expectedDatum.Revision = nil
+					},
+				),
+				Entry("revision invalid type",
+					func(object map[string]interface{}, expectedDatum *request.Condition) {
+						object["revision"] = true
+						expectedDatum.Revision = nil
+					},
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(true), "/revision"),
+				),
+				Entry("revision valid",
+					func(object map[string]interface{}, expectedDatum *request.Condition) {
+						valid := requestTest.RandomRevision()
+						object["revision"] = valid
+						expectedDatum.Revision = pointer.FromInt(valid)
+					},
+				),
+				Entry("multiple",
+					func(object map[string]interface{}, expectedDatum *request.Condition) {
+						object["revision"] = true
+						expectedDatum.Revision = nil
+					},
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(true), "/revision"),
+				),
+			)
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *request.Condition), expectedErrors ...error) {
+					datum := requestTest.RandomCondition()
+					mutator(datum)
+					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *request.Condition) {},
+				),
+				Entry("revision missing",
+					func(datum *request.Condition) { datum.Revision = nil },
+				),
+				Entry("revision out of range (lower)",
+					func(datum *request.Condition) {
+						datum.Revision = pointer.FromInt(-1)
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/revision"),
+				),
+				Entry("revision in range (lower)",
+					func(datum *request.Condition) {
+						datum.Revision = pointer.FromInt(0)
+					},
+				),
+				Entry("multiple errors",
+					func(datum *request.Condition) {
+						datum.Revision = pointer.FromInt(-1)
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/revision"),
+				),
+			)
+		})
+
+		Context("with new condition", func() {
+			var condition *request.Condition
+
+			BeforeEach(func() {
+				condition = requestTest.RandomCondition()
+			})
+
+			Context("MutateRequest", func() {
+				var req *http.Request
+
+				BeforeEach(func() {
+					req = testHttp.NewRequest()
+				})
+
+				It("returns an error when the request is missing", func() {
+					errorsTest.ExpectEqual(condition.MutateRequest(nil), errors.New("request is missing"))
+				})
+
+				It("sets request query as expected", func() {
+					Expect(condition.MutateRequest(req)).To(Succeed())
+					Expect(req.URL.Query()).To(Equal(url.Values{
+						"revision": []string{strconv.Itoa(*condition.Revision)},
+					}))
+				})
+
+				It("does not set request query when the condition is empty", func() {
+					condition.Revision = nil
+					Expect(condition.MutateRequest(req)).To(Succeed())
+					Expect(req.URL.Query()).To(BeEmpty())
+				})
+			})
+		})
+	})
+})

--- a/request/errors.go
+++ b/request/errors.go
@@ -57,6 +57,13 @@ func ErrorResourceNotFoundWithIDAndRevision(id string, revision int) error {
 	return errors.Preparedf(ErrorCodeResourceNotFound, "resource not found", "revision %d of resource with id %q not found", revision, id)
 }
 
+func ErrorResourceNotFoundWithIDAndOptionalRevision(id string, revision *int) error {
+	if revision != nil {
+		return ErrorResourceNotFoundWithIDAndRevision(id, *revision)
+	}
+	return ErrorResourceNotFoundWithID(id)
+}
+
 func ErrorHeaderMissing(key string) error {
 	return errors.Preparedf(ErrorCodeHeaderMissing, "header is missing", "header %q is missing", key)
 }

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	testHTTP "github.com/tidepool-org/platform/test/http"
 )
@@ -52,6 +53,8 @@ var _ = Describe("Errors", func() {
 		Entry("is ErrorResourceNotFound", request.ErrorResourceNotFound(), "resource-not-found", "resource not found", "resource not found"),
 		Entry("is ErrorResourceNotFoundWithID", request.ErrorResourceNotFoundWithID("test-id"), "resource-not-found", "resource not found", `resource with id "test-id" not found`),
 		Entry("is ErrorResourceNotFoundWithIDAndRevision", request.ErrorResourceNotFoundWithIDAndRevision("test-id", 1), "resource-not-found", "resource not found", `revision 1 of resource with id "test-id" not found`),
+		Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", nil), "resource-not-found", "resource not found", `resource with id "test-id" not found`),
+		Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", pointer.FromInt(1)), "resource-not-found", "resource not found", `revision 1 of resource with id "test-id" not found`),
 		Entry("is ErrorHeaderMissing", request.ErrorHeaderMissing("X-Test-Header"), "header-missing", "header is missing", `header "X-Test-Header" is missing`),
 		Entry("is ErrorHeaderInvalid", request.ErrorHeaderInvalid("X-Test-Header"), "header-invalid", "header is invalid", `header "X-Test-Header" is invalid`),
 		Entry("is ErrorParameterMissing", request.ErrorParameterMissing("test_parameter"), "parameter-missing", "parameter is missing", `parameter "test_parameter" is missing`),
@@ -71,6 +74,8 @@ var _ = Describe("Errors", func() {
 			Entry("is ErrorResourceNotFound", request.ErrorResourceNotFound(), 404),
 			Entry("is ErrorResourceNotFoundWithID", request.ErrorResourceNotFoundWithID("test-id"), 404),
 			Entry("is ErrorResourceNotFoundWithIDAndRevision", request.ErrorResourceNotFoundWithIDAndRevision("test-id", 1), 404),
+			Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", nil), 404),
+			Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", pointer.FromInt(1)), 404),
 			Entry("is another request error", request.ErrorJSONMalformed(), 500),
 			Entry("is another error", errors.New("test-error"), 500),
 			Entry("is nil error", nil, 500),

--- a/request/test/condition.go
+++ b/request/test/condition.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/request"
+	"github.com/tidepool-org/platform/test"
+)
+
+func RandomRevision() int {
+	return test.RandomIntFromRange(0, test.RandomIntMaximum())
+}
+
+func RandomCondition() *request.Condition {
+	datum := &request.Condition{}
+	datum.Revision = pointer.FromInt(RandomRevision())
+	return datum
+}
+
+func NewObjectFromCondition(datum *request.Condition, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Revision != nil {
+		object["revision"] = test.NewObjectFromInt(*datum.Revision, objectFormat)
+	}
+	return object
+}

--- a/store/structured/mongo/mongo.go
+++ b/store/structured/mongo/mongo.go
@@ -185,6 +185,9 @@ func (s *Session) ConstructUpdate(set bson.M, unset bson.M) bson.M {
 		update["$unset"] = unset
 	}
 	if len(update) != 0 {
+		update["$inc"] = bson.M{
+			"revision": 1,
+		}
 		return update
 	}
 	return nil

--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -212,11 +212,11 @@ var _ = Describe("Mongo", func() {
 				Entry("where set is empty and unset is nil", bson.M{}, nil, nil),
 				Entry("where set is nil and unset is empty", nil, bson.M{}, nil),
 				Entry("where set is empty and unset is empty", bson.M{}, bson.M{}, nil),
-				Entry("where set is present and unset is nil", bson.M{"one": "alpha", "two": true}, nil, bson.M{"$set": bson.M{"one": "alpha", "two": true}}),
-				Entry("where set is present and unset is empty", bson.M{"one": "alpha", "two": true}, bson.M{}, bson.M{"$set": bson.M{"one": "alpha", "two": true}}),
-				Entry("where set is nil and unset is present", nil, bson.M{"three": "charlie", "four": false}, bson.M{"$unset": bson.M{"three": "charlie", "four": false}}),
-				Entry("where set is empty and unset is present", bson.M{}, bson.M{"three": "charlie", "four": false}, bson.M{"$unset": bson.M{"three": "charlie", "four": false}}),
-				Entry("where set is empty and unset is present", bson.M{"one": "alpha", "two": true}, bson.M{"three": "charlie", "four": false}, bson.M{"$set": bson.M{"one": "alpha", "two": true}, "$unset": bson.M{"three": "charlie", "four": false}}),
+				Entry("where set is present and unset is nil", bson.M{"one": "alpha", "two": true}, nil, bson.M{"$set": bson.M{"one": "alpha", "two": true}, "$inc": bson.M{"revision": 1}}),
+				Entry("where set is present and unset is empty", bson.M{"one": "alpha", "two": true}, bson.M{}, bson.M{"$set": bson.M{"one": "alpha", "two": true}, "$inc": bson.M{"revision": 1}}),
+				Entry("where set is nil and unset is present", nil, bson.M{"three": "charlie", "four": false}, bson.M{"$unset": bson.M{"three": "charlie", "four": false}, "$inc": bson.M{"revision": 1}}),
+				Entry("where set is empty and unset is present", bson.M{}, bson.M{"three": "charlie", "four": false}, bson.M{"$unset": bson.M{"three": "charlie", "four": false}, "$inc": bson.M{"revision": 1}}),
+				Entry("where set is present and unset is present", bson.M{"one": "alpha", "two": true}, bson.M{"three": "charlie", "four": false}, bson.M{"$set": bson.M{"one": "alpha", "two": true}, "$unset": bson.M{"three": "charlie", "four": false}, "$inc": bson.M{"revision": 1}}),
 			)
 		})
 	})


### PR DESCRIPTION
@jh-bate The request condition (specifically the revision) can be used to prevent two separate process from updating the same resource at the same time. See next PRs for details.