### PR TITLE
Corrected README for building go tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ The Tidepool Platform API.
 
 # Setup
 
-1. Install Go version 1.10 or later.
+1. Install Go version 1.11.4 or later.
 1. Install `dep` dependency management tool. See https://golang.github.io/dep/docs/installation.html.
+1. Install mongodb (if it is not already installed).
+1. Start mongodb (if it is not already running).
 1. Create a brand new Go directory.
 1. Set the `GOPATH` environment variable to the newly created Go directory.
 1. Add `$GOPATH/bin` to the `PATH` environment variable.
 1. Execute `go get github.com/tidepool-org/platform` to pull down the project. You may ignore a "no buildable Go source files" warning.
 1. Change directory to `$GOPATH/src/github.com/tidepool-org/platform`.
 1. Source the `env.sh` file.
-1. Execute `make buildable` to install the various Go tools needed for building and editing the project.
+1. Execute `make editable` to install the various Go tools needed for building and editing the project.
 
 For example:
 
@@ -31,7 +33,7 @@ export PATH=$GOPATH/bin:$PATH
 go get github.com/tidepool-org/platform
 cd $GOPATH/src/github.com/tidepool-org/platform
 . ./env.sh
-make buildable
+make editable
 ```
 
 For reuse, you may want to include the following lines in your shell config (e.g. `.bashrc`) or use a tool like [direnv](http://direnv.net/ 'direnv'):
@@ -61,7 +63,7 @@ Use `Ctrl-C` to stop the executable. It may take up to 60 seconds to stop.
 * To setup your Go environment for building and editing the project:
 
 ```
-make buildable
+make editable
 ```
 
 * To build the executables:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Tidepool Platform API.
 1. Execute `go get github.com/tidepool-org/platform` to pull down the project. You may ignore a "no buildable Go source files" warning.
 1. Change directory to `$GOPATH/src/github.com/tidepool-org/platform`.
 1. Source the `env.sh` file.
-1. Execute `make editable` to install the various Go tools needed for building and editing the project.
+1. Execute `make buildable` to install the various Go tools needed for building and editing the project.
 
 For example:
 
@@ -29,7 +29,7 @@ export PATH=$GOPATH/bin:$PATH
 go get github.com/tidepool-org/platform
 cd $GOPATH/src/github.com/tidepool-org/platform
 . ./env.sh
-make editable
+make buildable
 ```
 
 For reuse, you may want to include the following lines in your shell config (e.g. `.bashrc`) or use a tool like [direnv](http://direnv.net/ 'direnv'):

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you use the Sublime Text editor with the GoSublime plugin, open the `platform
 - Review the release notes for **all** Golang versions, major and minor, from the current Golang version to the target Golang version. The entire Golang release history can be found at https://golang.org/doc/devel/release.html.
   - For major revisions, if any change described in the release notes could have a negative impact upon this repository, follow up and review any associated issues and the updated code. Make note of this change in order to explicitly test after upgrading.
   - For minor revisions, review all issues included in the associated GitHub milestone issue tracker. These can be found in the minor revision release notes. If any issue could have a negative impact upon this repository, review the updated code. Make note of this issue in order to explicitly test after upgrading.
-- Install `gimme` via `brew`. Execute `gimme -k`. Ensure that the target Golang version is listed. The `gimme` tool is used by Travis CI to manage Golang versions. If the version is not listed, then the Travis CI build will not succeed.
+- Install `gimme`(https://github.com/travis-ci/gimme) via `brew`. Execute `gimme -k`. Ensure that the target Golang version is listed. The `gimme` tool is used by Travis CI to manage Golang versions. If the version is not listed, then the Travis CI build will not succeed.
 - Browse to https://hub.docker.com/_/golang and ensure the target Golang version in an Alpine Linux image is available. For example, if the target version is `1.11.4`, then ensure that the `1.11.4-alpine` image tag is available. If the image tag is not avaiable, then the Travis CI build will not succeed.
 
 ## Upgrade

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Use `Ctrl-C` to stop the executable. It may take up to 60 seconds to stop.
 * To setup your Go environment for building and editing the project:
 
 ```
-make editable
+make buildable
 ```
 
 * To build the executables:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ For example:
 ```
 brew install go
 brew install dep
+brew install mongo
+brew services start mongodb
 mkdir ~/go
 export GOPATH=~/go
 export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
The README referred to a make target that does not exist.

@darinkrauss I am not certain that this is correct, but I think it is.  Please let me know.