### PR TITLE
Relax Dexcom API validations to match Tidepool data model validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## HEAD
 
+## v1.31.1
+
+* Relax Dexcom API validations to match Tidepool data model validations
+* Rename insulin dose constants to properly include units
+
 ## v1.30.0
 
 * Fix Dexcom API v2 edge cases

--- a/data/types/insulin/dose.go
+++ b/data/types/insulin/dose.go
@@ -6,15 +6,15 @@ import (
 )
 
 const (
-	DoseActiveMaximum     = 250.0
-	DoseActiveMinimum     = 0.0
-	DoseCorrectionMaximum = 250.0
-	DoseCorrectionMinimum = -250.0
-	DoseFoodMaximum       = 250.0
-	DoseFoodMinimum       = 0.0
-	DoseTotalMaximum      = 250.0
-	DoseTotalMinimum      = 0.0
-	DoseUnitsUnits        = "Units"
+	DoseActiveUnitsMaximum     = 250.0
+	DoseActiveUnitsMinimum     = 0.0
+	DoseCorrectionUnitsMaximum = 250.0
+	DoseCorrectionUnitsMinimum = -250.0
+	DoseFoodUnitsMaximum       = 250.0
+	DoseFoodUnitsMinimum       = 0.0
+	DoseTotalUnitsMaximum      = 250.0
+	DoseTotalUnitsMinimum      = 0.0
+	DoseUnitsUnits             = "Units"
 )
 
 func DoseUnits() []string {
@@ -54,10 +54,10 @@ func (d *Dose) Parse(parser data.ObjectParser) {
 }
 
 func (d *Dose) Validate(validator structure.Validator) {
-	validator.Float64("active", d.Active).InRange(DoseActiveMinimum, DoseActiveMaximum)
-	validator.Float64("correction", d.Correction).InRange(DoseCorrectionMinimum, DoseCorrectionMaximum)
-	validator.Float64("food", d.Food).InRange(DoseFoodMinimum, DoseFoodMaximum)
-	validator.Float64("total", d.Total).Exists().InRange(DoseTotalMinimum, DoseTotalMaximum)
+	validator.Float64("active", d.Active).InRange(DoseActiveUnitsMinimum, DoseActiveUnitsMaximum)
+	validator.Float64("correction", d.Correction).InRange(DoseCorrectionUnitsMinimum, DoseCorrectionUnitsMaximum)
+	validator.Float64("food", d.Food).InRange(DoseFoodUnitsMinimum, DoseFoodUnitsMaximum)
+	validator.Float64("total", d.Total).Exists().InRange(DoseTotalUnitsMinimum, DoseTotalUnitsMaximum)
 	validator.String("units", d.Units).Exists().OneOf(DoseUnits()...)
 }
 

--- a/data/types/insulin/dose_test.go
+++ b/data/types/insulin/dose_test.go
@@ -16,36 +16,36 @@ import (
 )
 
 var _ = Describe("Dose", func() {
-	It("DoseActiveMaximum is expected", func() {
-		Expect(insulin.DoseActiveMaximum).To(Equal(250.0))
+	It("DoseActiveUnitsMaximum is expected", func() {
+		Expect(insulin.DoseActiveUnitsMaximum).To(Equal(250.0))
 	})
 
-	It("DoseActiveMinimum is expected", func() {
-		Expect(insulin.DoseActiveMinimum).To(Equal(0.0))
+	It("DoseActiveUnitsMinimum is expected", func() {
+		Expect(insulin.DoseActiveUnitsMinimum).To(Equal(0.0))
 	})
 
-	It("DoseCorrectionMaximum is expected", func() {
-		Expect(insulin.DoseCorrectionMaximum).To(Equal(250.0))
+	It("DoseCorrectionUnitsMaximum is expected", func() {
+		Expect(insulin.DoseCorrectionUnitsMaximum).To(Equal(250.0))
 	})
 
-	It("DoseCorrectionMinimum is expected", func() {
-		Expect(insulin.DoseCorrectionMinimum).To(Equal(-250.0))
+	It("DoseCorrectionUnitsMinimum is expected", func() {
+		Expect(insulin.DoseCorrectionUnitsMinimum).To(Equal(-250.0))
 	})
 
-	It("DoseFoodMaximum is expected", func() {
-		Expect(insulin.DoseFoodMaximum).To(Equal(250.0))
+	It("DoseFoodUnitsMaximum is expected", func() {
+		Expect(insulin.DoseFoodUnitsMaximum).To(Equal(250.0))
 	})
 
-	It("DoseFoodMinimum is expected", func() {
-		Expect(insulin.DoseFoodMinimum).To(Equal(0.0))
+	It("DoseFoodUnitsMinimum is expected", func() {
+		Expect(insulin.DoseFoodUnitsMinimum).To(Equal(0.0))
 	})
 
-	It("DoseTotalMaximum is expected", func() {
-		Expect(insulin.DoseTotalMaximum).To(Equal(250.0))
+	It("DoseTotalUnitsMaximum is expected", func() {
+		Expect(insulin.DoseTotalUnitsMaximum).To(Equal(250.0))
 	})
 
-	It("DoseTotalMinimum is expected", func() {
-		Expect(insulin.DoseTotalMinimum).To(Equal(0.0))
+	It("DoseTotalUnitsMinimum is expected", func() {
+		Expect(insulin.DoseTotalUnitsMinimum).To(Equal(0.0))
 	})
 
 	It("DoseUnitsUnits is expected", func() {

--- a/data/types/insulin/test/dose.go
+++ b/data/types/insulin/test/dose.go
@@ -8,10 +8,10 @@ import (
 
 func NewDose() *insulin.Dose {
 	datum := insulin.NewDose()
-	datum.Active = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseActiveMinimum, insulin.DoseActiveMaximum))
-	datum.Correction = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseCorrectionMinimum, insulin.DoseCorrectionMaximum))
-	datum.Food = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseFoodMinimum, insulin.DoseFoodMaximum))
-	datum.Total = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseTotalMinimum, insulin.DoseTotalMaximum))
+	datum.Active = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseActiveUnitsMinimum, insulin.DoseActiveUnitsMaximum))
+	datum.Correction = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseCorrectionUnitsMinimum, insulin.DoseCorrectionUnitsMaximum))
+	datum.Food = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseFoodUnitsMinimum, insulin.DoseFoodUnitsMaximum))
+	datum.Total = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.DoseTotalUnitsMinimum, insulin.DoseTotalUnitsMaximum))
 	datum.Units = pointer.FromString(test.RandomStringFromArray(insulin.DoseUnits()))
 	return datum
 }

--- a/dexcom/alert.go
+++ b/dexcom/alert.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 
+	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
@@ -32,9 +33,29 @@ const (
 	AlertSettingAlertNameUrgentLow     = "urgentLow"
 	AlertSettingAlertNameUrgentLowSoon = "urgentLowSoon"
 
+	AlertSettingSnoozeMinutesMaximum = dataTypesSettingsCgm.SnoozeDurationMinutesMaximum
+	AlertSettingSnoozeMinutesMinimum = dataTypesSettingsCgm.SnoozeDurationMinutesMinimum
+
 	AlertSettingUnitMinutes    = "minutes"
 	AlertSettingUnitMgdL       = "mg/dL"
 	AlertSettingUnitMgdLMinute = "mg/dL/min"
+
+	AlertSettingValueFallMgdLMinuteMaximum    = dataTypesSettingsCgm.FallAlertRateMgdLMinuteMaximum
+	AlertSettingValueFallMgdLMinuteMinimum    = dataTypesSettingsCgm.FallAlertRateMgdLMinuteMinimum
+	AlertSettingValueHighMgdLMaximum          = dataTypesSettingsCgm.HighAlertLevelMgdLMaximum
+	AlertSettingValueHighMgdLMinimum          = dataTypesSettingsCgm.HighAlertLevelMgdLMinimum
+	AlertSettingValueLowMgdLMaximum           = dataTypesSettingsCgm.LowAlertLevelMgdLMaximum
+	AlertSettingValueLowMgdLMinimum           = dataTypesSettingsCgm.LowAlertLevelMgdLMinimum
+	AlertSettingValueNoReadingsMgdLMaximum    = dataTypesSettingsCgm.NoDataAlertDurationMinutesMaximum
+	AlertSettingValueNoReadingsMgdLMinimum    = dataTypesSettingsCgm.NoDataAlertDurationMinutesMinimum
+	AlertSettingValueOutOfRangeMgdLMaximum    = dataTypesSettingsCgm.OutOfRangeAlertDurationMinutesMaximum
+	AlertSettingValueOutOfRangeMgdLMinimum    = dataTypesSettingsCgm.OutOfRangeAlertDurationMinutesMinimum
+	AlertSettingValueRiseMgdLMinuteMaximum    = dataTypesSettingsCgm.RiseAlertRateMgdLMinuteMaximum
+	AlertSettingValueRiseMgdLMinuteMinimum    = dataTypesSettingsCgm.RiseAlertRateMgdLMinuteMinimum
+	AlertSettingValueUrgentLowMgdLMaximum     = dataTypesSettingsCgm.UrgentLowAlertLevelMgdLMaximum
+	AlertSettingValueUrgentLowMgdLMinimum     = dataTypesSettingsCgm.UrgentLowAlertLevelMgdLMinimum
+	AlertSettingValueUrgentLowSoonMgdLMaximum = dataTypesSettingsCgm.UrgentLowAlertLevelMgdLMaximum
+	AlertSettingValueUrgentLowSoonMgdLMinimum = dataTypesSettingsCgm.UrgentLowAlertLevelMgdLMinimum
 )
 
 func AlertScheduleSettingsDays() []string {
@@ -87,106 +108,32 @@ func AlertSettingUnitFalls() []string {
 	return []string{AlertSettingUnitMgdLMinute}
 }
 
-func AlertSettingValueFallMgdLMinutes() []float64 {
-	return []float64{2, 3}
-}
-
-func AlertSettingSnoozeFalls() []int {
-	return []int{0, 30}
-}
-
 func AlertSettingUnitHighs() []string {
 	return []string{AlertSettingUnitMgdL}
 }
-
-func AlertSettingValueHighMgdLs() []float64 {
-	return alertSettingValueHighMgdLs
-}
-
-var alertSettingValueHighMgdLs = generateFloatRange(120, 400, 10)
-
-func AlertSettingSnoozeHighs() []int {
-	return alertSettingSnoozeHighs
-}
-
-var alertSettingSnoozeHighs = append(append([]int{0}, generateIntegerRange(15, 240, 5)...), generateIntegerRange(255, 300, 15)...)
 
 func AlertSettingUnitLows() []string {
 	return []string{AlertSettingUnitMgdL}
 }
 
-func AlertSettingValueLowMgdLs() []float64 {
-	return alertSettingValueLowMgdLs
-}
-
-var alertSettingValueLowMgdLs = generateFloatRange(60, 100, 5)
-
-func AlertSettingSnoozeLows() []int {
-	return alertSettingSnoozeLows
-}
-
-var alertSettingSnoozeLows = append(append([]int{0}, generateIntegerRange(15, 240, 5)...), generateIntegerRange(255, 300, 15)...)
-
 func AlertSettingUnitNoReadings() []string {
 	return []string{AlertSettingUnitMinutes}
-}
-
-func AlertSettingValueNoReadingsMinutes() []float64 {
-	return []float64{0, 20}
-}
-
-func AlertSettingSnoozeNoReadings() []int {
-	return []int{0, 20, 25, 30}
 }
 
 func AlertSettingUnitOutOfRanges() []string {
 	return []string{AlertSettingUnitMinutes}
 }
 
-func AlertSettingValueOutOfRangeMinutes() []float64 {
-	return alertSettingValueOutOfRangeMinutes
-}
-
-var alertSettingValueOutOfRangeMinutes = generateFloatRange(20, 240, 5)
-
-func AlertSettingSnoozeOutOfRanges() []int {
-	return []int{0, 20, 25, 30}
-}
-
 func AlertSettingUnitRises() []string {
 	return []string{AlertSettingUnitMgdLMinute}
-}
-
-func AlertSettingValueRiseMgdLMinutes() []float64 {
-	return []float64{2, 3}
-}
-
-func AlertSettingSnoozeRises() []int {
-	return []int{0, 30}
 }
 
 func AlertSettingUnitUrgentLows() []string {
 	return []string{AlertSettingUnitMgdL}
 }
 
-func AlertSettingValueUrgentLowMgdLs() []float64 {
-	return []float64{55}
-}
-
-func AlertSettingSnoozeUrgentLows() []int {
-	return []int{0, 30}
-}
-
 func AlertSettingUnitUrgentLowSoons() []string {
 	return []string{AlertSettingUnitMgdL}
-}
-
-func AlertSettingValueUrgentLowSoonMgdLs() []float64 {
-	return []float64{55}
-}
-
-func AlertSettingSnoozeUrgentLowSoons() []int {
-	return []int{0, 30}
 }
 
 type AlertSchedules []*AlertSchedule
@@ -583,10 +530,10 @@ func (a *AlertSetting) validateFall(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMgdLMinute:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueFallMgdLMinutes()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueFallMgdLMinuteMinimum, AlertSettingValueFallMgdLMinuteMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).OneOf(AlertSettingSnoozeFalls()...)
+	validator.Int("snooze", a.Snooze).InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 
@@ -595,10 +542,10 @@ func (a *AlertSetting) validateHigh(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMgdL:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueHighMgdLs()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueHighMgdLMinimum, AlertSettingValueHighMgdLMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).Exists().OneOf(AlertSettingSnoozeHighs()...)
+	validator.Int("snooze", a.Snooze).Exists().InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 
@@ -607,10 +554,10 @@ func (a *AlertSetting) validateLow(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMgdL:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueLowMgdLs()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueLowMgdLMinimum, AlertSettingValueLowMgdLMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).Exists().OneOf(AlertSettingSnoozeLows()...)
+	validator.Int("snooze", a.Snooze).Exists().InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 
@@ -619,10 +566,10 @@ func (a *AlertSetting) validateNoReadings(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMinutes:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueNoReadingsMinutes()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueNoReadingsMgdLMinimum, AlertSettingValueNoReadingsMgdLMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).OneOf(AlertSettingSnoozeNoReadings()...)
+	validator.Int("snooze", a.Snooze).InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 
@@ -631,10 +578,10 @@ func (a *AlertSetting) validateOutOfRange(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMinutes:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueOutOfRangeMinutes()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueOutOfRangeMgdLMinimum, AlertSettingValueOutOfRangeMgdLMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).OneOf(AlertSettingSnoozeOutOfRanges()...)
+	validator.Int("snooze", a.Snooze).InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 
@@ -643,10 +590,10 @@ func (a *AlertSetting) validateRise(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMgdLMinute:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueRiseMgdLMinutes()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueRiseMgdLMinuteMinimum, AlertSettingValueRiseMgdLMinuteMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).OneOf(AlertSettingSnoozeRises()...)
+	validator.Int("snooze", a.Snooze).InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 
@@ -660,10 +607,10 @@ func (a *AlertSetting) validateUrgentLow(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMgdL:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueUrgentLowMgdLs()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueUrgentLowMgdLMinimum, AlertSettingValueUrgentLowMgdLMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).Exists().OneOf(AlertSettingSnoozeUrgentLows()...)
+	validator.Int("snooze", a.Snooze).Exists().InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists().True()
 }
 
@@ -672,10 +619,10 @@ func (a *AlertSetting) validateUrgentLowSoon(validator structure.Validator) {
 	if a.Unit != nil {
 		switch *a.Unit {
 		case AlertSettingUnitMgdL:
-			validator.Float64("value", a.Value).Exists().OneOf(AlertSettingValueUrgentLowSoonMgdLs()...)
+			validator.Float64("value", a.Value).Exists().InRange(AlertSettingValueUrgentLowSoonMgdLMinimum, AlertSettingValueUrgentLowSoonMgdLMaximum)
 		}
 	}
-	validator.Int("snooze", a.Snooze).Exists().OneOf(AlertSettingSnoozeUrgentLowSoons()...)
+	validator.Int("snooze", a.Snooze).Exists().InRange(AlertSettingSnoozeMinutesMinimum, AlertSettingSnoozeMinutesMaximum)
 	validator.Bool("enabled", a.Enabled).Exists()
 }
 

--- a/dexcom/alert_test.go
+++ b/dexcom/alert_test.go
@@ -80,6 +80,14 @@ var _ = Describe("Alert", func() {
 		Expect(dexcom.AlertSettingAlertNameUrgentLowSoon).To(Equal("urgentLowSoon"))
 	})
 
+	It("AlertSettingSnoozeMinutesMaximum is expected", func() {
+		Expect(dexcom.AlertSettingSnoozeMinutesMaximum).To(Equal(600.0))
+	})
+
+	It("AlertSettingSnoozeMinutesMinimum is expected", func() {
+		Expect(dexcom.AlertSettingSnoozeMinutesMinimum).To(Equal(0.0))
+	})
+
 	It("AlertSettingUnitMinutes is expected", func() {
 		Expect(dexcom.AlertSettingUnitMinutes).To(Equal("minutes"))
 	})
@@ -90,6 +98,70 @@ var _ = Describe("Alert", func() {
 
 	It("AlertSettingUnitMgdLMinute is expected", func() {
 		Expect(dexcom.AlertSettingUnitMgdLMinute).To(Equal("mg/dL/min"))
+	})
+
+	It("AlertSettingValueFallMgdLMinuteMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueFallMgdLMinuteMaximum).To(Equal(10.0))
+	})
+
+	It("AlertSettingValueFallMgdLMinuteMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueFallMgdLMinuteMinimum).To(Equal(1.0))
+	})
+
+	It("AlertSettingValueHighMgdLMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueHighMgdLMaximum).To(Equal(400.0))
+	})
+
+	It("AlertSettingValueHighMgdLMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueHighMgdLMinimum).To(Equal(100.0))
+	})
+
+	It("AlertSettingValueLowMgdLMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueLowMgdLMaximum).To(Equal(150.0))
+	})
+
+	It("AlertSettingValueLowMgdLMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueLowMgdLMinimum).To(Equal(50.0))
+	})
+
+	It("AlertSettingValueNoReadingsMgdLMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueNoReadingsMgdLMaximum).To(Equal(360.0))
+	})
+
+	It("AlertSettingValueNoReadingsMgdLMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueNoReadingsMgdLMinimum).To(Equal(0.0))
+	})
+
+	It("AlertSettingValueOutOfRangeMgdLMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueOutOfRangeMgdLMaximum).To(Equal(360.0))
+	})
+
+	It("AlertSettingValueOutOfRangeMgdLMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueOutOfRangeMgdLMinimum).To(Equal(0.0))
+	})
+
+	It("AlertSettingValueRiseMgdLMinuteMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueRiseMgdLMinuteMaximum).To(Equal(10.0))
+	})
+
+	It("AlertSettingValueRiseMgdLMinuteMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueRiseMgdLMinuteMinimum).To(Equal(1.0))
+	})
+
+	It("AlertSettingValueUrgentLowMgdLMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueUrgentLowMgdLMaximum).To(Equal(80.0))
+	})
+
+	It("AlertSettingValueUrgentLowMgdLMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueUrgentLowMgdLMinimum).To(Equal(40.0))
+	})
+
+	It("AlertSettingValueUrgentLowSoonMgdLMaximum is expected", func() {
+		Expect(dexcom.AlertSettingValueUrgentLowSoonMgdLMaximum).To(Equal(80.0))
+	})
+
+	It("AlertSettingValueUrgentLowSoonMgdLMinimum is expected", func() {
+		Expect(dexcom.AlertSettingValueUrgentLowSoonMgdLMinimum).To(Equal(40.0))
 	})
 
 	It("AlertScheduleSettingsDays returns expected", func() {
@@ -121,96 +193,32 @@ var _ = Describe("Alert", func() {
 		Expect(dexcom.AlertSettingUnitFalls()).To(Equal([]string{"mg/dL/min"}))
 	})
 
-	It("AlertSettingValueFallMgdLMinutes returns expected", func() {
-		Expect(dexcom.AlertSettingValueFallMgdLMinutes()).To(Equal([]float64{2, 3}))
-	})
-
-	It("AlertSettingSnoozeFalls returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeFalls()).To(Equal([]int{0, 30}))
-	})
-
 	It("AlertSettingUnitHighs returns expected", func() {
 		Expect(dexcom.AlertSettingUnitHighs()).To(Equal([]string{"mg/dL"}))
-	})
-
-	It("AlertSettingValueHighMgdLs returns expected", func() {
-		Expect(dexcom.AlertSettingValueHighMgdLs()).To(Equal([]float64{120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390, 400}))
-	})
-
-	It("AlertSettingSnoozeHighs returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeHighs()).To(Equal([]int{0, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160, 165, 170, 175, 180, 185, 190, 195, 200, 205, 210, 215, 220, 225, 230, 235, 240, 255, 270, 285, 300}))
 	})
 
 	It("AlertSettingUnitLows returns expected", func() {
 		Expect(dexcom.AlertSettingUnitLows()).To(Equal([]string{"mg/dL"}))
 	})
 
-	It("AlertSettingValueLowMgdLs returns expected", func() {
-		Expect(dexcom.AlertSettingValueLowMgdLs()).To(Equal([]float64{60, 65, 70, 75, 80, 85, 90, 95, 100}))
-	})
-
-	It("AlertSettingSnoozeLows returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeLows()).To(Equal([]int{0, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160, 165, 170, 175, 180, 185, 190, 195, 200, 205, 210, 215, 220, 225, 230, 235, 240, 255, 270, 285, 300}))
-	})
-
 	It("AlertSettingUnitNoReadings returns expected", func() {
 		Expect(dexcom.AlertSettingUnitNoReadings()).To(Equal([]string{"minutes"}))
-	})
-
-	It("AlertSettingValueNoReadingsMinutes returns expected", func() {
-		Expect(dexcom.AlertSettingValueNoReadingsMinutes()).To(Equal([]float64{0, 20}))
-	})
-
-	It("AlertSettingSnoozeNoReadings returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeNoReadings()).To(Equal([]int{0, 20, 25, 30}))
 	})
 
 	It("AlertSettingUnitOutOfRanges returns expected", func() {
 		Expect(dexcom.AlertSettingUnitOutOfRanges()).To(Equal([]string{"minutes"}))
 	})
 
-	It("AlertSettingValueOutOfRangeMinutes returns expected", func() {
-		Expect(dexcom.AlertSettingValueOutOfRangeMinutes()).To(Equal([]float64{20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160, 165, 170, 175, 180, 185, 190, 195, 200, 205, 210, 215, 220, 225, 230, 235, 240}))
-	})
-
-	It("AlertSettingSnoozeOutOfRanges returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeOutOfRanges()).To(Equal([]int{0, 20, 25, 30}))
-	})
-
 	It("AlertSettingUnitRises returns expected", func() {
 		Expect(dexcom.AlertSettingUnitRises()).To(Equal([]string{"mg/dL/min"}))
-	})
-
-	It("AlertSettingValueRiseMgdLMinutes returns expected", func() {
-		Expect(dexcom.AlertSettingValueRiseMgdLMinutes()).To(Equal([]float64{2, 3}))
-	})
-
-	It("AlertSettingSnoozeRises returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeRises()).To(Equal([]int{0, 30}))
 	})
 
 	It("AlertSettingUnitUrgentLows returns expected", func() {
 		Expect(dexcom.AlertSettingUnitUrgentLows()).To(Equal([]string{"mg/dL"}))
 	})
 
-	It("AlertSettingValueUrgentLowMgdLs returns expected", func() {
-		Expect(dexcom.AlertSettingValueUrgentLowMgdLs()).To(Equal([]float64{55}))
-	})
-
-	It("AlertSettingSnoozeUrgentLows returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeUrgentLows()).To(Equal([]int{0, 30}))
-	})
-
 	It("AlertSettingUnitUrgentLowSoons returns expected", func() {
 		Expect(dexcom.AlertSettingUnitUrgentLowSoons()).To(Equal([]string{"mg/dL"}))
-	})
-
-	It("AlertSettingValueUrgentLowSoonMgdLs returns expected", func() {
-		Expect(dexcom.AlertSettingValueUrgentLowSoonMgdLs()).To(Equal([]float64{55}))
-	})
-
-	It("AlertSettingSnoozeUrgentLowSoons returns expected", func() {
-		Expect(dexcom.AlertSettingSnoozeUrgentLowSoons()).To(Equal([]int{0, 30}))
 	})
 
 	Context("ParseAlertScheduleSettingsTime", func() {

--- a/dexcom/calibration.go
+++ b/dexcom/calibration.go
@@ -3,6 +3,7 @@ package dexcom
 import (
 	"strconv"
 
+	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -10,8 +11,8 @@ import (
 const (
 	CalibrationUnitMgdL = "mg/dL"
 
-	CalibrationValueMgdLMaximum = 600.0
-	CalibrationValueMgdLMinimum = 20.0
+	CalibrationValueMgdLMaximum = dataBloodGlucose.MgdLMaximum
+	CalibrationValueMgdLMinimum = dataBloodGlucose.MgdLMinimum
 )
 
 func CalibrationUnits() []string {

--- a/dexcom/calibration_test.go
+++ b/dexcom/calibration_test.go
@@ -13,11 +13,11 @@ var _ = Describe("Calibration", func() {
 	})
 
 	It("CalibrationValueMgdLMaximum is expected", func() {
-		Expect(dexcom.CalibrationValueMgdLMaximum).To(Equal(600.0))
+		Expect(dexcom.CalibrationValueMgdLMaximum).To(Equal(1000.0))
 	})
 
 	It("CalibrationValueMgdLMinimum is expected", func() {
-		Expect(dexcom.CalibrationValueMgdLMinimum).To(Equal(20.0))
+		Expect(dexcom.CalibrationValueMgdLMinimum).To(Equal(0.0))
 	})
 
 	It("CalibrationUnits returns expected", func() {

--- a/dexcom/egv_test.go
+++ b/dexcom/egv_test.go
@@ -17,11 +17,19 @@ var _ = Describe("EGV", func() {
 	})
 
 	It("EGVValueMgdLMaximum is expected", func() {
-		Expect(dexcom.EGVValueMgdLMaximum).To(Equal(400.0))
+		Expect(dexcom.EGVValueMgdLMaximum).To(Equal(1000.0))
 	})
 
 	It("EGVValueMgdLMinimum is expected", func() {
-		Expect(dexcom.EGVValueMgdLMinimum).To(Equal(40.0))
+		Expect(dexcom.EGVValueMgdLMinimum).To(Equal(0.0))
+	})
+
+	It("EGVValuePinnedMgdLMaximum is expected", func() {
+		Expect(dexcom.EGVValuePinnedMgdLMaximum).To(Equal(400.0))
+	})
+
+	It("EGVValuePinnedMgdLMinimum is expected", func() {
+		Expect(dexcom.EGVValuePinnedMgdLMinimum).To(Equal(40.0))
 	})
 
 	It("EGVStatusHigh is expected", func() {

--- a/dexcom/event.go
+++ b/dexcom/event.go
@@ -3,6 +3,9 @@ package dexcom
 import (
 	"strconv"
 
+	dataTypesActivityPhysical "github.com/tidepool-org/platform/data/types/activity/physical"
+	dataTypesFood "github.com/tidepool-org/platform/data/types/food"
+	dataTypesInsulin "github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -14,15 +17,15 @@ const (
 	EventTypeInsulin  = "insulin"
 
 	EventUnitCarbsGrams         = "grams"
-	EventValueCarbsGramsMaximum = 250.0
-	EventValueCarbsGramsMinimum = 0.0
+	EventValueCarbsGramsMaximum = dataTypesFood.CarbohydrateNetGramsMaximum
+	EventValueCarbsGramsMinimum = dataTypesFood.CarbohydrateNetGramsMinimum
 
 	EventSubTypeExerciseLight        = "light"
 	EventSubTypeExerciseMedium       = "medium"
 	EventSubTypeExerciseHeavy        = "heavy"
 	EventUnitExerciseMinutes         = "minutes"
-	EventValueExerciseMinutesMaximum = 360.0
-	EventValueExerciseMinutesMinimum = 0.0
+	EventValueExerciseMinutesMaximum = dataTypesActivityPhysical.DurationValueMinutesMaximum
+	EventValueExerciseMinutesMinimum = dataTypesActivityPhysical.DurationValueMinutesMinimum
 
 	EventSubTypeHealthAlcohol      = "alcohol"
 	EventSubTypeHealthCycle        = "cycle"
@@ -34,8 +37,8 @@ const (
 	EventSubTypeInsulinFastActing = "fastActing"
 	EventSubTypeInsulinLongActing = "longActing"
 	EventUnitInsulinUnits         = "units"
-	EventValueInsulinUnitsMaximum = 250.0
-	EventValueInsulinUnitsMinimum = 0.0
+	EventValueInsulinUnitsMaximum = dataTypesInsulin.DoseTotalUnitsMaximum
+	EventValueInsulinUnitsMinimum = dataTypesInsulin.DoseTotalUnitsMinimum
 
 	EventStatusCreated = "created"
 	EventStatusDeleted = "deleted"

--- a/dexcom/event_test.go
+++ b/dexcom/event_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Event", func() {
 	})
 
 	It("EventValueCarbsGramsMaximum is expected", func() {
-		Expect(dexcom.EventValueCarbsGramsMaximum).To(Equal(250.0))
+		Expect(dexcom.EventValueCarbsGramsMaximum).To(Equal(1000.0))
 	})
 
 	It("EventValueCarbsGramsMinimum is expected", func() {
@@ -53,7 +53,7 @@ var _ = Describe("Event", func() {
 	})
 
 	It("EventValueExerciseMinutesMaximum is expected", func() {
-		Expect(dexcom.EventValueExerciseMinutesMaximum).To(Equal(360.0))
+		Expect(dexcom.EventValueExerciseMinutesMaximum).To(Equal(10080.0))
 	})
 
 	It("EventValueExerciseMinutesMinimum is expected", func() {

--- a/dexcom/fetch/translate.go
+++ b/dexcom/fetch/translate.go
@@ -370,19 +370,21 @@ func translateEGVToDatum(egv *dexcom.EGV, unit *string, rateUnit *string) data.D
 		(*datum.Payload)["transmitterTicks"] = *egv.TransmitterTicks
 	}
 
-	switch *unit {
+	switch *datum.Units {
 	case dexcom.EGVUnitMgdL:
-		if *egv.Value < dexcom.EGVValueMgdLMinimum {
+		if *datum.Value < dexcom.EGVValuePinnedMgdLMinimum {
+			datum.Value = pointer.FromFloat64(dexcom.EGVValuePinnedMgdLMinimum - 1)
 			datum.Annotations = &data.BlobArray{{
 				"code":      "bg/out-of-range",
 				"value":     "low",
-				"threshold": dexcom.EGVValueMgdLMinimum,
+				"threshold": dexcom.EGVValuePinnedMgdLMinimum,
 			}}
-		} else if *egv.Value > dexcom.EGVValueMgdLMaximum {
+		} else if *datum.Value > dexcom.EGVValuePinnedMgdLMaximum {
+			datum.Value = pointer.FromFloat64(dexcom.EGVValuePinnedMgdLMaximum + 1)
 			datum.Annotations = &data.BlobArray{{
 				"code":      "bg/out-of-range",
 				"value":     "high",
-				"threshold": dexcom.EGVValueMgdLMaximum,
+				"threshold": dexcom.EGVValuePinnedMgdLMaximum,
 			}}
 		}
 	}

--- a/dexcom/test/alert.go
+++ b/dexcom/test/alert.go
@@ -111,65 +111,65 @@ func RandomAlertSetting() *dexcom.AlertSetting {
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitFalls()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMgdLMinute:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueFallMgdLMinutes()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueFallMgdLMinuteMinimum, dexcom.AlertSettingValueFallMgdLMinuteMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeFalls()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	case dexcom.AlertSettingAlertNameHigh:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitHighs()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMgdL:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueHighMgdLs()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueHighMgdLMinimum, dexcom.AlertSettingValueHighMgdLMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeHighs()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	case dexcom.AlertSettingAlertNameLow:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitLows()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMgdL:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueLowMgdLs()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueLowMgdLMinimum, dexcom.AlertSettingValueLowMgdLMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeLows()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	case dexcom.AlertSettingAlertNameNoReadings:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitNoReadings()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMinutes:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueNoReadingsMinutes()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueNoReadingsMgdLMinimum, dexcom.AlertSettingValueNoReadingsMgdLMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeNoReadings()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	case dexcom.AlertSettingAlertNameOutOfRange:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitOutOfRanges()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMinutes:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueOutOfRangeMinutes()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueOutOfRangeMgdLMinimum, dexcom.AlertSettingValueOutOfRangeMgdLMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeOutOfRanges()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	case dexcom.AlertSettingAlertNameRise:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitRises()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMgdLMinute:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueRiseMgdLMinutes()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueRiseMgdLMinuteMinimum, dexcom.AlertSettingValueRiseMgdLMinuteMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeRises()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	case dexcom.AlertSettingAlertNameUrgentLow:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitUrgentLows()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMgdL:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueUrgentLowMgdLs()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueUrgentLowMgdLMinimum, dexcom.AlertSettingValueUrgentLowMgdLMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeUrgentLows()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(true)
 	case dexcom.AlertSettingAlertNameUrgentLowSoon:
 		datum.Unit = pointer.FromString(test.RandomStringFromArray(dexcom.AlertSettingUnitUrgentLowSoons()))
 		switch *datum.Unit {
 		case dexcom.AlertSettingUnitMgdL:
-			datum.Value = pointer.FromFloat64(test.RandomFloat64FromArray(dexcom.AlertSettingValueUrgentLowSoonMgdLs()))
+			datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dexcom.AlertSettingValueUrgentLowSoonMgdLMinimum, dexcom.AlertSettingValueUrgentLowSoonMgdLMaximum))
 		}
-		datum.Snooze = pointer.FromInt(test.RandomIntFromArray(dexcom.AlertSettingSnoozeUrgentLowSoons()))
+		datum.Snooze = pointer.FromInt(test.RandomIntFromRange(dexcom.AlertSettingSnoozeMinutesMinimum, dexcom.AlertSettingSnoozeMinutesMaximum))
 		datum.Enabled = pointer.FromBool(test.RandomBool())
 	}
 	return datum


### PR DESCRIPTION
* Relax Dexcom API validations to match Tidepool data model validations
* Rename insulin dose constants to properly include units

@cbwebdevelopment Since Lenny is away and you've expressed an interest in the backend, would you mind reviewing this? Don't worry, Lenny already reviewed the counterpart PR for this branch into `master` in https://github.com/tidepool-org/platform/pull/391. Thanks!