### PR TITLE
Add application origin type and tests

### DIFF
--- a/origin/origin.go
+++ b/origin/origin.go
@@ -11,6 +11,7 @@ const (
 	IDLengthMaximum      = 100
 	NameLengthMaximum    = 100
 	TimeFormat           = time.RFC3339Nano
+	TypeApplication      = "application"
 	TypeDevice           = "device"
 	TypeManual           = "manual"
 	TypeService          = "service"
@@ -19,6 +20,7 @@ const (
 
 func Types() []string {
 	return []string{
+		TypeApplication,
 		TypeDevice,
 		TypeManual,
 		TypeService,

--- a/origin/origin_test.go
+++ b/origin/origin_test.go
@@ -31,6 +31,10 @@ var _ = Describe("Origin", func() {
 		Expect(origin.TimeFormat).To(Equal(time.RFC3339Nano))
 	})
 
+	It("TypeApplication is expected", func() {
+		Expect(origin.TypeApplication).To(Equal("application"))
+	})
+
 	It("TypeDevice is expected", func() {
 		Expect(origin.TypeDevice).To(Equal("device"))
 	})
@@ -48,7 +52,7 @@ var _ = Describe("Origin", func() {
 	})
 
 	It("Types returns expected", func() {
-		Expect(origin.Types()).To(Equal([]string{"device", "manual", "service"}))
+		Expect(origin.Types()).To(Equal([]string{"application", "device", "manual", "service"}))
 	})
 
 	Context("Origin", func() {
@@ -212,7 +216,10 @@ var _ = Describe("Origin", func() {
 				),
 				Entry("type invalid",
 					func(datum *origin.Origin) { datum.Type = pointer.FromString("invalid") },
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"device", "manual", "service"}), "/type"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"application", "device", "manual", "service"}), "/type"),
+				),
+				Entry("type application",
+					func(datum *origin.Origin) { datum.Type = pointer.FromString("application") },
 				),
 				Entry("type device",
 					func(datum *origin.Origin) { datum.Type = pointer.FromString("device") },
@@ -252,7 +259,7 @@ var _ = Describe("Origin", func() {
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/id"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/name"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueStringAsTimeNotValid("", time.RFC3339Nano), "/time"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"device", "manual", "service"}), "/type"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"application", "device", "manual", "service"}), "/type"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/version"),
 				),
 			)


### PR DESCRIPTION
This adds the ability to specify that the origin for a datum is an application (not device, service, or manually entered), specifically Tidepool Loop.

Feel free to merge into your branch if you approve of the change. Thanks!