### PR TITLE
Add data source revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add data source revision
 * Add request condition revision to enforce specific update and delete operations
 * Refactor data source service client into separate package
 * Refactor blob service client into separate package

--- a/data/source/service/client/client.go
+++ b/data/source/service/client/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/permission"
+	"github.com/tidepool-org/platform/request"
 )
 
 type Provider interface {
@@ -72,7 +73,7 @@ func (c *Client) Get(ctx context.Context, id string) (*dataSource.Source, error)
 	return result, nil
 }
 
-func (c *Client) Update(ctx context.Context, id string, update *dataSource.Update) (*dataSource.Source, error) {
+func (c *Client) Update(ctx context.Context, id string, condition *request.Condition, update *dataSource.Update) (*dataSource.Source, error) {
 	if err := c.AuthClient().EnsureAuthorizedService(ctx); err != nil {
 		return nil, err
 	}
@@ -80,10 +81,10 @@ func (c *Client) Update(ctx context.Context, id string, update *dataSource.Updat
 	session := c.DataSourceStructuredStore().NewSession()
 	defer session.Close()
 
-	return session.Update(ctx, id, update)
+	return session.Update(ctx, id, condition, update)
 }
 
-func (c *Client) Delete(ctx context.Context, id string) (bool, error) {
+func (c *Client) Delete(ctx context.Context, id string, condition *request.Condition) (bool, error) {
 	if err := c.AuthClient().EnsureAuthorizedService(ctx); err != nil {
 		return false, err
 	}
@@ -91,5 +92,5 @@ func (c *Client) Delete(ctx context.Context, id string) (bool, error) {
 	session := c.DataSourceStructuredStore().NewSession()
 	defer session.Close()
 
-	return session.Delete(ctx, id)
+	return session.Delete(ctx, id, condition)
 }

--- a/data/source/source.go
+++ b/data/source/source.go
@@ -36,8 +36,8 @@ type Accessor interface {
 	List(ctx context.Context, userID string, filter *Filter, pagination *page.Pagination) (Sources, error)
 	Create(ctx context.Context, userID string, create *Create) (*Source, error)
 	Get(ctx context.Context, id string) (*Source, error)
-	Update(ctx context.Context, id string, update *Update) (*Source, error)
-	Delete(ctx context.Context, id string) (bool, error)
+	Update(ctx context.Context, id string, condition *request.Condition, update *Update) (*Source, error)
+	Delete(ctx context.Context, id string, condition *request.Condition) (bool, error)
 }
 
 type Client interface {
@@ -183,6 +183,7 @@ type Source struct {
 	LastImportTime    *time.Time           `json:"lastImportTime,omitempty" bson:"lastImportTime,omitempty"`
 	CreatedTime       *time.Time           `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
 	ModifiedTime      *time.Time           `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	Revision          *int                 `json:"revision,omitempty" bson:"revision,omitempty"`
 }
 
 func (s *Source) Parse(parser structure.ObjectParser) {
@@ -205,6 +206,7 @@ func (s *Source) Parse(parser structure.ObjectParser) {
 	s.LastImportTime = parser.Time("lastImportTime", time.RFC3339)
 	s.CreatedTime = parser.Time("createdTime", time.RFC3339)
 	s.ModifiedTime = parser.Time("modifiedTime", time.RFC3339)
+	s.Revision = parser.Int("revision")
 }
 
 func (s *Source) Validate(validator structure.Validator) {
@@ -223,6 +225,7 @@ func (s *Source) Validate(validator structure.Validator) {
 	validator.Time("lastImportTime", s.LastImportTime).NotZero().BeforeNow(time.Second)
 	validator.Time("createdTime", s.CreatedTime).Exists().NotZero().BeforeNow(time.Second)
 	validator.Time("modifiedTime", s.ModifiedTime).NotZero().After(pointer.ToTime(s.CreatedTime)).BeforeNow(time.Second)
+	validator.Int("revision", s.Revision).Exists().GreaterThanOrEqualTo(0)
 }
 
 func (s *Source) Normalize(normalizer structure.Normalizer) {

--- a/data/source/store/structured/mongo/mongo.go
+++ b/data/source/store/structured/mongo/mongo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/request"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/user"
@@ -150,6 +151,7 @@ func (s *Session) Create(ctx context.Context, userID string, create *dataSource.
 		ProviderSessionID: create.ProviderSessionID,
 		State:             create.State,
 		CreatedTime:       pointer.FromTime(now.Truncate(time.Second)),
+		Revision:          pointer.FromInt(0),
 	}
 
 	var id string
@@ -170,7 +172,7 @@ func (s *Session) Create(ctx context.Context, userID string, create *dataSource.
 		return nil, errors.Wrap(err, "unable to create data source")
 	}
 
-	result, err := s.get(logger, id)
+	result, err := s.get(logger, id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +198,7 @@ func (s *Session) Get(ctx context.Context, id string) (*dataSource.Source, error
 	now := time.Now()
 	logger := log.LoggerFromContext(ctx).WithField("id", id)
 
-	result, err := s.get(logger, id)
+	result, err := s.get(logger, id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +207,7 @@ func (s *Session) Get(ctx context.Context, id string) (*dataSource.Source, error
 	return result, nil
 }
 
-func (s *Session) Update(ctx context.Context, id string, update *dataSource.Update) (*dataSource.Source, error) {
+func (s *Session) Update(ctx context.Context, id string, condition *request.Condition, update *dataSource.Update) (*dataSource.Source, error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")
 	}
@@ -213,6 +215,11 @@ func (s *Session) Update(ctx context.Context, id string, update *dataSource.Upda
 		return nil, errors.New("id is missing")
 	} else if !dataSource.IsValidID(id) {
 		return nil, errors.New("id is invalid")
+	}
+	if condition == nil {
+		condition = request.NewCondition()
+	} else if err := structureValidator.New().Validate(condition); err != nil {
+		return nil, errors.Wrap(err, "condition is invalid")
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
@@ -225,9 +232,15 @@ func (s *Session) Update(ctx context.Context, id string, update *dataSource.Upda
 	}
 
 	now := time.Now()
-	logger := log.LoggerFromContext(ctx).WithFields(log.Fields{"id": id, "update": update})
+	logger := log.LoggerFromContext(ctx).WithFields(log.Fields{"id": id, "condition": condition, "update": update})
 
 	if update.HasUpdates() {
+		query := bson.M{
+			"id": id,
+		}
+		if condition.Revision != nil {
+			query["revision"] = *condition.Revision
+		}
 		set := bson.M{
 			"modifiedTime": pointer.FromTime(now.Truncate(time.Second)),
 		}
@@ -258,25 +271,32 @@ func (s *Session) Update(ctx context.Context, id string, update *dataSource.Upda
 		if update.LastImportTime != nil {
 			set["lastImportTime"] = (*update.LastImportTime).Truncate(time.Second)
 		}
-		changeInfo, err := s.C().UpdateAll(bson.M{"id": id}, s.ConstructUpdate(set, unset))
+		changeInfo, err := s.C().UpdateAll(query, s.ConstructUpdate(set, unset))
 		if err != nil {
 			logger.WithError(err).Error("Unable to update data source")
 			return nil, errors.Wrap(err, "unable to update data source")
+		} else if changeInfo.Matched > 0 {
+			condition = nil
+		} else {
+			update = nil
 		}
 
 		logger = logger.WithField("changeInfo", changeInfo)
 	}
 
-	result, err := s.get(logger, id)
-	if err != nil {
-		return nil, err
+	var result *dataSource.Source
+	if update != nil {
+		var err error
+		if result, err = s.get(logger, id, condition); err != nil {
+			return nil, err
+		}
 	}
 
 	logger.WithField("duration", time.Since(now)/time.Microsecond).Debug("Update")
 	return result, nil
 }
 
-func (s *Session) Delete(ctx context.Context, id string) (bool, error) {
+func (s *Session) Delete(ctx context.Context, id string, condition *request.Condition) (bool, error) {
 	if ctx == nil {
 		return false, errors.New("context is missing")
 	}
@@ -285,15 +305,26 @@ func (s *Session) Delete(ctx context.Context, id string) (bool, error) {
 	} else if !dataSource.IsValidID(id) {
 		return false, errors.New("id is invalid")
 	}
+	if condition == nil {
+		condition = request.NewCondition()
+	} else if err := structureValidator.New().Validate(condition); err != nil {
+		return false, errors.Wrap(err, "condition is invalid")
+	}
 
 	if s.IsClosed() {
 		return false, errors.New("session closed")
 	}
 
 	now := time.Now()
-	logger := log.LoggerFromContext(ctx).WithField("id", id)
+	logger := log.LoggerFromContext(ctx).WithFields(log.Fields{"id": id, "condition": condition})
 
-	changeInfo, err := s.C().RemoveAll(bson.M{"id": id})
+	query := bson.M{
+		"id": id,
+	}
+	if condition.Revision != nil {
+		query["revision"] = *condition.Revision
+	}
+	changeInfo, err := s.C().RemoveAll(query)
 	if err != nil {
 		logger.WithError(err).Error("Unable to delete data source")
 		return false, errors.Wrap(err, "unable to delete data source")
@@ -303,21 +334,34 @@ func (s *Session) Delete(ctx context.Context, id string) (bool, error) {
 	return changeInfo.Removed > 0, nil
 }
 
-func (s *Session) get(logger log.Logger, id string) (*dataSource.Source, error) {
-	result := dataSource.Sources{}
-	err := s.C().Find(bson.M{"id": id}).Limit(2).All(&result)
+func (s *Session) get(logger log.Logger, id string, condition *request.Condition) (*dataSource.Source, error) {
+	results := dataSource.Sources{}
+	query := bson.M{
+		"id": id,
+	}
+	if condition != nil && condition.Revision != nil {
+		query["revision"] = *condition.Revision
+	}
+	err := s.C().Find(query).Limit(2).All(&results)
 	if err != nil {
 		logger.WithError(err).Error("Unable to get data source")
 		return nil, errors.Wrap(err, "unable to get data source")
 	}
 
-	switch len(result) {
+	var result *dataSource.Source
+	switch len(results) {
 	case 0:
 		return nil, nil
 	case 1:
-		return result[0], nil
+		result = results[0]
 	default:
 		logger.Error("Multiple data sources found")
-		return result[0], nil
+		result = results[0]
 	}
+
+	if result.Revision == nil {
+		result.Revision = pointer.FromInt(0)
+	}
+
+	return result, nil
 }

--- a/data/source/store/structured/mongo/mongo_test.go
+++ b/data/source/store/structured/mongo/mongo_test.go
@@ -25,6 +25,8 @@ import (
 	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/request"
+	requestTest "github.com/tidepool-org/platform/request/test"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 	userTest "github.com/tidepool-org/platform/user/test"
@@ -475,6 +477,7 @@ var _ = Describe("Mongo", func() {
 							"LastImportTime":    BeNil(),
 							"CreatedTime":       PointTo(BeTemporally("~", time.Now(), time.Second)),
 							"ModifiedTime":      BeNil(),
+							"Revision":          PointTo(Equal(0)),
 						})
 						result, err := session.Create(ctx, userID, create)
 						Expect(err).ToNot(HaveOccurred())
@@ -533,6 +536,9 @@ var _ = Describe("Mongo", func() {
 						result = allResult[0]
 						result.ID = pointer.FromString(id)
 						rand.Shuffle(len(allResult), func(i, j int) { allResult[i], allResult[j] = allResult[j], allResult[i] })
+					})
+
+					JustBeforeEach(func() {
 						Expect(mgoCollection.Insert(AsInterfaceArray(allResult)...)).To(Succeed())
 					})
 
@@ -548,234 +554,332 @@ var _ = Describe("Mongo", func() {
 					It("returns the result when the id exists", func() {
 						Expect(session.Get(ctx, id)).To(Equal(result))
 					})
+
+					Context("when the revision is missing", func() {
+						BeforeEach(func() {
+							result.Revision = nil
+						})
+
+						It("returns the result with revision 0", func() {
+							result.Revision = pointer.FromInt(0)
+							Expect(session.Get(ctx, id)).To(Equal(result))
+						})
+					})
 				})
 			})
 
 			Context("Update", func() {
 				var id string
+				var condition *request.Condition
 				var update *dataSource.Update
 
 				BeforeEach(func() {
 					id = dataSourceTest.RandomID()
+					condition = requestTest.RandomCondition()
 					update = dataSourceTest.RandomUpdate()
 				})
 
 				It("returns an error when the context is missing", func() {
 					ctx = nil
-					result, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, condition, update)
 					errorsTest.ExpectEqual(err, errors.New("context is missing"))
 					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the id is missing", func() {
 					id = ""
-					result, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, condition, update)
 					errorsTest.ExpectEqual(err, errors.New("id is missing"))
 					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the id is invalid", func() {
 					id = "invalid"
-					result, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, condition, update)
 					errorsTest.ExpectEqual(err, errors.New("id is invalid"))
+					Expect(result).To(BeNil())
+				})
+
+				It("returns an error when the condition is invalid", func() {
+					condition.Revision = pointer.FromInt(-1)
+					result, err := session.Update(ctx, id, condition, update)
+					errorsTest.ExpectEqual(err, errors.New("condition is invalid"))
 					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the update is missing", func() {
 					update = nil
-					result, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, condition, update)
 					errorsTest.ExpectEqual(err, errors.New("update is missing"))
 					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the update is invalid", func() {
 					update.State = pointer.FromString("")
-					result, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, condition, update)
 					errorsTest.ExpectEqual(err, errors.New("update is invalid"))
 					Expect(result).To(BeNil())
 				})
 
 				It("returns an error when the session is closed", func() {
 					session.Close()
-					result, err := session.Update(ctx, id, update)
+					result, err := session.Update(ctx, id, condition, update)
 					errorsTest.ExpectEqual(err, errors.New("session closed"))
 					Expect(result).To(BeNil())
 				})
 
 				Context("with data", func() {
-					var originalResult *dataSource.Source
+					var original *dataSource.Source
 
 					BeforeEach(func() {
-						originalResult = dataSourceTest.RandomSource()
-						originalResult.ID = pointer.FromString(id)
-						Expect(mgoCollection.Insert(originalResult)).To(Succeed())
+						original = dataSourceTest.RandomSource()
+						original.ID = pointer.FromString(id)
+						Expect(mgoCollection.Insert(original)).To(Succeed())
 					})
 
 					AfterEach(func() {
-						logger.AssertDebug("Update", log.Fields{"id": id, "update": update})
+						if condition != nil {
+							logger.AssertDebug("Update", log.Fields{"id": id, "condition": condition, "update": update})
+						} else {
+							logger.AssertDebug("Update", log.Fields{"id": id, "update": update})
+						}
 					})
 
-					It("returns updated result when the id exists and state is connected without error", func() {
-						update.State = pointer.FromString(dataSource.StateConnected)
-						update.Error = nil
-						matchAllFields := MatchAllFields(Fields{
-							"ID":                PointTo(Equal(id)),
-							"UserID":            Equal(originalResult.UserID),
-							"ProviderType":      Equal(originalResult.ProviderType),
-							"ProviderName":      Equal(originalResult.ProviderName),
-							"ProviderSessionID": Equal(originalResult.ProviderSessionID),
-							"State":             Equal(update.State),
-							"Error":             Equal(update.Error),
-							"DataSetIDs":        Equal(update.DataSetIDs),
-							"EarliestDataTime":  Equal(pointer.FromTime(update.EarliestDataTime.Truncate(time.Second))),
-							"LatestDataTime":    Equal(pointer.FromTime(update.LatestDataTime.Truncate(time.Second))),
-							"LastImportTime":    Equal(pointer.FromTime(update.LastImportTime.Truncate(time.Second))),
-							"CreatedTime":       Equal(originalResult.CreatedTime),
-							"ModifiedTime":      PointTo(BeTemporally("~", time.Now(), time.Second)),
-						})
-						result, err := session.Update(ctx, id, update)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(result).ToNot(BeNil())
-						Expect(*result).To(matchAllFields)
-						storeResult := dataSource.Sources{}
-						Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
-						Expect(storeResult).To(HaveLen(1))
-						Expect(*storeResult[0]).To(matchAllFields)
-					})
-
-					It("returns updated result when the id exists and state is disconnected without error", func() {
-						update.State = pointer.FromString(dataSource.StateDisconnected)
-						update.Error = nil
-						matchAllFields := MatchAllFields(Fields{
-							"ID":                PointTo(Equal(id)),
-							"UserID":            Equal(originalResult.UserID),
-							"ProviderType":      Equal(originalResult.ProviderType),
-							"ProviderName":      Equal(originalResult.ProviderName),
-							"ProviderSessionID": BeNil(),
-							"State":             Equal(update.State),
-							"Error":             Equal(update.Error),
-							"DataSetIDs":        Equal(update.DataSetIDs),
-							"EarliestDataTime":  Equal(pointer.FromTime(update.EarliestDataTime.Truncate(time.Second))),
-							"LatestDataTime":    Equal(pointer.FromTime(update.LatestDataTime.Truncate(time.Second))),
-							"LastImportTime":    Equal(pointer.FromTime(update.LastImportTime.Truncate(time.Second))),
-							"CreatedTime":       Equal(originalResult.CreatedTime),
-							"ModifiedTime":      PointTo(BeTemporally("~", time.Now(), time.Second)),
-						})
-						result, err := session.Update(ctx, id, update)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(result).ToNot(BeNil())
-						Expect(*result).To(matchAllFields)
-						storeResult := dataSource.Sources{}
-						Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
-						Expect(storeResult).To(HaveLen(1))
-						Expect(*storeResult[0]).To(matchAllFields)
-					})
-
-					It("returns updated result when the id exists and state is error with error", func() {
-						update.State = pointer.FromString(dataSource.StateConnected)
-						matchAllFields := MatchAllFields(Fields{
-							"ID":                PointTo(Equal(id)),
-							"UserID":            Equal(originalResult.UserID),
-							"ProviderType":      Equal(originalResult.ProviderType),
-							"ProviderName":      Equal(originalResult.ProviderName),
-							"ProviderSessionID": Equal(originalResult.ProviderSessionID),
-							"State":             Equal(update.State),
-							"Error":             Equal(update.Error),
-							"DataSetIDs":        Equal(update.DataSetIDs),
-							"EarliestDataTime":  Equal(pointer.FromTime(update.EarliestDataTime.Truncate(time.Second))),
-							"LatestDataTime":    Equal(pointer.FromTime(update.LatestDataTime.Truncate(time.Second))),
-							"LastImportTime":    Equal(pointer.FromTime(update.LastImportTime.Truncate(time.Second))),
-							"CreatedTime":       Equal(originalResult.CreatedTime),
-							"ModifiedTime":      PointTo(BeTemporally("~", time.Now(), time.Second)),
-						})
-						result, err := session.Update(ctx, id, update)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(result).ToNot(BeNil())
-						Expect(*result).To(matchAllFields)
-						storeResult := dataSource.Sources{}
-						Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
-						Expect(storeResult).To(HaveLen(1))
-						Expect(*storeResult[0]).To(matchAllFields)
-					})
-
-					It("returns nil when the id does not exist", func() {
-						id = dataSourceTest.RandomID()
-						Expect(session.Update(ctx, id, update)).To(BeNil())
-					})
-
-					Context("without updates", func() {
+					When("the condition revision does not match", func() {
 						BeforeEach(func() {
-							update = dataSource.NewUpdate()
+							condition.Revision = pointer.FromInt(*original.Revision + 1)
 						})
 
-						It("returns original result when the id exists", func() {
-							Expect(session.Update(ctx, id, update)).To(Equal(originalResult))
+						It("returns nil", func() {
+							Expect(session.Update(ctx, id, condition, update)).To(BeNil())
+						})
+					})
+
+					updateAssertions := func() {
+						Context("with updates", func() {
+							It("returns updated result when the id exists and state is connected without error", func() {
+								update.State = pointer.FromString(dataSource.StateConnected)
+								update.Error = nil
+								matchAllFields := MatchAllFields(Fields{
+									"ID":                PointTo(Equal(id)),
+									"UserID":            Equal(original.UserID),
+									"ProviderType":      Equal(original.ProviderType),
+									"ProviderName":      Equal(original.ProviderName),
+									"ProviderSessionID": Equal(original.ProviderSessionID),
+									"State":             Equal(update.State),
+									"Error":             Equal(update.Error),
+									"DataSetIDs":        Equal(update.DataSetIDs),
+									"EarliestDataTime":  PointTo(Equal(update.EarliestDataTime.Truncate(time.Second))),
+									"LatestDataTime":    PointTo(Equal(update.LatestDataTime.Truncate(time.Second))),
+									"LastImportTime":    PointTo(Equal(update.LastImportTime.Truncate(time.Second))),
+									"CreatedTime":       Equal(original.CreatedTime),
+									"ModifiedTime":      PointTo(BeTemporally("~", time.Now(), time.Second)),
+									"Revision":          PointTo(Equal(*original.Revision + 1)),
+								})
+								result, err := session.Update(ctx, id, condition, update)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(result).ToNot(BeNil())
+								Expect(*result).To(matchAllFields)
+								storeResult := dataSource.Sources{}
+								Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
+								Expect(storeResult).To(HaveLen(1))
+								Expect(*storeResult[0]).To(matchAllFields)
+							})
+
+							It("returns updated result when the id exists and state is disconnected without error", func() {
+								update.State = pointer.FromString(dataSource.StateDisconnected)
+								update.Error = nil
+								matchAllFields := MatchAllFields(Fields{
+									"ID":                PointTo(Equal(id)),
+									"UserID":            Equal(original.UserID),
+									"ProviderType":      Equal(original.ProviderType),
+									"ProviderName":      Equal(original.ProviderName),
+									"ProviderSessionID": BeNil(),
+									"State":             Equal(update.State),
+									"Error":             Equal(update.Error),
+									"DataSetIDs":        Equal(update.DataSetIDs),
+									"EarliestDataTime":  PointTo(Equal(update.EarliestDataTime.Truncate(time.Second))),
+									"LatestDataTime":    PointTo(Equal(update.LatestDataTime.Truncate(time.Second))),
+									"LastImportTime":    PointTo(Equal(update.LastImportTime.Truncate(time.Second))),
+									"CreatedTime":       Equal(original.CreatedTime),
+									"ModifiedTime":      PointTo(BeTemporally("~", time.Now(), time.Second)),
+									"Revision":          PointTo(Equal(*original.Revision + 1)),
+								})
+								result, err := session.Update(ctx, id, condition, update)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(result).ToNot(BeNil())
+								Expect(*result).To(matchAllFields)
+								storeResult := dataSource.Sources{}
+								Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
+								Expect(storeResult).To(HaveLen(1))
+								Expect(*storeResult[0]).To(matchAllFields)
+							})
+
+							It("returns updated result when the id exists and state is error with error", func() {
+								update.State = pointer.FromString(dataSource.StateConnected)
+								matchAllFields := MatchAllFields(Fields{
+									"ID":                PointTo(Equal(id)),
+									"UserID":            Equal(original.UserID),
+									"ProviderType":      Equal(original.ProviderType),
+									"ProviderName":      Equal(original.ProviderName),
+									"ProviderSessionID": Equal(original.ProviderSessionID),
+									"State":             Equal(update.State),
+									"Error":             Equal(update.Error),
+									"DataSetIDs":        Equal(update.DataSetIDs),
+									"EarliestDataTime":  PointTo(Equal(update.EarliestDataTime.Truncate(time.Second))),
+									"LatestDataTime":    PointTo(Equal(update.LatestDataTime.Truncate(time.Second))),
+									"LastImportTime":    PointTo(Equal(update.LastImportTime.Truncate(time.Second))),
+									"CreatedTime":       Equal(original.CreatedTime),
+									"ModifiedTime":      PointTo(BeTemporally("~", time.Now(), time.Second)),
+									"Revision":          PointTo(Equal(*original.Revision + 1)),
+								})
+								result, err := session.Update(ctx, id, condition, update)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(result).ToNot(BeNil())
+								Expect(*result).To(matchAllFields)
+								storeResult := dataSource.Sources{}
+								Expect(mgoCollection.Find(bson.M{"id": id}).All(&storeResult)).To(Succeed())
+								Expect(storeResult).To(HaveLen(1))
+								Expect(*storeResult[0]).To(matchAllFields)
+							})
+
+							It("returns nil when the id does not exist", func() {
+								id = dataSourceTest.RandomID()
+								Expect(session.Update(ctx, id, condition, update)).To(BeNil())
+							})
 						})
 
-						It("returns nil when the id does not exist", func() {
-							id = dataSourceTest.RandomID()
-							Expect(session.Update(ctx, id, update)).To(BeNil())
+						Context("without updates", func() {
+							BeforeEach(func() {
+								update = dataSource.NewUpdate()
+							})
+
+							It("returns original when the id exists", func() {
+								Expect(session.Update(ctx, id, condition, update)).To(Equal(original))
+							})
+
+							It("returns nil when the id does not exist", func() {
+								id = dataSourceTest.RandomID()
+								Expect(session.Update(ctx, id, condition, update)).To(BeNil())
+							})
 						})
+					}
+
+					When("the condition is missing", func() {
+						BeforeEach(func() {
+							condition = nil
+						})
+
+						updateAssertions()
+					})
+
+					When("the condition revision is missing", func() {
+						BeforeEach(func() {
+							condition.Revision = nil
+						})
+
+						updateAssertions()
+					})
+
+					When("the condition revision matches", func() {
+						BeforeEach(func() {
+							condition.Revision = pointer.CloneInt(original.Revision)
+						})
+
+						updateAssertions()
 					})
 				})
 			})
 
 			Context("Delete", func() {
 				var id string
+				var condition *request.Condition
 
 				BeforeEach(func() {
 					id = dataSourceTest.RandomID()
+					condition = requestTest.RandomCondition()
 				})
 
 				It("returns an error when the context is missing", func() {
 					ctx = nil
-					deleted, err := session.Delete(ctx, id)
+					deleted, err := session.Delete(ctx, id, condition)
 					errorsTest.ExpectEqual(err, errors.New("context is missing"))
 					Expect(deleted).To(BeFalse())
 				})
 
 				It("returns an error when the id is missing", func() {
 					id = ""
-					deleted, err := session.Delete(ctx, id)
+					deleted, err := session.Delete(ctx, id, condition)
 					errorsTest.ExpectEqual(err, errors.New("id is missing"))
 					Expect(deleted).To(BeFalse())
 				})
 
 				It("returns an error when the id is invalid", func() {
 					id = "invalid"
-					deleted, err := session.Delete(ctx, id)
+					deleted, err := session.Delete(ctx, id, condition)
 					errorsTest.ExpectEqual(err, errors.New("id is invalid"))
+					Expect(deleted).To(BeFalse())
+				})
+
+				It("returns an error when the condition is invalid", func() {
+					condition.Revision = pointer.FromInt(-1)
+					deleted, err := session.Delete(ctx, id, condition)
+					errorsTest.ExpectEqual(err, errors.New("condition is invalid"))
 					Expect(deleted).To(BeFalse())
 				})
 
 				It("returns an error when the session is closed", func() {
 					session.Close()
-					deleted, err := session.Delete(ctx, id)
+					deleted, err := session.Delete(ctx, id, condition)
 					errorsTest.ExpectEqual(err, errors.New("session closed"))
 					Expect(deleted).To(BeFalse())
 				})
 
 				Context("with data", func() {
-					var result *dataSource.Source
+					var original *dataSource.Source
 
 					BeforeEach(func() {
-						result = dataSourceTest.RandomSource()
-						result.ID = pointer.FromString(id)
-						Expect(mgoCollection.Insert(result)).To(Succeed())
+						original = dataSourceTest.RandomSource()
+						original.ID = pointer.FromString(id)
+						Expect(mgoCollection.Insert(original)).To(Succeed())
 					})
 
 					AfterEach(func() {
-						logger.AssertDebug("Delete", log.Fields{"id": id})
+						if condition != nil {
+							logger.AssertDebug("Delete", log.Fields{"id": id, "condition": condition})
+						} else {
+							logger.AssertDebug("Delete", log.Fields{"id": id})
+						}
 					})
 
-					It("returns true and deletes the result when the id exists", func() {
-						Expect(session.Delete(ctx, id)).To(BeTrue())
-						Expect(mgoCollection.Find(bson.M{"id": id}).Count()).To(Equal(0))
-					})
-
-					It("returns false when the id does not exist", func() {
+					It("returns false and does not delete the original when the id does not exist", func() {
 						id = dataSourceTest.RandomID()
-						Expect(session.Delete(ctx, id)).To(BeFalse())
+						Expect(session.Delete(ctx, id, condition)).To(BeFalse())
+						Expect(mgoCollection.Find(bson.M{"id": original.ID}).Count()).To(Equal(1))
+					})
+
+					It("returns false and does not delete the original when the id exists, but the condition revision does not match", func() {
+						condition.Revision = pointer.FromInt(*original.Revision + 1)
+						Expect(session.Delete(ctx, id, condition)).To(BeFalse())
+						Expect(mgoCollection.Find(bson.M{"id": original.ID}).Count()).To(Equal(1))
+					})
+
+					It("returns true and deletes the original when the id exists and the condition is missing", func() {
+						condition = nil
+						Expect(session.Delete(ctx, id, condition)).To(BeTrue())
+						Expect(mgoCollection.Find(bson.M{"id": original.ID}).Count()).To(Equal(0))
+					})
+
+					It("returns true and deletes the original when the id exists and the condition revision is missing", func() {
+						condition.Revision = nil
+						Expect(session.Delete(ctx, id, condition)).To(BeTrue())
+						Expect(mgoCollection.Find(bson.M{"id": original.ID}).Count()).To(Equal(0))
+					})
+
+					It("returns true and deletes the original when the id exists and the condition revision matches", func() {
+						condition.Revision = pointer.CloneInt(original.Revision)
+						Expect(session.Delete(ctx, id, condition)).To(BeTrue())
+						Expect(mgoCollection.Find(bson.M{"id": original.ID}).Count()).To(Equal(0))
 					})
 				})
 			})

--- a/data/source/store/structured/test/session.go
+++ b/data/source/store/structured/test/session.go
@@ -5,6 +5,7 @@ import (
 
 	dataSource "github.com/tidepool-org/platform/data/source"
 	"github.com/tidepool-org/platform/page"
+	"github.com/tidepool-org/platform/request"
 	"github.com/tidepool-org/platform/test"
 )
 
@@ -42,9 +43,10 @@ type GetOutput struct {
 }
 
 type UpdateInput struct {
-	Context context.Context
-	ID      string
-	Update  *dataSource.Update
+	Context   context.Context
+	ID        string
+	Condition *request.Condition
+	Update    *dataSource.Update
 }
 
 type UpdateOutput struct {
@@ -53,8 +55,9 @@ type UpdateOutput struct {
 }
 
 type DeleteInput struct {
-	Context context.Context
-	ID      string
+	Context   context.Context
+	ID        string
+	Condition *request.Condition
 }
 
 type DeleteOutput struct {
@@ -81,12 +84,12 @@ type Session struct {
 	GetOutput         *GetOutput
 	UpdateInvocations int
 	UpdateInputs      []UpdateInput
-	UpdateStub        func(ctx context.Context, id string, create *dataSource.Update) (*dataSource.Source, error)
+	UpdateStub        func(ctx context.Context, id string, condition *request.Condition, create *dataSource.Update) (*dataSource.Source, error)
 	UpdateOutputs     []UpdateOutput
 	UpdateOutput      *UpdateOutput
 	DeleteInvocations int
 	DeleteInputs      []DeleteInput
-	DeleteStub        func(ctx context.Context, id string) (bool, error)
+	DeleteStub        func(ctx context.Context, id string, condition *request.Condition) (bool, error)
 	DeleteOutputs     []DeleteOutput
 	DeleteOutput      *DeleteOutput
 }
@@ -148,11 +151,11 @@ func (s *Session) Get(ctx context.Context, id string) (*dataSource.Source, error
 	panic("Get has no output")
 }
 
-func (s *Session) Update(ctx context.Context, id string, update *dataSource.Update) (*dataSource.Source, error) {
+func (s *Session) Update(ctx context.Context, id string, condition *request.Condition, update *dataSource.Update) (*dataSource.Source, error) {
 	s.UpdateInvocations++
-	s.UpdateInputs = append(s.UpdateInputs, UpdateInput{Context: ctx, ID: id, Update: update})
+	s.UpdateInputs = append(s.UpdateInputs, UpdateInput{Context: ctx, ID: id, Condition: condition, Update: update})
 	if s.UpdateStub != nil {
-		return s.UpdateStub(ctx, id, update)
+		return s.UpdateStub(ctx, id, condition, update)
 	}
 	if len(s.UpdateOutputs) > 0 {
 		output := s.UpdateOutputs[0]
@@ -165,11 +168,11 @@ func (s *Session) Update(ctx context.Context, id string, update *dataSource.Upda
 	panic("Update has no output")
 }
 
-func (s *Session) Delete(ctx context.Context, id string) (bool, error) {
+func (s *Session) Delete(ctx context.Context, id string, condition *request.Condition) (bool, error) {
 	s.DeleteInvocations++
-	s.DeleteInputs = append(s.DeleteInputs, DeleteInput{Context: ctx, ID: id})
+	s.DeleteInputs = append(s.DeleteInputs, DeleteInput{Context: ctx, ID: id, Condition: condition})
 	if s.DeleteStub != nil {
-		return s.DeleteStub(ctx, id)
+		return s.DeleteStub(ctx, id, condition)
 	}
 	if len(s.DeleteOutputs) > 0 {
 		output := s.DeleteOutputs[0]

--- a/data/source/test/client.go
+++ b/data/source/test/client.go
@@ -5,6 +5,7 @@ import (
 
 	dataSource "github.com/tidepool-org/platform/data/source"
 	"github.com/tidepool-org/platform/page"
+	"github.com/tidepool-org/platform/request"
 )
 
 type ListInput struct {
@@ -41,9 +42,10 @@ type GetOutput struct {
 }
 
 type UpdateInput struct {
-	Context context.Context
-	UserID  string
-	Update  *dataSource.Update
+	Context   context.Context
+	ID        string
+	Condition *request.Condition
+	Update    *dataSource.Update
 }
 
 type UpdateOutput struct {
@@ -52,8 +54,9 @@ type UpdateOutput struct {
 }
 
 type DeleteInput struct {
-	Context context.Context
-	ID      string
+	Context   context.Context
+	ID        string
+	Condition *request.Condition
 }
 
 type DeleteOutput struct {
@@ -79,12 +82,12 @@ type Client struct {
 	GetOutput         *GetOutput
 	UpdateInvocations int
 	UpdateInputs      []UpdateInput
-	UpdateStub        func(ctx context.Context, userID string, create *dataSource.Update) (*dataSource.Source, error)
+	UpdateStub        func(ctx context.Context, id string, condition *request.Condition, create *dataSource.Update) (*dataSource.Source, error)
 	UpdateOutputs     []UpdateOutput
 	UpdateOutput      *UpdateOutput
 	DeleteInvocations int
 	DeleteInputs      []DeleteInput
-	DeleteStub        func(ctx context.Context, id string) (bool, error)
+	DeleteStub        func(ctx context.Context, id string, condition *request.Condition) (bool, error)
 	DeleteOutputs     []DeleteOutput
 	DeleteOutput      *DeleteOutput
 }
@@ -144,11 +147,11 @@ func (c *Client) Get(ctx context.Context, id string) (*dataSource.Source, error)
 	panic("Get has no output")
 }
 
-func (c *Client) Update(ctx context.Context, userID string, update *dataSource.Update) (*dataSource.Source, error) {
+func (c *Client) Update(ctx context.Context, id string, condition *request.Condition, update *dataSource.Update) (*dataSource.Source, error) {
 	c.UpdateInvocations++
-	c.UpdateInputs = append(c.UpdateInputs, UpdateInput{Context: ctx, UserID: userID, Update: update})
+	c.UpdateInputs = append(c.UpdateInputs, UpdateInput{Context: ctx, ID: id, Condition: condition, Update: update})
 	if c.UpdateStub != nil {
-		return c.UpdateStub(ctx, userID, update)
+		return c.UpdateStub(ctx, id, condition, update)
 	}
 	if len(c.UpdateOutputs) > 0 {
 		output := c.UpdateOutputs[0]
@@ -161,11 +164,11 @@ func (c *Client) Update(ctx context.Context, userID string, update *dataSource.U
 	panic("Update has no output")
 }
 
-func (c *Client) Delete(ctx context.Context, id string) (bool, error) {
+func (c *Client) Delete(ctx context.Context, id string, condition *request.Condition) (bool, error) {
 	c.DeleteInvocations++
-	c.DeleteInputs = append(c.DeleteInputs, DeleteInput{Context: ctx, ID: id})
+	c.DeleteInputs = append(c.DeleteInputs, DeleteInput{Context: ctx, ID: id, Condition: condition})
 	if c.DeleteStub != nil {
-		return c.DeleteStub(ctx, id)
+		return c.DeleteStub(ctx, id, condition)
 	}
 	if len(c.DeleteOutputs) > 0 {
 		output := c.DeleteOutputs[0]

--- a/data/source/test/source.go
+++ b/data/source/test/source.go
@@ -10,6 +10,7 @@ import (
 	dataTest "github.com/tidepool-org/platform/data/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
+	requestTest "github.com/tidepool-org/platform/request/test"
 	"github.com/tidepool-org/platform/test"
 	userTest "github.com/tidepool-org/platform/user/test"
 )
@@ -169,6 +170,7 @@ func RandomSource() *dataSource.Source {
 	datum.LastImportTime = pointer.FromTime(test.RandomTimeFromRange(*datum.LatestDataTime, time.Now()).Truncate(time.Millisecond))
 	datum.CreatedTime = pointer.FromTime(test.RandomTimeFromRange(test.RandomTimeMinimum(), time.Now()).Truncate(time.Second))
 	datum.ModifiedTime = pointer.FromTime(test.RandomTimeFromRange(*datum.CreatedTime, time.Now()).Truncate(time.Second))
+	datum.Revision = pointer.FromInt(requestTest.RandomRevision())
 	return datum
 }
 
@@ -190,6 +192,7 @@ func CloneSource(datum *dataSource.Source) *dataSource.Source {
 	clone.LastImportTime = pointer.CloneTime(datum.LastImportTime)
 	clone.CreatedTime = pointer.CloneTime(datum.CreatedTime)
 	clone.ModifiedTime = pointer.CloneTime(datum.ModifiedTime)
+	clone.Revision = test.CloneInt(datum.Revision)
 	return clone
 }
 
@@ -237,6 +240,9 @@ func NewObjectFromSource(datum *dataSource.Source, objectFormat test.ObjectForma
 	if datum.ModifiedTime != nil {
 		object["modifiedTime"] = test.NewObjectFromTime(*datum.ModifiedTime, objectFormat)
 	}
+	if datum.Revision != nil {
+		object["revision"] = test.NewObjectFromInt(*datum.Revision, objectFormat)
+	}
 	return object
 }
 
@@ -276,6 +282,7 @@ func ExpectEqualSource(actual *dataSource.Source, expected *dataSource.Source) {
 	} else {
 		gomega.Expect(actual.ModifiedTime).To(gomega.Equal(expected.ModifiedTime))
 	}
+	gomega.Expect(actual.Revision).To(gomega.Equal(expected.Revision))
 }
 
 func RandomSources(minimumLength int, maximumLength int) dataSource.Sources {

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -301,7 +301,7 @@ func (t *TaskRunner) updateDataSource(update *dataSource.Update) error {
 		return nil
 	}
 
-	source, err := t.DataSourceClient().Update(t.context, *t.dataSource.ID, update)
+	source, err := t.DataSourceClient().Update(t.context, *t.dataSource.ID, nil, update)
 	if err != nil {
 		return errors.Wrap(err, "unable to update data source")
 	} else if source == nil {

--- a/dexcom/provider/provider.go
+++ b/dexcom/provider/provider.go
@@ -76,7 +76,7 @@ func (p *Provider) OnCreate(ctx context.Context, userID string, providerSessionI
 		update := dataSource.NewUpdate()
 		update.State = pointer.FromString(dataSource.StateConnected)
 
-		source, err = p.dataSourceClient.Update(ctx, *source.ID, update)
+		source, err = p.dataSourceClient.Update(ctx, *source.ID, nil, update)
 		if err != nil {
 			return errors.Wrap(err, "unable to update data source")
 		}
@@ -100,7 +100,7 @@ func (p *Provider) OnCreate(ctx context.Context, userID string, providerSessionI
 
 	_, err = p.taskClient.CreateTask(ctx, taskCreate)
 	if err != nil {
-		p.dataSourceClient.Delete(ctx, *source.ID)
+		p.dataSourceClient.Delete(ctx, *source.ID, nil)
 		return errors.Wrap(err, "unable to create task")
 	}
 
@@ -132,7 +132,7 @@ func (p *Provider) OnDelete(ctx context.Context, userID string, providerSessionI
 		if dataSourceID, ok := task.Data["dataSourceId"].(string); ok && dataSourceID != "" {
 			update := dataSource.NewUpdate()
 			update.State = pointer.FromString(dataSource.StateDisconnected)
-			_, err = p.dataSourceClient.Update(ctx, dataSourceID, update)
+			_, err = p.dataSourceClient.Update(ctx, dataSourceID, nil, update)
 			if err != nil {
 				logger.WithError(err).WithField("dataSourceId", dataSourceID).Error("unable to update data source after deleting provider session")
 			}


### PR DESCRIPTION
@jh-bate Enable the capability to only update/delete a resource if it is at an expected revision. This can prevent two services from modifying the same resource at the same time resulting in potential data loss.