### PR TITLE
Add `update-password` command to `tapi`

### DIFF
--- a/tools/tapi/README.md
+++ b/tools/tapi/README.md
@@ -15,7 +15,7 @@ Note: The endpoint takes precedence over the environment name.
 
 ### Environment
 
-If you choose to specify the Tidepool environment name when invoking the tool it will automatically convert from all known environments (ie. `prd`, `int`, `stg`, `dev`, `local`) to the appropriate endpoint. For example:
+If you choose to specify the Tidepool environment name when invoking the tool it will automatically convert from all known environments (ie. `prd`, `int`, `stg`, `dev`, `local`, `tilt`) to the appropriate endpoint. For example:
 
 ```
 $ tapi login --env=prd
@@ -204,7 +204,7 @@ OPTIONS:
    --page PAGE          pagination PAGE (default: 0)
    --size SIZE          pagination SIZE (default: 0)
    --endpoint ENDPOINT  Tidepool API ENDPOINT (eg. 'https://api.tidepool.org') [$TIDEPOOL_ENDPOINT]
-   --env ENVIRONMENT    Tidepool ENVIRONMENT (ie. 'prd', 'int', 'stg', 'dev', 'local') [$TIDEPOOL_ENV]
+   --env ENVIRONMENT    Tidepool ENVIRONMENT (ie. 'prd', 'int', 'stg', 'dev', 'local', 'tilt') [$TIDEPOOL_ENV]
    --proxy URL          proxy URL [$HTTP_PROXY]
    --pretty, -p         pretty print JSON
    --verbose, -v        include info output

--- a/tools/tapi/cmd/cmd.go
+++ b/tools/tapi/cmd/cmd.go
@@ -16,7 +16,8 @@ var environmentEndpointMap = map[string]string{
 	"int":   "https://int-api.tidepool.org",
 	"stg":   "https://stg-api.tidepool.org",
 	"dev":   "https://dev-api.tidepool.org",
-	"local": "http://localhost:8009",
+	"local": "http://localhost:3000",
+	"tilt":  "http://gateway-proxy",
 }
 
 var _API *api.API

--- a/tools/tapi/cmd/common.go
+++ b/tools/tapi/cmd/common.go
@@ -29,7 +29,7 @@ func CommandFlags(flags ...cli.Flag) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:   EnvFlag,
-			Usage:  "Tidepool `ENVIRONMENT` (ie. 'prd', 'int', 'stg', 'dev', 'local')",
+			Usage:  "Tidepool `ENVIRONMENT` (ie. 'prd', 'int', 'stg', 'dev', 'local', 'tilt')",
 			EnvVar: "TIDEPOOL_ENV",
 		},
 		cli.StringFlag{

--- a/tools/tapi/cmd/user.go
+++ b/tools/tapi/cmd/user.go
@@ -106,10 +106,6 @@ func UserCommands() cli.Commands {
 							Name:  UserIDFlag,
 							Usage: "`USERID` of the user to update",
 						},
-						cli.StringFlag{
-							Name:  PasswordFlag,
-							Usage: "`PASSWORD` of the user to update (required if authenticated as the user being deleted)",
-						},
 					),
 					Before: ensureNoArgs,
 					Action: userUpdatePassword,
@@ -213,14 +209,6 @@ func userDelete(c *cli.Context) error {
 }
 
 func userUpdatePassword(c *cli.Context) error {
-	userID := c.String(UserIDFlag)
-	password := c.String(PasswordFlag)
-	if password == "" && API(c).IsSessionUserID(userID) {
-		var err error
-		if password, err = readFromConsoleNoEcho("Current Password: "); err != nil {
-			return err
-		}
-	}
 	newPassword, err := readFromConsoleNoEcho("New Password: ")
 	if err != nil {
 		return err


### PR DESCRIPTION
@tjotala Adding `update-password` functionality to the `tapi` tool (replacing the `tidepool-pwreset.js` tool).
The corresponding `develop` PR is [available here](https://github.com/tidepool-org/platform/pull/447)