### PR TITLE
Travis build optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,7 @@ services:
 
 script:
   - make ci-generate ci-build ci-test ci-snyk ci-deploy ci-docker
+
+cache:
+  directories:
+    - $HOME/.cache/go-build

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ test-watch: ginkgo
 
 ci-test: ginkgo
 	@echo "ginkgo -requireSuite -slowSpecThreshold=10 -r -randomizeSuites -randomizeAllSpecs -succinct -failOnPending -cover -trace -race -progress -keepGoing $(TEST)"
-	@cd $(ROOT_DIRECTORY) && . ./env.test.sh && ginkgo -requireSuite -slowSpecThreshold=10 -r -randomizeSuites -randomizeAllSpecs -succinct -failOnPending -cover -trace -race -progress -keepGoing $(TEST)
+	@cd $(ROOT_DIRECTORY) && . ./env.test.sh && ginkgo -requireSuite -slowSpecThreshold=10 --compilers=2 -r -randomizeSuites -randomizeAllSpecs -succinct -failOnPending -cover -trace -race -progress -keepGoing $(TEST)
 
 snyk-test:
 	@echo "snyk test --dev --org=tidepool"


### PR DESCRIPTION
- Enabled go build cache, which caches build outputs for reuse in future builds. 
- Set the number of ginkgo concurrent compilers to 2 (the number of cores available to us), because the default is the number of CPUs reported by Travis is the number of host CPUs (32)

This will saves us another 2-3 minutes. The build time is now down to under 12 minutes.