### PR TITLE
Add blob revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Add blob revision
 * Add data source revision
 * Add request condition revision to enforce specific update and delete operations
 * Refactor data source service client into separate package

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -36,7 +36,7 @@ type Client interface {
 	Create(ctx context.Context, userID string, create *Create) (*Blob, error)
 	Get(ctx context.Context, id string) (*Blob, error)
 	GetContent(ctx context.Context, id string) (*Content, error)
-	Delete(ctx context.Context, id string) (bool, error)
+	Delete(ctx context.Context, id string, condition *request.Condition) (bool, error)
 }
 
 type Filter struct {
@@ -116,6 +116,7 @@ type Blob struct {
 	Status       *string    `json:"status,omitempty" bson:"status,omitempty"`
 	CreatedTime  *time.Time `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
 	ModifiedTime *time.Time `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	Revision     *int       `json:"revision,omitempty" bson:"revision,omitempty"`
 }
 
 func (b *Blob) Parse(parser structure.ObjectParser) {
@@ -127,6 +128,7 @@ func (b *Blob) Parse(parser structure.ObjectParser) {
 	b.Status = parser.String("status")
 	b.CreatedTime = parser.Time("createdTime", time.RFC3339)
 	b.ModifiedTime = parser.Time("modifiedTime", time.RFC3339)
+	b.Revision = parser.Int("revision")
 }
 
 func (b *Blob) Validate(validator structure.Validator) {
@@ -138,6 +140,7 @@ func (b *Blob) Validate(validator structure.Validator) {
 	validator.String("status", b.Status).Exists().OneOf(Statuses()...)
 	validator.Time("createdTime", b.CreatedTime).Exists().NotZero().BeforeNow(time.Second)
 	validator.Time("modifiedTime", b.ModifiedTime).NotZero().After(pointer.ToTime(b.CreatedTime)).BeforeNow(time.Second)
+	validator.Int("revision", b.Revision).Exists().GreaterThanOrEqualTo(0)
 }
 
 type Blobs []*Blob

--- a/blob/client/client_test.go
+++ b/blob/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tidepool-org/platform/platform"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
+	requestTest "github.com/tidepool-org/platform/request/test"
 	"github.com/tidepool-org/platform/test"
 	testHttp "github.com/tidepool-org/platform/test/http"
 	userTest "github.com/tidepool-org/platform/user/test"
@@ -155,7 +156,10 @@ var _ = Describe("Client", func() {
 
 						Context("with server response", func() {
 							BeforeEach(func() {
-								requestHandlers = append(requestHandlers, VerifyContentType(""), VerifyBody(nil))
+								requestHandlers = append(requestHandlers,
+									VerifyContentType(""),
+									VerifyBody(nil),
+								)
 							})
 
 							AfterEach(func() {
@@ -315,7 +319,8 @@ var _ = Describe("Client", func() {
 								requestHandlers = append(requestHandlers,
 									VerifyRequest("POST", fmt.Sprintf("/v1/users/%s/blobs", userID)),
 									VerifyContentType(*create.MediaType),
-									VerifyBody(body))
+									VerifyBody(body),
+								)
 							})
 
 							AfterEach(func() {
@@ -430,7 +435,11 @@ var _ = Describe("Client", func() {
 
 					Context("with server response", func() {
 						BeforeEach(func() {
-							requestHandlers = append(requestHandlers, VerifyRequest("GET", fmt.Sprintf("/v1/blobs/%s", id)), VerifyContentType(""), VerifyBody(nil))
+							requestHandlers = append(requestHandlers,
+								VerifyRequest("GET", fmt.Sprintf("/v1/blobs/%s", id)),
+								VerifyContentType(""),
+								VerifyBody(nil),
+							)
 						})
 
 						AfterEach(func() {
@@ -520,7 +529,11 @@ var _ = Describe("Client", func() {
 
 					Context("with server response", func() {
 						BeforeEach(func() {
-							requestHandlers = append(requestHandlers, VerifyRequest("GET", fmt.Sprintf("/v1/blobs/%s/content", id)), VerifyContentType(""), VerifyBody(nil))
+							requestHandlers = append(requestHandlers,
+								VerifyRequest("GET", fmt.Sprintf("/v1/blobs/%s/content", id)),
+								VerifyContentType(""),
+								VerifyBody(nil),
+							)
 						})
 
 						AfterEach(func() {
@@ -630,6 +643,12 @@ var _ = Describe("Client", func() {
 				})
 
 				Context("Delete", func() {
+					var condition *request.Condition
+
+					BeforeEach(func() {
+						condition = requestTest.RandomCondition()
+					})
+
 					Context("without server response", func() {
 						AfterEach(func() {
 							Expect(server.ReceivedRequests()).To(BeEmpty())
@@ -637,82 +656,128 @@ var _ = Describe("Client", func() {
 
 						It("returns an error when the context is missing", func() {
 							ctx = nil
-							deleted, err := client.Delete(ctx, id)
+							deleted, err := client.Delete(ctx, id, condition)
 							errorsTest.ExpectEqual(err, errors.New("context is missing"))
 							Expect(deleted).To(BeFalse())
 						})
 
 						It("returns an error when the id is missing", func() {
 							id = ""
-							deleted, err := client.Delete(ctx, id)
+							deleted, err := client.Delete(ctx, id, condition)
 							errorsTest.ExpectEqual(err, errors.New("id is missing"))
 							Expect(deleted).To(BeFalse())
 						})
 
 						It("returns an error when the id is invalid", func() {
 							id = "invalid"
-							deleted, err := client.Delete(ctx, id)
+							deleted, err := client.Delete(ctx, id, condition)
 							errorsTest.ExpectEqual(err, errors.New("id is invalid"))
+							Expect(deleted).To(BeFalse())
+						})
+
+						It("returns an error when the condition is invalid", func() {
+							condition.Revision = pointer.FromInt(-1)
+							deleted, err := client.Delete(ctx, id, condition)
+							errorsTest.ExpectEqual(err, errors.New("condition is invalid"))
 							Expect(deleted).To(BeFalse())
 						})
 					})
 
-					Context("with server response", func() {
+					deleteAssertions := func() {
+						Context("with server response", func() {
+							AfterEach(func() {
+								Expect(server.ReceivedRequests()).To(HaveLen(1))
+							})
+
+							When("the server responds with an unauthenticated error", func() {
+								BeforeEach(func() {
+									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusUnauthorized, errors.NewSerializable(request.ErrorUnauthenticated()), responseHeaders))
+								})
+
+								It("returns an error", func() {
+									deleted, err := client.Delete(ctx, id, condition)
+									errorsTest.ExpectEqual(err, request.ErrorUnauthenticated())
+									Expect(deleted).To(BeFalse())
+								})
+							})
+
+							When("the server responds with an unauthorized error", func() {
+								BeforeEach(func() {
+									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusForbidden, errors.NewSerializable(request.ErrorUnauthorized()), responseHeaders))
+								})
+
+								It("returns an error", func() {
+									deleted, err := client.Delete(ctx, id, condition)
+									errorsTest.ExpectEqual(err, request.ErrorUnauthorized())
+									Expect(deleted).To(BeFalse())
+								})
+							})
+
+							When("the server responds with a not found error", func() {
+								BeforeEach(func() {
+									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNotFound, errors.NewSerializable(request.ErrorResourceNotFoundWithID(id)), responseHeaders))
+								})
+
+								It("returns successfully with delete false", func() {
+									deleted, err := client.Delete(ctx, id, condition)
+									Expect(err).ToNot(HaveOccurred())
+									Expect(deleted).To(BeFalse())
+								})
+							})
+
+							When("the server responds successfully", func() {
+								BeforeEach(func() {
+									requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNoContent, nil, responseHeaders))
+								})
+
+								It("returns successfully with delete true", func() {
+									deleted, err := client.Delete(ctx, id, condition)
+									Expect(err).ToNot(HaveOccurred())
+									Expect(deleted).To(BeTrue())
+								})
+							})
+						})
+					}
+
+					When("condition is missing", func() {
 						BeforeEach(func() {
-							requestHandlers = append(requestHandlers, VerifyRequest("DELETE", fmt.Sprintf("/v1/blobs/%s", id)), VerifyContentType(""), VerifyBody(nil))
+							condition = nil
+							requestHandlers = append(requestHandlers,
+								VerifyRequest("DELETE", fmt.Sprintf("/v1/blobs/%s", id)),
+								VerifyContentType(""),
+								VerifyBody(nil),
+							)
 						})
 
-						AfterEach(func() {
-							Expect(server.ReceivedRequests()).To(HaveLen(1))
+						deleteAssertions()
+					})
+
+					When("condition revision is missing", func() {
+						BeforeEach(func() {
+							condition.Revision = nil
+							requestHandlers = append(requestHandlers,
+								VerifyRequest("DELETE", fmt.Sprintf("/v1/blobs/%s", id)),
+								VerifyContentType(""),
+								VerifyBody(nil),
+							)
 						})
 
-						When("the server responds with an unauthenticated error", func() {
-							BeforeEach(func() {
-								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusUnauthorized, errors.NewSerializable(request.ErrorUnauthenticated()), responseHeaders))
-							})
+						deleteAssertions()
+					})
 
-							It("returns an error", func() {
-								deleted, err := client.Delete(ctx, id)
-								errorsTest.ExpectEqual(err, request.ErrorUnauthenticated())
-								Expect(deleted).To(BeFalse())
-							})
+					When("condition revision is present", func() {
+						BeforeEach(func() {
+							query := url.Values{
+								"revision": []string{strconv.Itoa(*condition.Revision)},
+							}
+							requestHandlers = append(requestHandlers,
+								VerifyRequest("DELETE", fmt.Sprintf("/v1/blobs/%s", id), query.Encode()),
+								VerifyContentType(""),
+								VerifyBody(nil),
+							)
 						})
 
-						When("the server responds with an unauthorized error", func() {
-							BeforeEach(func() {
-								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusForbidden, errors.NewSerializable(request.ErrorUnauthorized()), responseHeaders))
-							})
-
-							It("returns an error", func() {
-								deleted, err := client.Delete(ctx, id)
-								errorsTest.ExpectEqual(err, request.ErrorUnauthorized())
-								Expect(deleted).To(BeFalse())
-							})
-						})
-
-						When("the server responds with a not found error", func() {
-							BeforeEach(func() {
-								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNotFound, errors.NewSerializable(request.ErrorResourceNotFoundWithID(id)), responseHeaders))
-							})
-
-							It("returns successfully with delete false", func() {
-								deleted, err := client.Delete(ctx, id)
-								Expect(err).ToNot(HaveOccurred())
-								Expect(deleted).To(BeFalse())
-							})
-						})
-
-						When("the server responds successfully", func() {
-							BeforeEach(func() {
-								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusNoContent, nil, responseHeaders))
-							})
-
-							It("returns successfully with delete true", func() {
-								deleted, err := client.Delete(ctx, id)
-								Expect(err).ToNot(HaveOccurred())
-								Expect(deleted).To(BeTrue())
-							})
-						})
+						deleteAssertions()
 					})
 				})
 			})

--- a/blob/service/api/v1/v1.go
+++ b/blob/service/api/v1/v1.go
@@ -180,11 +180,17 @@ func (r *Router) Delete(res rest.ResponseWriter, req *rest.Request) {
 		return
 	}
 
-	exists, err := r.provider.BlobClient().Delete(req.Context(), id)
+	condition := request.NewCondition()
+	if err = request.DecodeRequestQuery(req.Request, condition); err != nil {
+		responder.Error(http.StatusBadRequest, err)
+		return
+	}
+
+	deleted, err := r.provider.BlobClient().Delete(req.Context(), id, condition)
 	if responder.RespondIfError(err) {
 		return
-	} else if !exists {
-		responder.Error(http.StatusNotFound, request.ErrorResourceNotFoundWithID(id))
+	} else if !deleted {
+		responder.Error(http.StatusNotFound, request.ErrorResourceNotFoundWithIDAndOptionalRevision(id, condition.Revision))
 		return
 	}
 

--- a/blob/store/structured/structured.go
+++ b/blob/store/structured/structured.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tidepool-org/platform/crypto"
 	"github.com/tidepool-org/platform/net"
 	"github.com/tidepool-org/platform/page"
+	"github.com/tidepool-org/platform/request"
 	"github.com/tidepool-org/platform/structure"
 )
 
@@ -21,8 +22,8 @@ type Session interface {
 	List(ctx context.Context, userID string, filter *blob.Filter, pagination *page.Pagination) (blob.Blobs, error)
 	Create(ctx context.Context, userID string, create *Create) (*blob.Blob, error)
 	Get(ctx context.Context, id string) (*blob.Blob, error)
-	Update(ctx context.Context, id string, update *Update) (*blob.Blob, error)
-	Delete(ctx context.Context, id string) (bool, error)
+	Update(ctx context.Context, id string, condition *request.Condition, update *Update) (*blob.Blob, error)
+	Delete(ctx context.Context, id string, condition *request.Condition) (bool, error)
 }
 
 type Create struct {

--- a/blob/test/blob.go
+++ b/blob/test/blob.go
@@ -12,6 +12,7 @@ import (
 	cryptoTest "github.com/tidepool-org/platform/crypto/test"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
+	requestTest "github.com/tidepool-org/platform/request/test"
 	"github.com/tidepool-org/platform/test"
 	userTest "github.com/tidepool-org/platform/user/test"
 )
@@ -76,6 +77,7 @@ func RandomBlob() *blob.Blob {
 	if *datum.Status == blob.StatusAvailable {
 		datum.ModifiedTime = pointer.FromTime(test.RandomTimeFromRange(*datum.CreatedTime, time.Now()).Truncate(time.Second))
 	}
+	datum.Revision = pointer.FromInt(requestTest.RandomRevision())
 	return datum
 }
 
@@ -92,6 +94,7 @@ func CloneBlob(datum *blob.Blob) *blob.Blob {
 	clone.Status = pointer.CloneString(datum.Status)
 	clone.CreatedTime = pointer.CloneTime(datum.CreatedTime)
 	clone.ModifiedTime = pointer.CloneTime(datum.ModifiedTime)
+	clone.Revision = test.CloneInt(datum.Revision)
 	return clone
 }
 
@@ -124,6 +127,9 @@ func NewObjectFromBlob(datum *blob.Blob, objectFormat test.ObjectFormat) map[str
 	if datum.ModifiedTime != nil {
 		object["modifiedTime"] = test.NewObjectFromTime(*datum.ModifiedTime, objectFormat)
 	}
+	if datum.Revision != nil {
+		object["revision"] = test.NewObjectFromInt(*datum.Revision, objectFormat)
+	}
 	return object
 }
 
@@ -146,6 +152,7 @@ func ExpectEqualBlob(actual *blob.Blob, expected *blob.Blob) {
 	} else {
 		gomega.Expect(actual.ModifiedTime).To(gomega.Equal(expected.ModifiedTime))
 	}
+	gomega.Expect(actual.Revision).To(gomega.Equal(expected.Revision))
 }
 
 func RandomBlobs(minimumLength int, maximumLength int) blob.Blobs {

--- a/blob/test/client.go
+++ b/blob/test/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tidepool-org/platform/blob"
 	"github.com/tidepool-org/platform/page"
+	"github.com/tidepool-org/platform/request"
 )
 
 type ListInput struct {
@@ -51,8 +52,9 @@ type GetContentOutput struct {
 }
 
 type DeleteInput struct {
-	Context context.Context
-	ID      string
+	Context   context.Context
+	ID        string
+	Condition *request.Condition
 }
 
 type DeleteOutput struct {
@@ -83,7 +85,7 @@ type Client struct {
 	GetContentOutput      *GetContentOutput
 	DeleteInvocations     int
 	DeleteInputs          []DeleteInput
-	DeleteStub            func(ctx context.Context, id string) (bool, error)
+	DeleteStub            func(ctx context.Context, id string, condition *request.Condition) (bool, error)
 	DeleteOutputs         []DeleteOutput
 	DeleteOutput          *DeleteOutput
 }
@@ -160,11 +162,11 @@ func (c *Client) GetContent(ctx context.Context, id string) (*blob.Content, erro
 	panic("GetContent has no output")
 }
 
-func (c *Client) Delete(ctx context.Context, id string) (bool, error) {
+func (c *Client) Delete(ctx context.Context, id string, condition *request.Condition) (bool, error) {
 	c.DeleteInvocations++
-	c.DeleteInputs = append(c.DeleteInputs, DeleteInput{Context: ctx, ID: id})
+	c.DeleteInputs = append(c.DeleteInputs, DeleteInput{Context: ctx, ID: id, Condition: condition})
 	if c.DeleteStub != nil {
-		return c.DeleteStub(ctx, id)
+		return c.DeleteStub(ctx, id, condition)
 	}
 	if len(c.DeleteOutputs) > 0 {
 		output := c.DeleteOutputs[0]


### PR DESCRIPTION
@jh-bate Enable the capability to only update/delete a resource if it is at an expected revision. This can prevent two services from modifying the same resource at the same time resulting in potential data loss.