### PR TITLE
Make device id optional for data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.29.0
 
+* Make device id optional for data
 * Refactor device time change event to include time zone name
 * Add time zone name validator
 * Move pump settings display units to pump settings display blood glucose units

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -162,12 +162,7 @@ func (b *Base) Validate(validator structure.Validator) {
 		}
 	}
 
-	deviceIDValidator := validator.String("deviceId", b.DeviceID)
-	if b.Type != "upload" { // HACK: Need to replace upload.Upload with data.DataSet
-		deviceIDValidator.Exists()
-	}
-	deviceIDValidator.NotEmpty()
-
+	validator.String("deviceId", b.DeviceID).NotEmpty()
 	validator.String("deviceTime", b.DeviceTime).AsTime(DeviceTimeFormat)
 
 	validator.String("id", b.ID).Using(data.IDValidator)

--- a/data/types/base_test.go
+++ b/data/types/base_test.go
@@ -372,7 +372,6 @@ var _ = Describe("Base", func() {
 				Entry("device id missing",
 					func(datum *types.Base) { datum.DeviceID = nil },
 					structure.Origins(),
-					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/deviceId"),
 				),
 				Entry("device id empty",
 					func(datum *types.Base) { datum.DeviceID = pointer.FromString("") },
@@ -818,7 +817,7 @@ var _ = Describe("Base", func() {
 				Entry("multiple errors with external origin",
 					func(datum *types.Base) {
 						datum.ClockDriftOffset = pointer.FromInt(-86400001)
-						datum.DeviceID = nil
+						datum.DeviceID = pointer.FromString("")
 						datum.DeviceTime = pointer.FromString("invalid")
 						datum.ID = pointer.FromString("")
 						datum.Location.GPS = nil
@@ -834,7 +833,7 @@ var _ = Describe("Base", func() {
 					},
 					structure.Origins(),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotInRange(-86400001, -86400000, 86400000), "/clockDriftOffset"),
-					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/deviceId"),
+					testErrors.WithPointerSource(structureValidator.ErrorValueEmpty(), "/deviceId"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueStringAsTimeNotValid("invalid", "2006-01-02T15:04:05"), "/deviceTime"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueEmpty(), "/id"),
 					testErrors.WithPointerSource(structureValidator.ErrorValueNotExists(), "/location/gps"),


### PR DESCRIPTION
@jh-bate For most HealthKit data we don't have a logical device id, so make it optional rather than using some arbitrarily constructed surrogate.