### PR TITLE
BACK-1161 Mitigate Dexcom API bug

### DIFF
--- a/dexcom/egv.go
+++ b/dexcom/egv.go
@@ -171,8 +171,8 @@ func NewEGV(unit *string) *EGV {
 }
 
 func (e *EGV) Parse(parser structure.ObjectParser) {
-	e.SystemTime = TimeFromRaw(parser.Time("systemTime", TimeFormat))
-	e.DisplayTime = TimeFromRaw(parser.Time("displayTime", TimeFormat))
+	e.SystemTime = TimeFromRaw(parser.ForgivingTime("systemTime", TimeFormat))
+	e.DisplayTime = TimeFromRaw(parser.ForgivingTime("displayTime", TimeFormat))
 	e.Value = parser.Float64("value")
 	e.RealTimeValue = parser.Float64("realtimeValue")
 	e.SmoothedValue = parser.Float64("smoothedValue")

--- a/request/values_parser.go
+++ b/request/values_parser.go
@@ -192,6 +192,24 @@ func (v *Values) Time(reference string, layout string) *time.Time {
 	return &timeValue
 }
 
+// ForgivingTime is a parser added specifically to handle https://tidepool.atlassian.net/browse/BACK-1161
+// It should be deprecated once Dexcom fixes their API.
+func (v *Values) ForgivingTime(reference string, layout string) *time.Time {
+	rawValue, ok := v.raw(reference)
+	if !ok {
+		return nil
+	}
+
+	forgivingTime := structure.ForgivingTimeString(rawValue)
+	timeValue, err := time.Parse(layout, forgivingTime)
+	if err != nil {
+		v.base.WithReference(reference).ReportError(structureParser.ErrorValueTimeNotParsable(rawValue, layout))
+		return nil
+	}
+
+	return &timeValue
+}
+
 func (v *Values) Object(reference string) *map[string]interface{} {
 	rawValue, ok := v.raw(reference)
 	if !ok {

--- a/structure/parser.go
+++ b/structure/parser.go
@@ -26,6 +26,7 @@ type ObjectParser interface {
 	String(reference string) *string
 	StringArray(reference string) *[]string
 	Time(reference string, layout string) *time.Time
+	ForgivingTime(reference string, layout string) *time.Time
 
 	Object(reference string) *map[string]interface{}
 	Array(reference string) *[]interface{}
@@ -80,4 +81,21 @@ type ArrayParser interface {
 	WithReferenceObjectParser(reference int) ObjectParser
 	WithReferenceArrayParser(reference int) ArrayParser
 	WithReferenceErrorReporter(reference int) ErrorReporter
+}
+
+// ForgivingTimeString is a helper function added specifically to handle https://tidepool.atlassian.net/browse/BACK-1161
+// It should be deprecated once Dexcom fixes their API.
+func ForgivingTimeString(stringValue string) (forgivingTime string) {
+	if len(stringValue) < 19 {
+		forgivingBytes := []byte("0000-01-01T00:00:00")
+		for i := range forgivingBytes {
+			if i < len(stringValue) {
+				forgivingBytes[i] = stringValue[i]
+			}
+		}
+		forgivingTime = string(forgivingBytes)
+	} else {
+		forgivingTime = stringValue
+	}
+	return forgivingTime
 }


### PR DESCRIPTION
Adds a "Forgiving Time" parser to mitigate the recently introduced
bug in the Dexcom API
* Fixes [BACK-1161]