### PR TITLE
Fix blob size verification and handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## HEAD
 
+* Return HTTP status code 413 Request Entity Too Large when blob size exceeds maximum
+* Replace blob.Create with blob.Content
+* Remove blob Content-Length header usage and blob.Content.Size as it does not work with content encoding
+* Update test config reporter for better debugging
+* Fix randomly failing profile mongo test
 * Fix unused tests
 * Fix import ordering due to Golang tool changes
 * Update dependencies

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -34,7 +34,7 @@ func Statuses() []string {
 
 type Client interface {
 	List(ctx context.Context, userID string, filter *Filter, pagination *page.Pagination) (Blobs, error)
-	Create(ctx context.Context, userID string, create *Create) (*Blob, error)
+	Create(ctx context.Context, userID string, content *Content) (*Blob, error)
 	Get(ctx context.Context, id string) (*Blob, error)
 	GetContent(ctx context.Context, id string) (*Content, error)
 	Delete(ctx context.Context, id string, condition *request.Condition) (bool, error)
@@ -70,29 +70,10 @@ func (f *Filter) MutateRequest(req *http.Request) error {
 	return request.NewArrayParametersMutator(parameters).MutateRequest(req)
 }
 
-type Create struct {
-	Body      io.Reader
-	DigestMD5 *string
-	MediaType *string
-}
-
-func NewCreate() *Create {
-	return &Create{}
-}
-
-func (c *Create) Validate(validator structure.Validator) {
-	if c.Body == nil {
-		validator.WithReference("body").ReportError(structureValidator.ErrorValueNotExists())
-	}
-	validator.String("digestMD5", c.DigestMD5).Using(crypto.Base64EncodedMD5HashValidator)
-	validator.String("mediaType", c.MediaType).Exists().Using(net.MediaTypeValidator)
-}
-
 type Content struct {
 	Body      io.ReadCloser
 	DigestMD5 *string
 	MediaType *string
-	Size      *int
 }
 
 func NewContent() *Content {
@@ -103,9 +84,8 @@ func (c *Content) Validate(validator structure.Validator) {
 	if c.Body == nil {
 		validator.WithReference("body").ReportError(structureValidator.ErrorValueNotExists())
 	}
-	validator.String("digestMD5", c.DigestMD5).Exists().Using(crypto.Base64EncodedMD5HashValidator)
+	validator.String("digestMD5", c.DigestMD5).Using(crypto.Base64EncodedMD5HashValidator)
 	validator.String("mediaType", c.MediaType).Exists().Using(net.MediaTypeValidator)
-	validator.Int("size", c.Size).Exists().GreaterThanOrEqualTo(0)
 }
 
 type Blob struct {

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -255,79 +255,6 @@ var _ = Describe("Blob", func() {
 		})
 	})
 
-	Context("NewCreate", func() {
-		It("returns successfully with default values", func() {
-			create := blob.NewCreate()
-			Expect(create).ToNot(BeNil())
-			Expect(create.Body).To(BeNil())
-			Expect(create.DigestMD5).To(BeNil())
-			Expect(create.MediaType).To(BeNil())
-		})
-	})
-
-	Context("Create", func() {
-		Context("Validate", func() {
-			DescribeTable("validates the datum",
-				func(mutator func(datum *blob.Create), expectedErrors ...error) {
-					datum := blobTest.RandomCreate()
-					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
-				},
-				Entry("succeeds",
-					func(datum *blob.Create) {},
-				),
-				Entry("body missing",
-					func(datum *blob.Create) { datum.Body = nil },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/body"),
-				),
-				Entry("body valid",
-					func(datum *blob.Create) { datum.Body = bytes.NewReader(test.RandomBytes()) },
-				),
-				Entry("digest MD5 missing",
-					func(datum *blob.Create) { datum.DigestMD5 = nil },
-				),
-				Entry("digest MD5 empty",
-					func(datum *blob.Create) { datum.DigestMD5 = pointer.FromString("") },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/digestMD5"),
-				),
-				Entry("digest MD5 invalid",
-					func(datum *blob.Create) { datum.DigestMD5 = pointer.FromString("#") },
-					errorsTest.WithPointerSource(crypto.ErrorValueStringAsBase64EncodedMD5HashNotValid("#"), "/digestMD5"),
-				),
-				Entry("digest MD5 valid",
-					func(datum *blob.Create) {
-						datum.DigestMD5 = pointer.FromString(cryptoTest.RandomBase64EncodedMD5Hash())
-					},
-				),
-				Entry("media type missing",
-					func(datum *blob.Create) { datum.MediaType = nil },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/mediaType"),
-				),
-				Entry("media type empty",
-					func(datum *blob.Create) { datum.MediaType = pointer.FromString("") },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/mediaType"),
-				),
-				Entry("media type invalid",
-					func(datum *blob.Create) { datum.MediaType = pointer.FromString("/") },
-					errorsTest.WithPointerSource(net.ErrorValueStringAsMediaTypeNotValid("/"), "/mediaType"),
-				),
-				Entry("media type valid",
-					func(datum *blob.Create) { datum.MediaType = pointer.FromString(netTest.RandomMediaType()) },
-				),
-				Entry("multiple errors",
-					func(datum *blob.Create) {
-						datum.Body = nil
-						datum.DigestMD5 = pointer.FromString("")
-						datum.MediaType = nil
-					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/body"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/digestMD5"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/mediaType"),
-				),
-			)
-		})
-	})
-
 	Context("NewContent", func() {
 		It("returns successfully with default values", func() {
 			content := blob.NewContent()
@@ -358,7 +285,6 @@ var _ = Describe("Blob", func() {
 				),
 				Entry("digest MD5 missing",
 					func(datum *blob.Content) { datum.DigestMD5 = nil },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/digestMD5"),
 				),
 				Entry("digest MD5 empty",
 					func(datum *blob.Content) { datum.DigestMD5 = pointer.FromString("") },
@@ -388,28 +314,15 @@ var _ = Describe("Blob", func() {
 				Entry("media type valid",
 					func(datum *blob.Content) { datum.MediaType = pointer.FromString(netTest.RandomMediaType()) },
 				),
-				Entry("size missing",
-					func(datum *blob.Content) { datum.Size = nil },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/size"),
-				),
-				Entry("size out of range (lower)",
-					func(datum *blob.Content) { datum.Size = pointer.FromInt(-1) },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/size"),
-				),
-				Entry("size in range (lower)",
-					func(datum *blob.Content) { datum.Size = pointer.FromInt(0) },
-				),
 				Entry("multiple errors",
 					func(datum *blob.Content) {
 						datum.Body = nil
 						datum.DigestMD5 = pointer.FromString("")
 						datum.MediaType = nil
-						datum.Size = pointer.FromInt(-1)
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/body"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/digestMD5"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/mediaType"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/size"),
 				),
 			)
 		})

--- a/blob/client/client.go
+++ b/blob/client/client.go
@@ -58,7 +58,7 @@ func (c *Client) List(ctx context.Context, userID string, filter *blob.Filter, p
 	return result, nil
 }
 
-func (c *Client) Create(ctx context.Context, userID string, create *blob.Create) (*blob.Blob, error) {
+func (c *Client) Create(ctx context.Context, userID string, content *blob.Content) (*blob.Blob, error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")
 	}
@@ -67,23 +67,23 @@ func (c *Client) Create(ctx context.Context, userID string, create *blob.Create)
 	} else if !user.IsValidID(userID) {
 		return nil, errors.New("user id is invalid")
 	}
-	if create == nil {
-		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
-		return nil, errors.Wrap(err, "create is invalid")
+	if content == nil {
+		return nil, errors.New("content is missing")
+	} else if err := structureValidator.New().Validate(content); err != nil {
+		return nil, errors.Wrap(err, "content is invalid")
 	}
 
 	var mutators []request.RequestMutator
-	if create.DigestMD5 != nil {
-		mutators = append(mutators, request.NewHeaderMutator("Digest", fmt.Sprintf("MD5=%s", *create.DigestMD5)))
+	if content.DigestMD5 != nil {
+		mutators = append(mutators, request.NewHeaderMutator("Digest", fmt.Sprintf("MD5=%s", *content.DigestMD5)))
 	}
-	if create.MediaType != nil {
-		mutators = append(mutators, request.NewHeaderMutator("Content-Type", *create.MediaType))
+	if content.MediaType != nil {
+		mutators = append(mutators, request.NewHeaderMutator("Content-Type", *content.MediaType))
 	}
 
 	url := c.client.ConstructURL("v1", "users", userID, "blobs")
 	result := &blob.Blob{}
-	if err := c.client.RequestData(ctx, http.MethodPost, url, mutators, create.Body, result); err != nil {
+	if err := c.client.RequestData(ctx, http.MethodPost, url, mutators, content.Body, result); err != nil {
 		return nil, err
 	}
 
@@ -140,16 +140,11 @@ func (c *Client) GetContent(ctx context.Context, id string) (*blob.Content, erro
 	if err != nil {
 		return nil, err
 	}
-	size, err := request.ParseIntHeader(headersInspector.Headers, "Content-Length")
-	if err != nil {
-		return nil, err
-	}
 
 	return &blob.Content{
 		Body:      body,
 		DigestMD5: digestMD5,
 		MediaType: mediaType,
-		Size:      size,
 	}, nil
 }
 

--- a/blob/service/api/v1/v1.go
+++ b/blob/service/api/v1/v1.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/ant0ine/go-json-rest/rest"
 
@@ -93,12 +92,12 @@ func (r *Router) Create(res rest.ResponseWriter, req *rest.Request) {
 		return
 	}
 
-	create := blob.NewCreate()
-	create.Body = req.Body
-	create.DigestMD5 = digestMD5
-	create.MediaType = mediaType
+	content := blob.NewContent()
+	content.Body = req.Body
+	content.DigestMD5 = digestMD5
+	content.MediaType = mediaType
 
-	result, err := r.provider.BlobClient().Create(req.Context(), userID, create)
+	result, err := r.provider.BlobClient().Create(req.Context(), userID, content)
 	if err != nil {
 		if errors.Code(err) == blob.ErrorCodeDigestsNotEqual {
 			responder.Error(http.StatusBadRequest, err)
@@ -161,9 +160,6 @@ func (r *Router) GetContent(res rest.ResponseWriter, req *rest.Request) {
 	}
 	if content.MediaType != nil {
 		mutators = append(mutators, request.NewHeaderMutator("Content-Type", *content.MediaType))
-	}
-	if content.Size != nil {
-		mutators = append(mutators, request.NewHeaderMutator("Content-Length", strconv.Itoa(*content.Size)))
 	}
 
 	responder.Reader(http.StatusOK, content.Body, mutators...)

--- a/blob/service/api/v1/v1_test.go
+++ b/blob/service/api/v1/v1_test.go
@@ -358,26 +358,26 @@ var _ = Describe("V1", func() {
 							})
 						})
 
-						Context("with create", func() {
-							var create *blob.Create
+						Context("with content", func() {
+							var content *blob.Content
 
 							BeforeEach(func() {
-								create = blobTest.RandomCreate()
+								content = blobTest.RandomContent()
 							})
 
 							JustBeforeEach(func() {
-								req.Body = ioutil.NopCloser(create.Body)
-								if create.DigestMD5 != nil {
-									req.Header.Add("Digest", fmt.Sprintf("md5=%s", *create.DigestMD5))
+								req.Body = ioutil.NopCloser(content.Body)
+								if content.DigestMD5 != nil {
+									req.Header.Add("Digest", fmt.Sprintf("md5=%s", *content.DigestMD5))
 								}
-								if create.MediaType != nil {
-									req.Header.Add("Content-Type", *create.MediaType)
+								if content.MediaType != nil {
+									req.Header.Add("Content-Type", *content.MediaType)
 								}
 							})
 
 							When("the digest header is invalid", func() {
 								BeforeEach(func() {
-									create.DigestMD5 = pointer.FromString("invalid")
+									content.DigestMD5 = pointer.FromString("invalid")
 								})
 
 								It("responds with bad request and expected error in body", func() {
@@ -391,7 +391,7 @@ var _ = Describe("V1", func() {
 
 							When("the digest header is invalid with multiple values", func() {
 								BeforeEach(func() {
-									req.Header.Add("Digest", fmt.Sprintf("md5=%s", *create.DigestMD5))
+									req.Header.Add("Digest", fmt.Sprintf("md5=%s", *content.DigestMD5))
 								})
 
 								It("responds with bad request and expected error in body", func() {
@@ -405,7 +405,7 @@ var _ = Describe("V1", func() {
 
 							When("the content type header is missing", func() {
 								BeforeEach(func() {
-									create.MediaType = nil
+									content.MediaType = nil
 								})
 
 								It("responds with bad request and expected error in body", func() {
@@ -419,7 +419,7 @@ var _ = Describe("V1", func() {
 
 							When("the content type header is invalid", func() {
 								BeforeEach(func() {
-									create.MediaType = pointer.FromString("/")
+									content.MediaType = pointer.FromString("/")
 								})
 
 								It("responds with bad request and expected error in body", func() {
@@ -433,7 +433,7 @@ var _ = Describe("V1", func() {
 
 							When("the content type header is invalid with multiple values", func() {
 								BeforeEach(func() {
-									req.Header.Add("Content-Type", *create.MediaType)
+									req.Header.Add("Content-Type", *content.MediaType)
 								})
 
 								It("responds with bad request and expected error in body", func() {
@@ -499,17 +499,17 @@ var _ = Describe("V1", func() {
 
 								When("the digest header is not specified", func() {
 									BeforeEach(func() {
-										create.DigestMD5 = nil
+										content.DigestMD5 = nil
 									})
 
 									AfterEach(func() {
 										Expect(client.CreateInputs).To(Equal([]blobTest.CreateInput{{
 											Context: ctx,
 											UserID:  userID,
-											Create: &blob.Create{
-												Body:      ioutil.NopCloser(create.Body),
+											Content: &blob.Content{
+												Body:      ioutil.NopCloser(content.Body),
 												DigestMD5: nil,
-												MediaType: create.MediaType,
+												MediaType: content.MediaType,
 											},
 										}}))
 									})
@@ -522,10 +522,10 @@ var _ = Describe("V1", func() {
 										Expect(client.CreateInputs).To(Equal([]blobTest.CreateInput{{
 											Context: ctx,
 											UserID:  userID,
-											Create: &blob.Create{
-												Body:      ioutil.NopCloser(create.Body),
-												DigestMD5: create.DigestMD5,
-												MediaType: create.MediaType,
+											Content: &blob.Content{
+												Body:      ioutil.NopCloser(content.Body),
+												DigestMD5: content.DigestMD5,
+												MediaType: content.MediaType,
 											},
 										}}))
 									})
@@ -736,16 +736,14 @@ var _ = Describe("V1", func() {
 							content.Body = ioutil.NopCloser(bytes.NewReader(body))
 							content.DigestMD5 = pointer.FromString(cryptoTest.RandomBase64EncodedMD5Hash())
 							content.MediaType = pointer.FromString(netTest.RandomMediaType())
-							content.Size = pointer.FromInt(test.RandomIntFromRange(1, 100*1024*1024))
 							client.GetContentOutputs = []blobTest.GetContentOutput{{Content: content, Error: nil}}
 							res.WriteOutputs = []testRest.WriteOutput{{BytesWritten: 0, Error: nil}}
 							handlerFunc(res, req)
 							Expect(res.WriteHeaderInputs).To(Equal([]int{http.StatusOK}))
 							Expect(res.WriteInputs).To(Equal([][]byte{body}))
 							Expect(res.HeaderOutput).To(Equal(&http.Header{
-								"Content-Length": []string{strconv.Itoa(*content.Size)},
-								"Content-Type":   []string{*content.MediaType},
-								"Digest":         []string{fmt.Sprintf("MD5=%s", *content.DigestMD5)},
+								"Content-Type": []string{*content.MediaType},
+								"Digest":       []string{fmt.Sprintf("MD5=%s", *content.DigestMD5)},
 							}))
 						})
 					})

--- a/blob/test/blob.go
+++ b/blob/test/blob.go
@@ -46,22 +46,12 @@ func NewObjectFromFilter(datum *blob.Filter, objectFormat test.ObjectFormat) map
 	return object
 }
 
-func RandomCreate() *blob.Create {
-	content := test.RandomBytes()
-	datum := &blob.Create{}
-	datum.Body = bytes.NewReader(content)
-	datum.DigestMD5 = pointer.FromString(crypto.Base64EncodedMD5Hash(content))
-	datum.MediaType = pointer.FromString(netTest.RandomMediaType())
-	return datum
-}
-
 func RandomContent() *blob.Content {
 	content := test.RandomBytes()
 	datum := &blob.Content{}
 	datum.Body = ioutil.NopCloser(bytes.NewReader(content))
 	datum.DigestMD5 = pointer.FromString(crypto.Base64EncodedMD5Hash(content))
 	datum.MediaType = pointer.FromString(netTest.RandomMediaType())
-	datum.Size = pointer.FromInt(test.RandomIntFromRange(1, 100*1024*1024))
 	return datum
 }
 

--- a/blob/test/client.go
+++ b/blob/test/client.go
@@ -23,7 +23,7 @@ type ListOutput struct {
 type CreateInput struct {
 	Context context.Context
 	UserID  string
-	Create  *blob.Create
+	Content *blob.Content
 }
 
 type CreateOutput struct {
@@ -70,7 +70,7 @@ type Client struct {
 	ListOutput            *ListOutput
 	CreateInvocations     int
 	CreateInputs          []CreateInput
-	CreateStub            func(ctx context.Context, userID string, create *blob.Create) (*blob.Blob, error)
+	CreateStub            func(ctx context.Context, userID string, content *blob.Content) (*blob.Blob, error)
 	CreateOutputs         []CreateOutput
 	CreateOutput          *CreateOutput
 	GetInvocations        int
@@ -111,11 +111,11 @@ func (c *Client) List(ctx context.Context, userID string, filter *blob.Filter, p
 	panic("List has no output")
 }
 
-func (c *Client) Create(ctx context.Context, userID string, create *blob.Create) (*blob.Blob, error) {
+func (c *Client) Create(ctx context.Context, userID string, content *blob.Content) (*blob.Blob, error) {
 	c.CreateInvocations++
-	c.CreateInputs = append(c.CreateInputs, CreateInput{Context: ctx, UserID: userID, Create: create})
+	c.CreateInputs = append(c.CreateInputs, CreateInput{Context: ctx, UserID: userID, Content: content})
 	if c.CreateStub != nil {
-		return c.CreateStub(ctx, userID, create)
+		return c.CreateStub(ctx, userID, content)
 	}
 	if len(c.CreateOutputs) > 0 {
 		output := c.CreateOutputs[0]

--- a/client/client.go
+++ b/client/client.go
@@ -208,6 +208,8 @@ func errorFromStatusCode(res *http.Response, req *http.Request) error {
 		return request.ErrorUnauthorized()
 	case http.StatusNotFound:
 		return request.ErrorResourceNotFound()
+	case http.StatusRequestEntityTooLarge:
+		return request.ErrorResourceTooLarge()
 	case http.StatusTooManyRequests:
 		return request.ErrorTooManyRequests()
 	default:

--- a/config/test/reporter.go
+++ b/config/test/reporter.go
@@ -1,18 +1,21 @@
 package test
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/tidepool-org/platform/config"
-	"github.com/tidepool-org/platform/test"
 )
 
 type Reporter struct {
-	*test.Mock
+	Scopes []string
 	Config map[string]interface{}
+	Debug  bool
 }
 
 func NewReporter() *Reporter {
 	return &Reporter{
-		Mock:   test.NewMock(),
+		Scopes: []string{},
 		Config: map[string]interface{}{},
 	}
 }
@@ -20,32 +23,40 @@ func NewReporter() *Reporter {
 func (r *Reporter) Get(key string) (string, error) {
 	raw, found := r.Config[key]
 	if !found {
+		r.debug("Reporter.Get(%q) returning error ErrorKeyNotFound", key)
 		return "", config.ErrorKeyNotFound(key)
 	}
 	value, ok := raw.(string)
 	if !ok {
+		r.debug("Reporter.Get(%q) returning error ErrorKeyNotFound", key)
 		return "", config.ErrorKeyNotFound(key)
 	}
+	r.debug("Reporter.Get(%q) returning value %q", key, value)
 	return value, nil
 }
 
 func (r *Reporter) GetWithDefault(key string, defaultValue string) string {
 	value, err := r.Get(key)
 	if err != nil {
+		r.debug("Reporter.GetWithDefault(%q, %q) returning default value", key, defaultValue)
 		return defaultValue
 	}
+	r.debug("Reporter.GetWithDefault(%q, %q) returning value %q", key, defaultValue, value)
 	return value
 }
 
 func (r *Reporter) Set(key string, value string) {
+	r.debug("Reporter.Set(%q, %q)", key, value)
 	r.Config[key] = value
 }
 
 func (r *Reporter) Delete(key string) {
+	r.debug("Reporter.Delete(%q)", key)
 	delete(r.Config, key)
 }
 
 func (r *Reporter) WithScopes(scopes ...string) config.Reporter {
+	r.debug("Reporter.WithScopes(%#v) returning new Reporter", scopes)
 	config := r.Config
 	for _, scope := range scopes {
 		raw, _ := config[scope]
@@ -55,7 +66,13 @@ func (r *Reporter) WithScopes(scopes ...string) config.Reporter {
 		config = map[string]interface{}{}
 	}
 	return &Reporter{
-		Mock:   test.NewMock(),
+		Scopes: append(r.Scopes, scopes...),
 		Config: config,
+	}
+}
+
+func (r *Reporter) debug(format string, a ...interface{}) {
+	if r.Debug {
+		fmt.Fprintf(os.Stderr, "DEBUG: %s with scopes %#v\n", fmt.Sprintf(format, a...), r.Scopes)
 	}
 }

--- a/profile/store/mongo/mongo_test.go
+++ b/profile/store/mongo/mongo_test.go
@@ -2,6 +2,7 @@ package mongo_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,7 +25,7 @@ func RandomProfileID() string {
 func NewProfile(profileID string, fullName string) bson.M {
 	return bson.M{
 		"_id":   profileID,
-		"value": `{"profile":{"fullName":"` + fullName + `","patient":{"birthday":"2000-01-01","diagnosisDate":"2010-12-31","targetDevices":["dexcom","tandem"],"targetTimezone":"US/Pacific"}},"private":{"uploads":{"name":"","id":"1234567890","hash":"1234567890abcdef"}}}`,
+		"value": fmt.Sprintf(`{"profile":{"fullName":%q,"patient":{"birthday":"2000-01-01","diagnosisDate":"2010-12-31","targetDevices":["dexcom","tandem"],"targetTimezone":"US/Pacific"}},"private":{"uploads":{"name":"","id":"1234567890","hash":"1234567890abcdef"}}}`, fullName),
 	}
 }
 

--- a/request/errors.go
+++ b/request/errors.go
@@ -14,6 +14,7 @@ const (
 	ErrorCodeUnauthenticated     = "unauthenticated"
 	ErrorCodeUnauthorized        = "unauthorized"
 	ErrorCodeResourceNotFound    = "resource-not-found"
+	ErrorCodeResourceTooLarge    = "resource-too-large"
 	ErrorCodeHeaderMissing       = "header-missing"
 	ErrorCodeHeaderInvalid       = "header-invalid"
 	ErrorCodeParameterMissing    = "parameter-missing"
@@ -64,6 +65,10 @@ func ErrorResourceNotFoundWithIDAndOptionalRevision(id string, revision *int) er
 	return ErrorResourceNotFoundWithID(id)
 }
 
+func ErrorResourceTooLarge() error {
+	return errors.Preparedf(ErrorCodeResourceTooLarge, "resource too large", "resource too large")
+}
+
 func ErrorHeaderMissing(key string) error {
 	return errors.Preparedf(ErrorCodeHeaderMissing, "header is missing", "header %q is missing", key)
 }
@@ -97,6 +102,8 @@ func StatusCodeForError(err error) int {
 			return http.StatusForbidden
 		case ErrorCodeResourceNotFound:
 			return http.StatusNotFound
+		case ErrorCodeResourceTooLarge:
+			return http.StatusRequestEntityTooLarge
 		}
 	}
 	return http.StatusInternalServerError

--- a/request/errors_test.go
+++ b/request/errors_test.go
@@ -13,22 +13,60 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
-	testHTTP "github.com/tidepool-org/platform/test/http"
+	testHttp "github.com/tidepool-org/platform/test/http"
 )
 
 var _ = Describe("Errors", func() {
-	Context("ErrorUnexpectedResponse", func() {
-		It("returns the expected error", func() {
-			req := testHTTP.NewRequest()
-			res := &http.Response{StatusCode: 405}
-			err := request.ErrorUnexpectedResponse(res, req)
-			Expect(err).ToNot(BeNil())
-			Expect(errors.Code(err)).To(Equal("unexpected-response"))
-			Expect(errors.Cause(err)).To(Equal(err))
-			bytes, bytesErr := json.Marshal(errors.Sanitize(err))
-			Expect(bytesErr).ToNot(HaveOccurred())
-			Expect(bytes).To(MatchJSON(fmt.Sprintf(`{"code": "unexpected-response", "title": "unexpected response", "detail": "unexpected response status code %d from %s \"%s\""}`, res.StatusCode, req.Method, req.URL.String())))
-		})
+	It("ErrorCodeInternalServerError is expected", func() {
+		Expect(request.ErrorCodeInternalServerError).To(Equal("internal-server-error"))
+	})
+
+	It("ErrorCodeUnexpectedResponse is expected", func() {
+		Expect(request.ErrorCodeUnexpectedResponse).To(Equal("unexpected-response"))
+	})
+
+	It("ErrorCodeTooManyRequests is expected", func() {
+		Expect(request.ErrorCodeTooManyRequests).To(Equal("too-many-requests"))
+	})
+
+	It("ErrorCodeBadRequest is expected", func() {
+		Expect(request.ErrorCodeBadRequest).To(Equal("bad-request"))
+	})
+
+	It("ErrorCodeUnauthenticated is expected", func() {
+		Expect(request.ErrorCodeUnauthenticated).To(Equal("unauthenticated"))
+	})
+
+	It("ErrorCodeUnauthorized is expected", func() {
+		Expect(request.ErrorCodeUnauthorized).To(Equal("unauthorized"))
+	})
+
+	It("ErrorCodeResourceNotFound is expected", func() {
+		Expect(request.ErrorCodeResourceNotFound).To(Equal("resource-not-found"))
+	})
+
+	It("ErrorCodeResourceTooLarge is expected", func() {
+		Expect(request.ErrorCodeResourceTooLarge).To(Equal("resource-too-large"))
+	})
+
+	It("ErrorCodeHeaderMissing is expected", func() {
+		Expect(request.ErrorCodeHeaderMissing).To(Equal("header-missing"))
+	})
+
+	It("ErrorCodeHeaderInvalid is expected", func() {
+		Expect(request.ErrorCodeHeaderInvalid).To(Equal("header-invalid"))
+	})
+
+	It("ErrorCodeParameterMissing is expected", func() {
+		Expect(request.ErrorCodeParameterMissing).To(Equal("parameter-missing"))
+	})
+
+	It("ErrorCodeParameterInvalid is expected", func() {
+		Expect(request.ErrorCodeParameterInvalid).To(Equal("parameter-invalid"))
+	})
+
+	It("ErrorCodeJSONMalformed is expected", func() {
+		Expect(request.ErrorCodeJSONMalformed).To(Equal("json-malformed"))
 	})
 
 	Context("ErrorInternalServerError", func() {
@@ -44,6 +82,20 @@ var _ = Describe("Errors", func() {
 		})
 	})
 
+	Context("ErrorUnexpectedResponse", func() {
+		It("returns the expected error", func() {
+			req := testHttp.NewRequest()
+			res := &http.Response{StatusCode: 405}
+			err := request.ErrorUnexpectedResponse(res, req)
+			Expect(err).ToNot(BeNil())
+			Expect(errors.Code(err)).To(Equal("unexpected-response"))
+			Expect(errors.Cause(err)).To(Equal(err))
+			bytes, bytesErr := json.Marshal(errors.Sanitize(err))
+			Expect(bytesErr).ToNot(HaveOccurred())
+			Expect(bytes).To(MatchJSON(fmt.Sprintf(`{"code": "unexpected-response", "title": "unexpected response", "detail": "unexpected response status code %d from %s \"%s\""}`, res.StatusCode, req.Method, req.URL.String())))
+		})
+	})
+
 	DescribeTable("have expected details when error",
 		errorsTest.ExpectErrorDetails,
 		Entry("is ErrorTooManyRequests", request.ErrorTooManyRequests(), "too-many-requests", "too many requests", "too many requests"),
@@ -55,6 +107,7 @@ var _ = Describe("Errors", func() {
 		Entry("is ErrorResourceNotFoundWithIDAndRevision", request.ErrorResourceNotFoundWithIDAndRevision("test-id", 1), "resource-not-found", "resource not found", `revision 1 of resource with id "test-id" not found`),
 		Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", nil), "resource-not-found", "resource not found", `resource with id "test-id" not found`),
 		Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", pointer.FromInt(1)), "resource-not-found", "resource not found", `revision 1 of resource with id "test-id" not found`),
+		Entry("is ErrorResourceTooLarge", request.ErrorResourceTooLarge(), "resource-too-large", "resource too large", "resource too large"),
 		Entry("is ErrorHeaderMissing", request.ErrorHeaderMissing("X-Test-Header"), "header-missing", "header is missing", `header "X-Test-Header" is missing`),
 		Entry("is ErrorHeaderInvalid", request.ErrorHeaderInvalid("X-Test-Header"), "header-invalid", "header is invalid", `header "X-Test-Header" is invalid`),
 		Entry("is ErrorParameterMissing", request.ErrorParameterMissing("test_parameter"), "parameter-missing", "parameter is missing", `parameter "test_parameter" is missing`),
@@ -76,6 +129,7 @@ var _ = Describe("Errors", func() {
 			Entry("is ErrorResourceNotFoundWithIDAndRevision", request.ErrorResourceNotFoundWithIDAndRevision("test-id", 1), 404),
 			Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", nil), 404),
 			Entry("is ErrorResourceNotFoundWithIDAndOptionalRevision", request.ErrorResourceNotFoundWithIDAndOptionalRevision("test-id", pointer.FromInt(1)), 404),
+			Entry("is ErrorResourceTooLarge", request.ErrorResourceTooLarge(), 413),
 			Entry("is another request error", request.ErrorJSONMalformed(), 500),
 			Entry("is another error", errors.New("test-error"), 500),
 			Entry("is nil error", nil, 500),

--- a/service/test/service.go
+++ b/service/test/service.go
@@ -78,7 +78,6 @@ func (s *Service) AuthClient() auth.Client {
 
 func (s *Service) Expectations() {
 	s.Mock.Expectations()
-	s.ConfigReporterImpl.Expectations()
 	gomega.Expect(s.SecretOutputs).To(gomega.BeEmpty())
 	s.AuthClientImpl.AssertOutputsEmpty()
 }


### PR DESCRIPTION
* Return HTTP status code 413 Request Entity Too Large when blob size exceeds maximum
* Replace blob.Create with blob.Content
* Remove blob Content-Length header usage and blob.Content.Size as it does not work with content encoding
* Update test config reporter for better debugging