### PR TITLE
[BACK-1339] Fix dexcom health event validation

### DIFF
--- a/dexcom/event.go
+++ b/dexcom/event.go
@@ -227,7 +227,9 @@ func (e *Event) validateExercise(validator structure.Validator) {
 func (e *Event) validateHealth(validator structure.Validator) {
 	validator.String("eventSubType", e.SubType).OneOf(EventSubTypesHealth()...)
 	validator.String("unit", e.Unit).NotExists()
-	validator.Float64("value", e.Value).NotExists()
+	if e.Value != nil {
+		validator.Float64("value", e.Value).EqualTo(0)
+	}
 }
 
 func (e *Event) validateInsulin(validator structure.Validator) {

--- a/dexcom/event.go
+++ b/dexcom/event.go
@@ -227,9 +227,7 @@ func (e *Event) validateExercise(validator structure.Validator) {
 func (e *Event) validateHealth(validator structure.Validator) {
 	validator.String("eventSubType", e.SubType).OneOf(EventSubTypesHealth()...)
 	validator.String("unit", e.Unit).NotExists()
-	if e.Value != nil {
-		validator.Float64("value", e.Value).EqualTo(0)
-	}
+	validator.Float64("value", e.Value).EqualTo(0)
 }
 
 func (e *Event) validateInsulin(validator structure.Validator) {

--- a/dexcom/event_test.go
+++ b/dexcom/event_test.go
@@ -3,6 +3,9 @@ package dexcom_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/tidepool-org/platform/dexcom/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/structure/validator"
 
 	"github.com/tidepool-org/platform/dexcom"
 )
@@ -130,5 +133,19 @@ var _ = Describe("Event", func() {
 
 	It("EventStatuses returns expected", func() {
 		Expect(dexcom.EventStatuses()).To(Equal([]string{"created", "deleted"}))
+	})
+	
+	Describe("Validate", func() {
+		It("Allows health events value to be 0", func() {
+			event := test.RandomEvent()
+			event.Type = pointer.FromString(dexcom.EventTypeHealth)
+			event.SubType = pointer.FromString(dexcom.EventSubTypeHealthIllness)
+			event.Value = pointer.FromFloat64(0)
+
+			validator := validator.New()
+			event.Validate(validator)
+
+			Expect(validator.Error()).ToNot(HaveOccurred())
+		})
 	})
 })

--- a/dexcom/event_test.go
+++ b/dexcom/event_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Event", func() {
 			event := test.RandomEvent()
 			event.Type = pointer.FromString(dexcom.EventTypeHealth)
 			event.SubType = pointer.FromString(dexcom.EventSubTypeHealthIllness)
+			event.Unit = nil
 			event.Value = pointer.FromFloat64(0)
 
 			validator := validator.New()

--- a/dexcom/event_test.go
+++ b/dexcom/event_test.go
@@ -3,6 +3,7 @@ package dexcom_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/tidepool-org/platform/dexcom/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure/validator"
@@ -134,7 +135,7 @@ var _ = Describe("Event", func() {
 	It("EventStatuses returns expected", func() {
 		Expect(dexcom.EventStatuses()).To(Equal([]string{"created", "deleted"}))
 	})
-	
+
 	Describe("Validate", func() {
 		It("Allows health events value to be 0", func() {
 			event := test.RandomEvent()


### PR DESCRIPTION
A patient reported that their data could not be synced. During the investigation I found occurrences of a validation error, where we expect a health event value to not be present, where now it's being returned as 0 

It looks like Dexcom introduced a change on their side which trips up our validation logic. The response is valid according to their API docs. I added 0 to the allowed values, because [we're ignoring](https://github.com/tidepool-org/platform/blob/8ba106f739f1337299539c2e50e9840e8266c14f/dexcom/fetch/translate.go#L451) this value anyway.

This affects 162 people and prevents us from syncing their data.