### PR TITLE
Update data deduplicators to accommodate deactivating deleted data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v1.29.0
 
+* Update delete data set origin deduplicator to delete duplicates found when adding data
+* Update delete data set origin deduplicator to deactivate deleted data
+* Update base deduplicator to activate data set separately from data set data
+* Update data store to not activate data set when data set data activated
+* Add data selectors to data set data operations to target specific data records
+* Update data store to add activate, archive, delete, destroy deleted, and destroy operations on data set data
+* Refactor data store and test for code consistency
 * Refactor for code consistency
 * Rename data.Delete to data.Selector for more general usage
 * Add data deduplicator name migration

--- a/data/deduplicator/deduplicator/base.go
+++ b/data/deduplicator/deduplicator/base.go
@@ -100,7 +100,7 @@ func (b *Base) DeleteData(ctx context.Context, session dataStoreDEPRECATED.DataS
 		return errors.New("selectors is missing")
 	}
 
-	return session.DeleteDataSetData(ctx, dataSet, selectors)
+	return session.DestroyDataSetData(ctx, dataSet, selectors)
 }
 
 func (b *Base) Close(ctx context.Context, session dataStoreDEPRECATED.DataSession, dataSet *dataTypesUpload.Upload) error {
@@ -114,7 +114,13 @@ func (b *Base) Close(ctx context.Context, session dataStoreDEPRECATED.DataSessio
 		return errors.New("data set is missing")
 	}
 
-	return session.ActivateDataSetData(ctx, dataSet)
+	update := data.NewDataSetUpdate()
+	update.Active = pointer.FromBool(true)
+	if _, err := session.UpdateDataSet(ctx, *dataSet.UploadID, update); err != nil {
+		return err
+	}
+
+	return session.ActivateDataSetData(ctx, dataSet, nil)
 }
 
 func (b *Base) Delete(ctx context.Context, session dataStoreDEPRECATED.DataSession, dataSet *dataTypesUpload.Upload) error {

--- a/data/deduplicator/deduplicator/base_test.go
+++ b/data/deduplicator/deduplicator/base_test.go
@@ -313,19 +313,19 @@ var _ = Describe("Base", func() {
 					Expect(deduplicator.DeleteData(ctx, session, dataSet, nil)).To(MatchError("selectors is missing"))
 				})
 
-				When("delete data set data is invoked", func() {
+				When("destroy data set data is invoked", func() {
 					AfterEach(func() {
-						Expect(session.DeleteDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+						Expect(session.DestroyDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
 					})
 
-					It("returns an error when delete data set data returns an error", func() {
+					It("returns an error when destroy data set data returns an error", func() {
 						responseErr := errorsTest.RandomError()
-						session.DeleteDataSetDataOutputs = []error{responseErr}
+						session.DestroyDataSetDataOutputs = []error{responseErr}
 						Expect(deduplicator.DeleteData(ctx, session, dataSet, selectors)).To(Equal(responseErr))
 					})
 
-					It("returns successfully when delete data set data returns successfully", func() {
-						session.DeleteDataSetDataOutputs = []error{nil}
+					It("returns successfully when destroy data set data returns successfully", func() {
+						session.DestroyDataSetDataOutputs = []error{nil}
 						Expect(deduplicator.DeleteData(ctx, session, dataSet, selectors)).To(Succeed())
 					})
 				})
@@ -344,20 +344,36 @@ var _ = Describe("Base", func() {
 					Expect(deduplicator.Close(ctx, session, nil)).To(MatchError("data set is missing"))
 				})
 
-				When("activate data set data is invoked", func() {
+				When("update data set is invoked", func() {
 					AfterEach(func() {
-						Expect(session.ActivateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet}}))
+						Expect(session.UpdateDataSetInputs).To(Equal([]dataStoreDEPRECATEDTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
 					})
 
-					It("returns an error when active data set data returns an error", func() {
+					It("returns an error when update data set data returns an error", func() {
 						responseErr := errorsTest.RandomError()
-						session.ActivateDataSetDataOutputs = []error{responseErr}
+						session.UpdateDataSetOutputs = []dataStoreDEPRECATEDTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
 						Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
 					})
 
-					It("returns successfully when active data set data returns successfully", func() {
-						session.ActivateDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.Close(ctx, session, dataSet)).To(Succeed())
+					When("activate data set data is invoked", func() {
+						BeforeEach(func() {
+							session.UpdateDataSetOutputs = []dataStoreDEPRECATEDTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+						})
+
+						AfterEach(func() {
+							Expect(session.ActivateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+						})
+
+						It("returns an error when active data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							session.ActivateDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when active data set data returns successfully", func() {
+							session.ActivateDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.Close(ctx, session, dataSet)).To(Succeed())
+						})
 					})
 				})
 			})

--- a/data/deduplicator/deduplicator/device_truncate_data_set_test.go
+++ b/data/deduplicator/deduplicator/device_truncate_data_set_test.go
@@ -62,7 +62,7 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 				Expect(deduplicator.New(dataSet)).To(BeFalse())
 			})
 
-			dataSetTypeValidations := func() {
+			dataSetTypeAssertions := func() {
 				It("returns false when the deduplicator name does not match", func() {
 					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
 					Expect(deduplicator.New(dataSet)).To(BeFalse())
@@ -113,7 +113,7 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 					dataSet.DataSetType = nil
 				})
 
-				dataSetTypeValidations()
+				dataSetTypeAssertions()
 			})
 
 			When("the data set type is normal", func() {
@@ -121,7 +121,7 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 					dataSet.DataSetType = pointer.FromString("normal")
 				})
 
-				dataSetTypeValidations()
+				dataSetTypeAssertions()
 			})
 		})
 
@@ -341,19 +341,19 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 					Expect(deduplicator.DeleteData(ctx, session, dataSet, nil)).To(MatchError("selectors is missing"))
 				})
 
-				When("delete data set data is invoked", func() {
+				When("destroy data set data is invoked", func() {
 					AfterEach(func() {
-						Expect(session.DeleteDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+						Expect(session.DestroyDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
 					})
 
-					It("returns an error when delete data set data returns an error", func() {
+					It("returns an error when destroy data set data returns an error", func() {
 						responseErr := errorsTest.RandomError()
-						session.DeleteDataSetDataOutputs = []error{responseErr}
+						session.DestroyDataSetDataOutputs = []error{responseErr}
 						Expect(deduplicator.DeleteData(ctx, session, dataSet, selectors)).To(Equal(responseErr))
 					})
 
-					It("returns successfully when delete data set data returns successfully", func() {
-						session.DeleteDataSetDataOutputs = []error{nil}
+					It("returns successfully when destroy data set data returns successfully", func() {
+						session.DestroyDataSetDataOutputs = []error{nil}
 						Expect(deduplicator.DeleteData(ctx, session, dataSet, selectors)).To(Succeed())
 					})
 				})
@@ -383,24 +383,40 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 						Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
 					})
 
-					When("activate data set data is invoked", func() {
+					When("update data set is invoked", func() {
 						BeforeEach(func() {
 							session.DeleteOtherDataSetDataOutputs = []error{nil}
 						})
 
 						AfterEach(func() {
-							Expect(session.ActivateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet}}))
+							Expect(session.UpdateDataSetInputs).To(Equal([]dataStoreDEPRECATEDTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
 						})
 
-						It("returns an error when active data set data returns an error", func() {
+						It("returns an error when update data set data returns an error", func() {
 							responseErr := errorsTest.RandomError()
-							session.ActivateDataSetDataOutputs = []error{responseErr}
+							session.UpdateDataSetOutputs = []dataStoreDEPRECATEDTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
 							Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
 						})
 
-						It("returns successfully when active data set data returns successfully", func() {
-							session.ActivateDataSetDataOutputs = []error{nil}
-							Expect(deduplicator.Close(ctx, session, dataSet)).To(Succeed())
+						When("activate data set data is invoked", func() {
+							BeforeEach(func() {
+								session.UpdateDataSetOutputs = []dataStoreDEPRECATEDTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+							})
+
+							AfterEach(func() {
+								Expect(session.ActivateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+							})
+
+							It("returns an error when active data set data returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								session.ActivateDataSetDataOutputs = []error{responseErr}
+								Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
+							})
+
+							It("returns successfully when active data set data returns successfully", func() {
+								session.ActivateDataSetDataOutputs = []error{nil}
+								Expect(deduplicator.Close(ctx, session, dataSet)).To(Succeed())
+							})
 						})
 					})
 				})

--- a/data/deduplicator/deduplicator/none_test.go
+++ b/data/deduplicator/deduplicator/none_test.go
@@ -162,7 +162,7 @@ var _ = Describe("None", func() {
 						Expect(session.UpdateDataSetInputs).To(Equal([]dataStoreDEPRECATEDTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
 					})
 
-					updateValidations := func() {
+					updateAssertions := func() {
 						When("the data set does not have a deduplicator", func() {
 							BeforeEach(func() {
 								dataSet.Deduplicator = nil
@@ -234,7 +234,7 @@ var _ = Describe("None", func() {
 							Expect(dataSet.Active).To(BeFalse())
 						})
 
-						updateValidations()
+						updateAssertions()
 					})
 
 					When("data set type is continuous", func() {
@@ -247,7 +247,7 @@ var _ = Describe("None", func() {
 							Expect(dataSet.Active).To(BeTrue())
 						})
 
-						updateValidations()
+						updateAssertions()
 					})
 
 					When("data set type is normal", func() {
@@ -260,7 +260,7 @@ var _ = Describe("None", func() {
 							Expect(dataSet.Active).To(BeFalse())
 						})
 
-						updateValidations()
+						updateAssertions()
 					})
 				})
 			})
@@ -296,7 +296,7 @@ var _ = Describe("None", func() {
 						Expect(session.CreateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
 					})
 
-					createValidations := func() {
+					createAssertions := func() {
 						It("returns an error when create data set data returns an error", func() {
 							responseErr := errorsTest.RandomError()
 							session.CreateDataSetDataOutputs = []error{responseErr}
@@ -323,7 +323,7 @@ var _ = Describe("None", func() {
 							}
 						})
 
-						createValidations()
+						createAssertions()
 					})
 
 					When("data set type is continuous", func() {
@@ -340,7 +340,7 @@ var _ = Describe("None", func() {
 							}
 						})
 
-						createValidations()
+						createAssertions()
 					})
 
 					When("data set type is normal", func() {
@@ -357,7 +357,7 @@ var _ = Describe("None", func() {
 							}
 						})
 
-						createValidations()
+						createAssertions()
 					})
 				})
 			})
@@ -385,19 +385,19 @@ var _ = Describe("None", func() {
 					Expect(deduplicator.DeleteData(ctx, session, dataSet, nil)).To(MatchError("selectors is missing"))
 				})
 
-				When("delete data set data is invoked", func() {
+				When("destroy data set data is invoked", func() {
 					AfterEach(func() {
-						Expect(session.DeleteDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+						Expect(session.DestroyDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
 					})
 
-					It("returns an error when delete data set data returns an error", func() {
+					It("returns an error when destroy data set data returns an error", func() {
 						responseErr := errorsTest.RandomError()
-						session.DeleteDataSetDataOutputs = []error{responseErr}
+						session.DestroyDataSetDataOutputs = []error{responseErr}
 						Expect(deduplicator.DeleteData(ctx, session, dataSet, selectors)).To(Equal(responseErr))
 					})
 
-					It("returns successfully when delete data set data returns successfully", func() {
-						session.DeleteDataSetDataOutputs = []error{nil}
+					It("returns successfully when destroy data set data returns successfully", func() {
+						session.DestroyDataSetDataOutputs = []error{nil}
 						Expect(deduplicator.DeleteData(ctx, session, dataSet, selectors)).To(Succeed())
 					})
 				})
@@ -426,21 +426,37 @@ var _ = Describe("None", func() {
 					})
 				})
 
-				When("activate data set data is invoked", func() {
+				When("update data set is invoked", func() {
 					AfterEach(func() {
-						Expect(session.ActivateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet}}))
+						Expect(session.UpdateDataSetInputs).To(Equal([]dataStoreDEPRECATEDTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
 					})
 
-					activateValidations := func() {
-						It("returns an error when active data set data returns an error", func() {
+					updateAssertions := func() {
+						It("returns an error when update data set data returns an error", func() {
 							responseErr := errorsTest.RandomError()
-							session.ActivateDataSetDataOutputs = []error{responseErr}
+							session.UpdateDataSetOutputs = []dataStoreDEPRECATEDTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
 							Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
 						})
 
-						It("returns successfully when active data set data returns successfully", func() {
-							session.ActivateDataSetDataOutputs = []error{nil}
-							Expect(deduplicator.Close(ctx, session, dataSet)).To(Succeed())
+						When("activate data set data is invoked", func() {
+							BeforeEach(func() {
+								session.UpdateDataSetOutputs = []dataStoreDEPRECATEDTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+							})
+
+							AfterEach(func() {
+								Expect(session.ActivateDataSetDataInputs).To(Equal([]dataStoreDEPRECATEDTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+							})
+
+							It("returns an error when active data set data returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								session.ActivateDataSetDataOutputs = []error{responseErr}
+								Expect(deduplicator.Close(ctx, session, dataSet)).To(Equal(responseErr))
+							})
+
+							It("returns successfully when active data set data returns successfully", func() {
+								session.ActivateDataSetDataOutputs = []error{nil}
+								Expect(deduplicator.Close(ctx, session, dataSet)).To(Succeed())
+							})
 						})
 					}
 
@@ -449,7 +465,7 @@ var _ = Describe("None", func() {
 							dataSet.DataSetType = nil
 						})
 
-						activateValidations()
+						updateAssertions()
 					})
 
 					When("data set type is normal", func() {
@@ -457,7 +473,7 @@ var _ = Describe("None", func() {
 							dataSet.DataSetType = pointer.FromString("normal")
 						})
 
-						activateValidations()
+						updateAssertions()
 					})
 				})
 			})

--- a/data/deduplicator/factory/factory_test.go
+++ b/data/deduplicator/factory/factory_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Factory", func() {
 				})
 			})
 
-			newValidations := func() {
+			newAssertions := func() {
 				AfterEach(func() {
 					Expect(secondDeduplicator.NewInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
 					Expect(firstDeduplicator.NewInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
@@ -143,7 +143,7 @@ var _ = Describe("Factory", func() {
 					dataSet.Deduplicator = nil
 				})
 
-				newValidations()
+				newAssertions()
 			})
 
 			When("the data set does not have a deduplicator name", func() {
@@ -151,7 +151,7 @@ var _ = Describe("Factory", func() {
 					dataSet.Deduplicator.Name = nil
 				})
 
-				newValidations()
+				newAssertions()
 			})
 		})
 

--- a/data/storeDEPRECATED/store.go
+++ b/data/storeDEPRECATED/store.go
@@ -24,13 +24,16 @@ type DataSession interface {
 	CreateDataSet(ctx context.Context, dataSet *upload.Upload) error
 	UpdateDataSet(ctx context.Context, id string, update *data.DataSetUpdate) (*upload.Upload, error)
 	DeleteDataSet(ctx context.Context, dataSet *upload.Upload) error
+
 	CreateDataSetData(ctx context.Context, dataSet *upload.Upload, dataSetData []data.Datum) error
+	ActivateDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error
+	ArchiveDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error
 	DeleteDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error
-	ActivateDataSetData(ctx context.Context, dataSet *upload.Upload) error
+	DestroyDeletedDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error
+	DestroyDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error
+
 	ArchiveDeviceDataUsingHashesFromDataSet(ctx context.Context, dataSet *upload.Upload) error
 	UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.Context, dataSet *upload.Upload) error
-	ArchiveDataSetDataUsingOriginIDs(ctx context.Context, dataSet *upload.Upload, originIDs []string) error
-	DeleteArchivedDataSetData(ctx context.Context, dataSet *upload.Upload) error
 	DeleteOtherDataSetData(ctx context.Context, dataSet *upload.Upload) error
 	DestroyDataForUserByID(ctx context.Context, userID string) error
 

--- a/data/storeDEPRECATED/test/data_session.go
+++ b/data/storeDEPRECATED/test/data_session.go
@@ -61,15 +61,34 @@ type CreateDataSetDataInput struct {
 	DataSetData []data.Datum
 }
 
+type ActivateDataSetDataInput struct {
+	Context   context.Context
+	DataSet   *upload.Upload
+	Selectors *data.Selectors
+}
+
+type ArchiveDataSetDataInput struct {
+	Context   context.Context
+	DataSet   *upload.Upload
+	Selectors *data.Selectors
+}
+
 type DeleteDataSetDataInput struct {
 	Context   context.Context
 	DataSet   *upload.Upload
 	Selectors *data.Selectors
 }
 
-type ActivateDataSetDataInput struct {
-	Context context.Context
-	DataSet *upload.Upload
+type DestroyDeletedDataSetDataInput struct {
+	Context   context.Context
+	DataSet   *upload.Upload
+	Selectors *data.Selectors
+}
+
+type DestroyDataSetDataInput struct {
+	Context   context.Context
+	DataSet   *upload.Upload
+	Selectors *data.Selectors
 }
 
 type ArchiveDeviceDataUsingHashesFromDataSetInput struct {
@@ -86,11 +105,6 @@ type ArchiveDataSetDataUsingOriginIDsInput struct {
 	Context   context.Context
 	DataSet   *upload.Upload
 	OriginIDs []string
-}
-
-type DeleteArchivedDataSetDataInput struct {
-	Context context.Context
-	DataSet *upload.Upload
 }
 
 type DeleteOtherDataSetDataInput struct {
@@ -128,10 +142,6 @@ type ListUserDataSetsOutput struct {
 type DataSession struct {
 	*test.Mock
 	*test.Closer
-	IsClosedInvocations                                  int
-	IsClosedOutputs                                      []bool
-	EnsureIndexesInvocations                             int
-	EnsureIndexesOutputs                                 []error
 	GetDataSetsForUserByIDInvocations                    int
 	GetDataSetsForUserByIDInputs                         []GetDataSetsForUserByIDInput
 	GetDataSetsForUserByIDOutputs                        []GetDataSetsForUserByIDOutput
@@ -150,24 +160,27 @@ type DataSession struct {
 	CreateDataSetDataInvocations                         int
 	CreateDataSetDataInputs                              []CreateDataSetDataInput
 	CreateDataSetDataOutputs                             []error
-	DeleteDataSetDataInvocations                         int
-	DeleteDataSetDataInputs                              []DeleteDataSetDataInput
-	DeleteDataSetDataOutputs                             []error
 	ActivateDataSetDataInvocations                       int
 	ActivateDataSetDataInputs                            []ActivateDataSetDataInput
 	ActivateDataSetDataOutputs                           []error
+	ArchiveDataSetDataInvocations                        int
+	ArchiveDataSetDataInputs                             []ArchiveDataSetDataInput
+	ArchiveDataSetDataOutputs                            []error
+	DeleteDataSetDataInvocations                         int
+	DeleteDataSetDataInputs                              []DeleteDataSetDataInput
+	DeleteDataSetDataOutputs                             []error
+	DestroyDeletedDataSetDataInvocations                 int
+	DestroyDeletedDataSetDataInputs                      []DestroyDeletedDataSetDataInput
+	DestroyDeletedDataSetDataOutputs                     []error
+	DestroyDataSetDataInvocations                        int
+	DestroyDataSetDataInputs                             []DestroyDataSetDataInput
+	DestroyDataSetDataOutputs                            []error
 	ArchiveDeviceDataUsingHashesFromDataSetInvocations   int
 	ArchiveDeviceDataUsingHashesFromDataSetInputs        []ArchiveDeviceDataUsingHashesFromDataSetInput
 	ArchiveDeviceDataUsingHashesFromDataSetOutputs       []error
 	UnarchiveDeviceDataUsingHashesFromDataSetInvocations int
 	UnarchiveDeviceDataUsingHashesFromDataSetInputs      []UnarchiveDeviceDataUsingHashesFromDataSetInput
 	UnarchiveDeviceDataUsingHashesFromDataSetOutputs     []error
-	ArchiveDataSetDataUsingOriginIDsInvocations          int
-	ArchiveDataSetDataUsingOriginIDsInputs               []ArchiveDataSetDataUsingOriginIDsInput
-	ArchiveDataSetDataUsingOriginIDsOutputs              []error
-	DeleteArchivedDataSetDataInvocations                 int
-	DeleteArchivedDataSetDataInputs                      []DeleteArchivedDataSetDataInput
-	DeleteArchivedDataSetDataOutputs                     []error
 	DeleteOtherDataSetDataInvocations                    int
 	DeleteOtherDataSetDataInputs                         []DeleteOtherDataSetDataInput
 	DeleteOtherDataSetDataOutputs                        []error
@@ -187,26 +200,6 @@ func NewDataSession() *DataSession {
 		Mock:   test.NewMock(),
 		Closer: test.NewCloser(),
 	}
-}
-
-func (d *DataSession) IsClosed() bool {
-	d.IsClosedInvocations++
-
-	gomega.Expect(d.IsClosedOutputs).ToNot(gomega.BeEmpty())
-
-	output := d.IsClosedOutputs[0]
-	d.IsClosedOutputs = d.IsClosedOutputs[1:]
-	return output
-}
-
-func (d *DataSession) EnsureIndexes() error {
-	d.EnsureIndexesInvocations++
-
-	gomega.Expect(d.EnsureIndexesOutputs).ToNot(gomega.BeEmpty())
-
-	output := d.EnsureIndexesOutputs[0]
-	d.EnsureIndexesOutputs = d.EnsureIndexesOutputs[1:]
-	return output
 }
 
 func (d *DataSession) GetDataSetsForUserByID(ctx context.Context, userID string, filter *dataStoreDEPRECATED.Filter, pagination *page.Pagination) ([]*upload.Upload, error) {
@@ -281,6 +274,30 @@ func (d *DataSession) CreateDataSetData(ctx context.Context, dataSet *upload.Upl
 	return output
 }
 
+func (d *DataSession) ActivateDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error {
+	d.ActivateDataSetDataInvocations++
+
+	d.ActivateDataSetDataInputs = append(d.ActivateDataSetDataInputs, ActivateDataSetDataInput{Context: ctx, DataSet: dataSet, Selectors: selectors})
+
+	gomega.Expect(d.ActivateDataSetDataOutputs).ToNot(gomega.BeEmpty())
+
+	output := d.ActivateDataSetDataOutputs[0]
+	d.ActivateDataSetDataOutputs = d.ActivateDataSetDataOutputs[1:]
+	return output
+}
+
+func (d *DataSession) ArchiveDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error {
+	d.ArchiveDataSetDataInvocations++
+
+	d.ArchiveDataSetDataInputs = append(d.ArchiveDataSetDataInputs, ArchiveDataSetDataInput{Context: ctx, DataSet: dataSet, Selectors: selectors})
+
+	gomega.Expect(d.ArchiveDataSetDataOutputs).ToNot(gomega.BeEmpty())
+
+	output := d.ArchiveDataSetDataOutputs[0]
+	d.ArchiveDataSetDataOutputs = d.ArchiveDataSetDataOutputs[1:]
+	return output
+}
+
 func (d *DataSession) DeleteDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error {
 	d.DeleteDataSetDataInvocations++
 
@@ -293,15 +310,27 @@ func (d *DataSession) DeleteDataSetData(ctx context.Context, dataSet *upload.Upl
 	return output
 }
 
-func (d *DataSession) ActivateDataSetData(ctx context.Context, dataSet *upload.Upload) error {
-	d.ActivateDataSetDataInvocations++
+func (d *DataSession) DestroyDeletedDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error {
+	d.DestroyDeletedDataSetDataInvocations++
 
-	d.ActivateDataSetDataInputs = append(d.ActivateDataSetDataInputs, ActivateDataSetDataInput{Context: ctx, DataSet: dataSet})
+	d.DestroyDeletedDataSetDataInputs = append(d.DestroyDeletedDataSetDataInputs, DestroyDeletedDataSetDataInput{Context: ctx, DataSet: dataSet, Selectors: selectors})
 
-	gomega.Expect(d.ActivateDataSetDataOutputs).ToNot(gomega.BeEmpty())
+	gomega.Expect(d.DestroyDeletedDataSetDataOutputs).ToNot(gomega.BeEmpty())
 
-	output := d.ActivateDataSetDataOutputs[0]
-	d.ActivateDataSetDataOutputs = d.ActivateDataSetDataOutputs[1:]
+	output := d.DestroyDeletedDataSetDataOutputs[0]
+	d.DestroyDeletedDataSetDataOutputs = d.DestroyDeletedDataSetDataOutputs[1:]
+	return output
+}
+
+func (d *DataSession) DestroyDataSetData(ctx context.Context, dataSet *upload.Upload, selectors *data.Selectors) error {
+	d.DestroyDataSetDataInvocations++
+
+	d.DestroyDataSetDataInputs = append(d.DestroyDataSetDataInputs, DestroyDataSetDataInput{Context: ctx, DataSet: dataSet, Selectors: selectors})
+
+	gomega.Expect(d.DestroyDataSetDataOutputs).ToNot(gomega.BeEmpty())
+
+	output := d.DestroyDataSetDataOutputs[0]
+	d.DestroyDataSetDataOutputs = d.DestroyDataSetDataOutputs[1:]
 	return output
 }
 
@@ -326,30 +355,6 @@ func (d *DataSession) UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.Cont
 
 	output := d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs[0]
 	d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs = d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs[1:]
-	return output
-}
-
-func (d *DataSession) ArchiveDataSetDataUsingOriginIDs(ctx context.Context, dataSet *upload.Upload, originIDs []string) error {
-	d.ArchiveDataSetDataUsingOriginIDsInvocations++
-
-	d.ArchiveDataSetDataUsingOriginIDsInputs = append(d.ArchiveDataSetDataUsingOriginIDsInputs, ArchiveDataSetDataUsingOriginIDsInput{Context: ctx, DataSet: dataSet, OriginIDs: originIDs})
-
-	gomega.Expect(d.ArchiveDataSetDataUsingOriginIDsOutputs).ToNot(gomega.BeEmpty())
-
-	output := d.ArchiveDataSetDataUsingOriginIDsOutputs[0]
-	d.ArchiveDataSetDataUsingOriginIDsOutputs = d.ArchiveDataSetDataUsingOriginIDsOutputs[1:]
-	return output
-}
-
-func (d *DataSession) DeleteArchivedDataSetData(ctx context.Context, dataSet *upload.Upload) error {
-	d.DeleteArchivedDataSetDataInvocations++
-
-	d.DeleteArchivedDataSetDataInputs = append(d.DeleteArchivedDataSetDataInputs, DeleteArchivedDataSetDataInput{Context: ctx, DataSet: dataSet})
-
-	gomega.Expect(d.DeleteArchivedDataSetDataOutputs).ToNot(gomega.BeEmpty())
-
-	output := d.DeleteArchivedDataSetDataOutputs[0]
-	d.DeleteArchivedDataSetDataOutputs = d.DeleteArchivedDataSetDataOutputs[1:]
 	return output
 }
 
@@ -404,16 +409,17 @@ func (d *DataSession) GetDataSet(ctx context.Context, id string) (*data.DataSet,
 func (d *DataSession) Expectations() {
 	d.Mock.Expectations()
 	d.Closer.AssertOutputsEmpty()
-	gomega.Expect(d.IsClosedOutputs).To(gomega.BeEmpty())
-	gomega.Expect(d.EnsureIndexesOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.GetDataSetsForUserByIDOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.GetDataSetByIDOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.CreateDataSetOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.UpdateDataSetOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.DeleteDataSetOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.CreateDataSetDataOutputs).To(gomega.BeEmpty())
-	gomega.Expect(d.DeleteDataSetDataOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.ActivateDataSetDataOutputs).To(gomega.BeEmpty())
+	gomega.Expect(d.ArchiveDataSetDataOutputs).To(gomega.BeEmpty())
+	gomega.Expect(d.DeleteDataSetDataOutputs).To(gomega.BeEmpty())
+	gomega.Expect(d.DestroyDeletedDataSetDataOutputs).To(gomega.BeEmpty())
+	gomega.Expect(d.DestroyDataSetDataOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.ArchiveDeviceDataUsingHashesFromDataSetOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.UnarchiveDeviceDataUsingHashesFromDataSetOutputs).To(gomega.BeEmpty())
 	gomega.Expect(d.DeleteOtherDataSetDataOutputs).To(gomega.BeEmpty())

--- a/data/test/data.go
+++ b/data/test/data.go
@@ -35,8 +35,11 @@ func CloneSelectorOrigin(datum *data.SelectorOrigin) *data.SelectorOrigin {
 
 func RandomSelector() *data.Selector {
 	datum := data.NewSelector()
-	datum.ID = pointer.FromString(RandomID())
-	datum.Origin = RandomSelectorOrigin()
+	if test.RandomBool() {
+		datum.ID = pointer.FromString(RandomID())
+	} else {
+		datum.Origin = RandomSelectorOrigin()
+	}
 	return datum
 }
 

--- a/data/test/data_set.go
+++ b/data/test/data_set.go
@@ -1,8 +1,12 @@
 package test
 
 import (
+	"math/rand"
+
 	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
+	timeZoneTest "github.com/tidepool-org/platform/time/zone/test"
 )
 
 func RandomSetID() string {
@@ -11,4 +15,22 @@ func RandomSetID() string {
 
 func RandomSetIDs() []string {
 	return test.RandomStringArrayFromRangeAndGeneratorWithoutDuplicates(1, 3, RandomSetID)
+}
+
+func RandomDataSetUpdate() *data.DataSetUpdate {
+	datum := data.NewDataSetUpdate()
+	datum.Active = pointer.FromBool(false)
+	datum.DeviceID = pointer.FromString(NewDeviceID())
+	datum.DeviceModel = pointer.FromString(test.NewText(1, 32))
+	datum.DeviceSerialNumber = pointer.FromString(test.NewText(1, 16))
+	datum.Deduplicator = RandomDeduplicatorDescriptor()
+	datum.State = pointer.FromString(test.RandomStringFromArray([]string{"closed", "open"}))
+	datum.Time = pointer.FromTime(test.NewTime())
+	datum.TimeZoneName = pointer.FromString(timeZoneTest.RandomName())
+	datum.TimeZoneOffset = pointer.FromInt(RandomTimeZoneOffset())
+	return datum
+}
+
+func RandomTimeZoneOffset() int {
+	return -4440 + rand.Intn(4440+6960)
 }


### PR DESCRIPTION
* Update delete data set origin deduplicator to delete duplicates found when adding data
* Update delete data set origin deduplicator to deactivate deleted data
* Update base deduplicator to activate data set separately from data set data
* Update data store to not activate data set when data set data activated
* Add data selectors to data set data operations to target specific data records
* Update data store to add activate, archive, delete, destroy deleted, and destroy operations on data set data
* Refactor data store and test for code consistency

@jh-bate 