### PR TITLE
Fix data set id validation to allow Jellyfish id format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Fix data set id validation to allow Jellyfish id format
+
 ## v1.30.0
 
 * Fix Dexcom API v2 edge cases

--- a/data/data.go
+++ b/data/data.go
@@ -121,7 +121,7 @@ func IDValidator(value string, errorReporter structure.ErrorReporter) {
 func ValidateID(value string) error {
 	if value == "" {
 		return structureValidator.ErrorValueEmpty()
-	} else if !setIDExpression.MatchString(value) {
+	} else if !idExpression.MatchString(value) {
 		return ErrorValueStringAsIDNotValid(value)
 	}
 	return nil
@@ -131,4 +131,4 @@ func ErrorValueStringAsIDNotValid(value string) error {
 	return errors.Preparedf(structureValidator.ErrorCodeValueNotValid, "value is not valid", "value %q is not valid as data id", value)
 }
 
-var idExpression = regexp.MustCompile("^[0-9a-z]{32}$")
+var idExpression = regexp.MustCompile("^[0-9a-z]{32}$") // TODO: Want just "[0-9a-f]{32}" (Jellyfish uses [0-9a-z])

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Data", func() {
 			Entry("is empty", "", structureValidator.ErrorValueEmpty()),
 			Entry("has string length out of range (lower)", "0123456789abcdef0123456789abcde", data.ErrorValueStringAsIDNotValid("0123456789abcdef0123456789abcde")),
 			Entry("has string length in range", test.RandomStringFromRangeAndCharset(32, 32, test.CharsetHexidecimalLowercase)),
+			Entry("has string length in range for Jellyfish", test.RandomStringFromRangeAndCharset(32, 32, test.CharsetNumeric+test.CharsetLowercase)),
 			Entry("has string length out of range (upper)", "0123456789abcdef0123456789abcdef0", data.ErrorValueStringAsIDNotValid("0123456789abcdef0123456789abcdef0")),
 			Entry("has uppercase characters", "0123456789ABCDEF0123456789abcdef", data.ErrorValueStringAsIDNotValid("0123456789ABCDEF0123456789abcdef")),
 			Entry("has symbols", "0123456789$%^&*(0123456789abcdef", data.ErrorValueStringAsIDNotValid("0123456789$%^&*(0123456789abcdef")),


### PR DESCRIPTION
@pazaan Same as already approved PR https://github.com/tidepool-org/platform/pull/384. Moving to a `develop` branch so created a new PR to keep it clean.
