### PR TITLE
Append mongo connection option params correctly

### DIFF
--- a/store/structured/mongo/config.go
+++ b/store/structured/mongo/config.go
@@ -1,6 +1,7 @@
 package mongo
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -60,7 +61,7 @@ func (c *Config) AsConnectionString() string {
 		url += "?ssl=false"
 	}
 	if c.OptParams != nil && *c.OptParams != "" {
-		url += *c.OptParams
+		url += fmt.Sprintf("&%s", *c.OptParams)
 	}
 
 	return url

--- a/store/structured/mongo/config_test.go
+++ b/store/structured/mongo/config_test.go
@@ -183,6 +183,28 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Context("AsConnectionString", func() {
+		var config *storeStructuredMongo.Config
+
+		BeforeEach(func() {
+			config = storeStructuredMongo.NewConfig()
+			config.Scheme = "mongodb"
+			config.Addresses = []string{"1.2.3.4:1234", "5.6.7.8:5678"}
+			config.TLS = true
+			config.Database = "database"
+			config.CollectionPrefix = "collection_prefix"
+			config.Username = pointer.FromString("username")
+			config.Password = pointer.FromString("password")
+			config.Timeout = 5 * time.Second
+			config.OptParams = pointer.FromString("w=majority")
+		})
+
+		It("generates correct connection string", func() {
+			expected := "mongodb://username:password@1.2.3.4:1234,5.6.7.8:5678/database?ssl=true&w=majority"
+			Expect(config.AsConnectionString()).To(Equal(expected))
+		})
+	})
+
 	Context("SplitAddresses", func() {
 		DescribeTable("returns expected addresses when",
 			func(addressesString string, expectedAddresses []string) {


### PR DESCRIPTION
The first two connection params `ssl` and `replicaSet` were not set correctly due to the missing ampersand.