### PR TITLE
Add continuous origin deduplicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Add continuous origin deduplicator to use origin id as deduplication key for continuous data sets
+* Allow client to specific data set deduplicator
 * Fix data store tests
 * Add blob size maximum
 * Add blob revision

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -28,8 +28,24 @@ type DeduplicatorDescriptor struct {
 	Hash    string `bson:"hash,omitempty"`
 }
 
+func ParseDeduplicatorDescriptor(parser ObjectParser) *DeduplicatorDescriptor {
+	if parser.Object() == nil {
+		return nil
+	}
+	datum := NewDeduplicatorDescriptor()
+	datum.Parse(parser)
+	parser.ProcessNotParsed()
+	return datum
+}
+
 func NewDeduplicatorDescriptor() *DeduplicatorDescriptor {
 	return &DeduplicatorDescriptor{}
+}
+
+func (d *DeduplicatorDescriptor) Parse(parser ObjectParser) {
+	if ptr := parser.ParseString("name"); ptr != nil {
+		d.Name = *ptr
+	}
 }
 
 func (d *DeduplicatorDescriptor) Validate(validator structure.Validator) {

--- a/data/deduplicator/continuous_origin.go
+++ b/data/deduplicator/continuous_origin.go
@@ -1,0 +1,112 @@
+package deduplicator
+
+import (
+	"context"
+
+	"github.com/tidepool-org/platform/data"
+	dataStoreDEPRECATED "github.com/tidepool-org/platform/data/storeDEPRECATED"
+	dataTypes "github.com/tidepool-org/platform/data/types"
+	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
+)
+
+type continousOriginFactory struct {
+	*BaseFactory
+}
+
+type continuousOriginDeduplicator struct {
+	*BaseDeduplicator
+}
+
+const _ContinuousOriginDeduplicatorName = "org.tidepool.continuous.origin"
+const _ContinuousOriginDeduplicatorVersion = "1.0.0"
+
+func NewContinuousOriginFactory() (Factory, error) {
+	baseFactory, err := NewBaseFactory(_ContinuousOriginDeduplicatorName, _ContinuousOriginDeduplicatorVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	factory := &continousOriginFactory{
+		BaseFactory: baseFactory,
+	}
+	factory.Factory = factory
+
+	return factory, nil
+}
+
+func (c *continousOriginFactory) CanDeduplicateDataSet(dataSet *dataTypesUpload.Upload) (bool, error) {
+	if can, err := c.BaseFactory.CanDeduplicateDataSet(dataSet); err != nil || !can {
+		return can, err
+	}
+
+	if dataSet.Deduplicator == nil {
+		return false, nil
+	}
+	if !dataSet.Deduplicator.IsRegisteredWithNamedDeduplicator(_ContinuousOriginDeduplicatorName) {
+		return false, nil
+	}
+	if dataSet.DataSetType == nil {
+		return false, nil
+	}
+	if *dataSet.DataSetType != dataTypesUpload.DataSetTypeContinuous {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (c *continousOriginFactory) NewDeduplicatorForDataSet(logger log.Logger, dataSession dataStoreDEPRECATED.DataSession, dataSet *dataTypesUpload.Upload) (data.Deduplicator, error) {
+	baseDeduplicator, err := NewBaseDeduplicator(c.name, c.version, logger, dataSession, dataSet)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataSet.Deduplicator == nil {
+		return nil, errors.New("data set deduplicator is missing")
+	}
+	if !dataSet.Deduplicator.IsRegisteredWithNamedDeduplicator(_ContinuousOriginDeduplicatorName) {
+		return nil, errors.New("data set is not registered with deduplicator")
+	}
+	if dataSet.DataSetType == nil {
+		return nil, errors.New("data set type is missing")
+	}
+	if *dataSet.DataSetType != dataTypesUpload.DataSetTypeContinuous {
+		return nil, errors.New("data set type is not continuous")
+	}
+
+	return &continuousOriginDeduplicator{
+		BaseDeduplicator: baseDeduplicator,
+	}, nil
+}
+
+func (c *continuousOriginDeduplicator) AddDataSetData(ctx context.Context, dataSetData []data.Datum) error {
+	if len(dataSetData) == 0 {
+		return nil
+	}
+
+	var originIDs []string
+	for _, datum := range dataSetData {
+		datum.SetActive(true)
+		if base, ok := datum.(*dataTypes.Base); !ok {
+			return errors.New("data set data invalid")
+		} else if base.Origin != nil && base.Origin.ID != nil {
+			originIDs = append(originIDs, *base.Origin.ID)
+		}
+	}
+
+	if err := c.dataSession.ArchiveDataSetDataUsingOriginIDs(ctx, c.dataSet, originIDs); err != nil {
+		return errors.Wrapf(err, "unable to archive device data using origin from data set with id %q", *c.dataSet.UploadID)
+	}
+
+	if err := c.BaseDeduplicator.AddDataSetData(ctx, dataSetData); err != nil {
+		return err
+	}
+
+	if err := c.dataSession.DeleteArchivedDataSetData(ctx, c.dataSet); err != nil {
+		return errors.Wrapf(err, "unable to delete archived device data from data set with id %q", *c.dataSet.UploadID)
+	}
+
+	return nil
+}

--- a/data/deduplicator/continuous_origin_test.go
+++ b/data/deduplicator/continuous_origin_test.go
@@ -1,0 +1,297 @@
+package deduplicator_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"context"
+	"fmt"
+
+	"github.com/tidepool-org/platform/data"
+	dataDeduplicator "github.com/tidepool-org/platform/data/deduplicator"
+	dataStoreDEPRECATEDTest "github.com/tidepool-org/platform/data/storeDEPRECATED/test"
+	dataTest "github.com/tidepool-org/platform/data/test"
+	dataTypes "github.com/tidepool-org/platform/data/types"
+	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
+	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/pointer"
+	userTest "github.com/tidepool-org/platform/user/test"
+)
+
+var _ = Describe("ContinuousOrigin", func() {
+	Context("NewContinuousOriginFactory", func() {
+		It("returns a new factory", func() {
+			Expect(dataDeduplicator.NewContinuousOriginFactory()).ToNot(BeNil())
+		})
+	})
+
+	Context("with a new factory", func() {
+		var factory dataDeduplicator.Factory
+		var dataSetID string
+		var userID string
+		var dataSet *dataTypesUpload.Upload
+
+		BeforeEach(func() {
+			var err error
+			factory, err = dataDeduplicator.NewContinuousOriginFactory()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(factory).ToNot(BeNil())
+			dataSetID = dataTest.RandomSetID()
+			userID = userTest.RandomID()
+			dataSet = dataTypesUpload.New()
+			Expect(dataSet).ToNot(BeNil())
+			dataSet.DataSetType = pointer.FromString(dataTypesUpload.DataSetTypeContinuous)
+			dataSet.Deduplicator = &data.DeduplicatorDescriptor{
+				Name: "org.tidepool.continuous.origin",
+			}
+			dataSet.UploadID = pointer.FromString(dataSetID)
+			dataSet.UserID = pointer.FromString(userID)
+		})
+
+		Context("CanDeduplicateDataSet", func() {
+			It("returns an error if the data set is missing", func() {
+				can, err := factory.CanDeduplicateDataSet(nil)
+				Expect(err).To(MatchError("data set is missing"))
+				Expect(can).To(BeFalse())
+			})
+
+			It("returns false if the data set id is missing", func() {
+				dataSet.UploadID = nil
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the data set id is empty", func() {
+				dataSet.UploadID = pointer.FromString("")
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the data set user id is missing", func() {
+				dataSet.UserID = nil
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the data set user id is empty", func() {
+				dataSet.UserID = pointer.FromString("")
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the deduplicator is missing", func() {
+				dataSet.Deduplicator = nil
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the deduplicator name is not matching", func() {
+				dataSet.Deduplicator.Name = "not-matching"
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the data set type is missing", func() {
+				dataSet.DataSetType = nil
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns false if the data set type is not continuous", func() {
+				dataSet.DataSetType = pointer.FromString(dataTypesUpload.DataSetTypeNormal)
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeFalse())
+			})
+
+			It("returns true if successful", func() {
+				Expect(factory.CanDeduplicateDataSet(dataSet)).To(BeTrue())
+			})
+		})
+
+		Context("with logger and data store session", func() {
+			var logger log.Logger
+			var dataSession *dataStoreDEPRECATEDTest.DataSession
+
+			BeforeEach(func() {
+				logger = logTest.NewLogger()
+				dataSession = dataStoreDEPRECATEDTest.NewDataSession()
+				Expect(dataSession).ToNot(BeNil())
+			})
+
+			AfterEach(func() {
+				dataSession.Expectations()
+			})
+
+			Context("NewDeduplicatorForDataSet", func() {
+				It("returns an error if the logger is missing", func() {
+					deduplicator, err := factory.NewDeduplicatorForDataSet(nil, dataSession, dataSet)
+					Expect(err).To(MatchError("logger is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data store session is missing", func() {
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, nil, dataSet)
+					Expect(err).To(MatchError("data store session is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set is missing", func() {
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set id is missing", func() {
+					dataSet.UploadID = nil
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set id is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set id is empty", func() {
+					dataSet.UploadID = pointer.FromString("")
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set id is empty"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set user id is missing", func() {
+					dataSet.UserID = nil
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set user id is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set user id is empty", func() {
+					dataSet.UserID = pointer.FromString("")
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set user id is empty"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set deduplicator is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the deduplicator name is not matching", func() {
+					dataSet.Deduplicator.Name = "not-matching"
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set is not registered with deduplicator"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set type is missing", func() {
+					dataSet.DataSetType = nil
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set type is missing"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns an error if the data set type is not continuous", func() {
+					dataSet.DataSetType = pointer.FromString(dataTypesUpload.DataSetTypeNormal)
+					deduplicator, err := factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).To(MatchError("data set type is not continuous"))
+					Expect(deduplicator).To(BeNil())
+				})
+
+				It("returns successfully", func() {
+					Expect(factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)).ToNot(BeNil())
+				})
+			})
+
+			Context("with a context and new deduplicator", func() {
+				var ctx context.Context
+				var deduplicator data.Deduplicator
+				var originIDs []string
+				var dataSetData []data.Datum
+
+				BeforeEach(func() {
+					ctx = context.Background()
+					var err error
+					deduplicator, err = factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deduplicator).ToNot(BeNil())
+					originIDs = []string{}
+					dataSetData = []data.Datum{}
+					for i := 0; i < 3; i++ {
+						baseDatum := dataTypesTest.NewBase()
+						baseDatum.Active = false
+						originIDs = append(originIDs, *baseDatum.Origin.ID)
+						dataSetData = append(dataSetData, baseDatum)
+					}
+				})
+
+				Context("AddDataSetData", func() {
+					It("returns successfully if the data is nil", func() {
+						Expect(deduplicator.AddDataSetData(ctx, nil)).To(Succeed())
+					})
+
+					It("returns successfully if there is no data", func() {
+						Expect(deduplicator.AddDataSetData(ctx, []data.Datum{})).To(Succeed())
+					})
+
+					Context("when archive data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSession.ArchiveDataSetDataUsingOriginIDsInputs).To(ConsistOf(dataStoreDEPRECATEDTest.ArchiveDataSetDataUsingOriginIDsInput{Context: ctx, DataSet: dataSet, OriginIDs: originIDs}))
+						})
+
+						It("returns an error if archive data set data using origin ids returns an error", func() {
+							err := errorsTest.RandomError()
+							dataSession.ArchiveDataSetDataUsingOriginIDsOutputs = []error{err}
+							Expect(deduplicator.AddDataSetData(ctx, dataSetData)).To(MatchError(fmt.Sprintf("unable to archive device data using origin from data set with id %q; %s", *dataSet.UploadID, err)))
+
+						})
+
+						Context("archive data set data returns successfully and create data set data is invoked", func() {
+							BeforeEach(func() {
+								dataSession.ArchiveDataSetDataUsingOriginIDsOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(dataSession.CreateDataSetDataInputs).To(ConsistOf(dataStoreDEPRECATEDTest.CreateDataSetDataInput{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}))
+							})
+
+							It("returns an error if create data set data returns an error", func() {
+								err := errorsTest.RandomError()
+								dataSession.CreateDataSetDataOutputs = []error{err}
+								Expect(deduplicator.AddDataSetData(ctx, dataSetData)).To(MatchError(fmt.Sprintf("unable to create data set data with id %q; %s", *dataSet.UploadID, err)))
+							})
+
+							Context("create data set data returns successfully and delete archived data set data is invoked", func() {
+								BeforeEach(func() {
+									dataSession.CreateDataSetDataOutputs = []error{nil}
+								})
+
+								AfterEach(func() {
+									Expect(dataSession.DeleteArchivedDataSetDataInputs).To(ConsistOf(dataStoreDEPRECATEDTest.DeleteArchivedDataSetDataInput{Context: ctx, DataSet: dataSet}))
+								})
+
+								It("returns an error if delete archive data set data returns an error", func() {
+									err := errorsTest.RandomError()
+									dataSession.DeleteArchivedDataSetDataOutputs = []error{err}
+									Expect(deduplicator.AddDataSetData(ctx, dataSetData)).To(MatchError(fmt.Sprintf("unable to delete archived device data from data set with id %q; %s", *dataSet.UploadID, err)))
+								})
+
+								Context("delete archived data set data returns successfully", func() {
+									BeforeEach(func() {
+										dataSession.DeleteArchivedDataSetDataOutputs = []error{nil}
+									})
+
+									It("returns successfully", func() {
+										Expect(deduplicator.AddDataSetData(ctx, dataSetData)).To(Succeed())
+									})
+
+									It("marks the data set data as active", func() {
+										Expect(deduplicator.AddDataSetData(ctx, dataSetData)).To(Succeed())
+										for _, datum := range dataSetData {
+											baseDatum, _ := datum.(*dataTypes.Base)
+											Expect(baseDatum.Active).To(BeTrue())
+										}
+									})
+								})
+							})
+						})
+					})
+				})
+			})
+		})
+	})
+})

--- a/data/deduplicator/delegate.go
+++ b/data/deduplicator/delegate.go
@@ -48,6 +48,22 @@ func (d *DelegateFactory) NewDeduplicatorForDataSet(logger log.Logger, dataSessi
 		return nil, errors.New("data set is missing")
 	}
 
+	if dataSet.Deduplicator != nil {
+		if dataSet.Deduplicator.Name == "" {
+			return nil, errors.New("data set deduplicator name is missing")
+		}
+
+		for _, factory := range d.factories {
+			if is, err := factory.IsRegisteredWithDataSet(dataSet); err != nil {
+				return nil, err
+			} else if is {
+				return factory.NewDeduplicatorForDataSet(logger, dataSession, dataSet)
+			}
+		}
+
+		return nil, errors.New("data set deduplicator name is unknown")
+	}
+
 	for _, factory := range d.factories {
 		if can, err := factory.CanDeduplicateDataSet(dataSet); err != nil {
 			return nil, err

--- a/data/service/service/standard.go
+++ b/data/service/service/standard.go
@@ -173,12 +173,20 @@ func (s *Standard) initializeDataDeduplicatorFactory() error {
 		return errors.Wrap(err, "unable to create continuous data deduplicator factory")
 	}
 
+	s.Logger().Debug("Creating continuous origin data deduplicator factory")
+
+	continuousOriginDeduplicatorFactory, err := deduplicator.NewContinuousOriginFactory()
+	if err != nil {
+		return errors.Wrap(err, "unable to create continuous origin data deduplicator factory")
+	}
+
 	s.Logger().Debug("Creating data deduplicator factory")
 
 	factories := []deduplicator.Factory{
 		truncateDeduplicatorFactory,
 		hashDeactivateOldDeduplicatorFactory,
 		continuousDeduplicatorFactory,
+		continuousOriginDeduplicatorFactory,
 	}
 
 	dataDeduplicatorFactory, err := deduplicator.NewDelegateFactory(factories)

--- a/data/storeDEPRECATED/mongo/mongo_suite_test.go
+++ b/data/storeDEPRECATED/mongo/mongo_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "data/store/mongo")
+	RunSpecs(t, "data/storeDEPRECATED/mongo")
 }

--- a/data/storeDEPRECATED/store.go
+++ b/data/storeDEPRECATED/store.go
@@ -28,6 +28,8 @@ type DataSession interface {
 	ActivateDataSetData(ctx context.Context, dataSet *upload.Upload) error
 	ArchiveDeviceDataUsingHashesFromDataSet(ctx context.Context, dataSet *upload.Upload) error
 	UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.Context, dataSet *upload.Upload) error
+	ArchiveDataSetDataUsingOriginIDs(ctx context.Context, dataSet *upload.Upload, originIDs []string) error
+	DeleteArchivedDataSetData(ctx context.Context, dataSet *upload.Upload) error
 	DeleteOtherDataSetData(ctx context.Context, dataSet *upload.Upload) error
 	DestroyDataForUserByID(ctx context.Context, userID string) error
 

--- a/data/storeDEPRECATED/test/data_session.go
+++ b/data/storeDEPRECATED/test/data_session.go
@@ -76,6 +76,17 @@ type UnarchiveDeviceDataUsingHashesFromDataSetInput struct {
 	DataSet *upload.Upload
 }
 
+type ArchiveDataSetDataUsingOriginIDsInput struct {
+	Context   context.Context
+	DataSet   *upload.Upload
+	OriginIDs []string
+}
+
+type DeleteArchivedDataSetDataInput struct {
+	Context context.Context
+	DataSet *upload.Upload
+}
+
 type DeleteOtherDataSetDataInput struct {
 	Context context.Context
 	DataSet *upload.Upload
@@ -142,6 +153,12 @@ type DataSession struct {
 	UnarchiveDeviceDataUsingHashesFromDataSetInvocations int
 	UnarchiveDeviceDataUsingHashesFromDataSetInputs      []UnarchiveDeviceDataUsingHashesFromDataSetInput
 	UnarchiveDeviceDataUsingHashesFromDataSetOutputs     []error
+	ArchiveDataSetDataUsingOriginIDsInvocations          int
+	ArchiveDataSetDataUsingOriginIDsInputs               []ArchiveDataSetDataUsingOriginIDsInput
+	ArchiveDataSetDataUsingOriginIDsOutputs              []error
+	DeleteArchivedDataSetDataInvocations                 int
+	DeleteArchivedDataSetDataInputs                      []DeleteArchivedDataSetDataInput
+	DeleteArchivedDataSetDataOutputs                     []error
 	DeleteOtherDataSetDataInvocations                    int
 	DeleteOtherDataSetDataInputs                         []DeleteOtherDataSetDataInput
 	DeleteOtherDataSetDataOutputs                        []error
@@ -288,6 +305,30 @@ func (d *DataSession) UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.Cont
 
 	output := d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs[0]
 	d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs = d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs[1:]
+	return output
+}
+
+func (d *DataSession) ArchiveDataSetDataUsingOriginIDs(ctx context.Context, dataSet *upload.Upload, originIDs []string) error {
+	d.ArchiveDataSetDataUsingOriginIDsInvocations++
+
+	d.ArchiveDataSetDataUsingOriginIDsInputs = append(d.ArchiveDataSetDataUsingOriginIDsInputs, ArchiveDataSetDataUsingOriginIDsInput{Context: ctx, DataSet: dataSet, OriginIDs: originIDs})
+
+	gomega.Expect(d.ArchiveDataSetDataUsingOriginIDsOutputs).ToNot(gomega.BeEmpty())
+
+	output := d.ArchiveDataSetDataUsingOriginIDsOutputs[0]
+	d.ArchiveDataSetDataUsingOriginIDsOutputs = d.ArchiveDataSetDataUsingOriginIDsOutputs[1:]
+	return output
+}
+
+func (d *DataSession) DeleteArchivedDataSetData(ctx context.Context, dataSet *upload.Upload) error {
+	d.DeleteArchivedDataSetDataInvocations++
+
+	d.DeleteArchivedDataSetDataInputs = append(d.DeleteArchivedDataSetDataInputs, DeleteArchivedDataSetDataInput{Context: ctx, DataSet: dataSet})
+
+	gomega.Expect(d.DeleteArchivedDataSetDataOutputs).ToNot(gomega.BeEmpty())
+
+	output := d.DeleteArchivedDataSetDataOutputs[0]
+	d.DeleteArchivedDataSetDataOutputs = d.DeleteArchivedDataSetDataOutputs[1:]
 	return output
 }
 

--- a/data/types/upload/upload.go
+++ b/data/types/upload/upload.go
@@ -122,6 +122,8 @@ func (u *Upload) Parse(parser data.ObjectParser) error {
 		return err
 	}
 
+	u.Deduplicator = data.ParseDeduplicatorDescriptor(parser.NewChildObjectParser("deduplicator"))
+
 	u.Client = ParseClient(parser.NewChildObjectParser("client"))
 	u.ComputerTime = parser.ParseString("computerTime")
 	u.DataSetType = parser.ParseString("dataSetType")


### PR DESCRIPTION
* Add continuous origin deduplicator to use origin id as deduplication key for continuous data sets
* Allow client to specific data set deduplicator

@jh-bate Will be used by v2 Dexcom API and updates to Tidepool Mobile. Deduplicates within the same continuous data set, but uses the new origin.id field as the deduplication key.