### PR TITLE
[BACK-1437] Remove duplication of index creation

### DIFF
--- a/confirmation/store/mongo/store.go
+++ b/confirmation/store/mongo/store.go
@@ -50,6 +50,7 @@ type ConfirmationSession struct {
 
 func (c *ConfirmationSession) EnsureIndexes() error {
 	return c.EnsureAllIndexes([]mgo.Index{
+		// Additional indexes are also created in `hydrophone`.
 		{Key: []string{"email"}, Background: true},
 		{Key: []string{"status"}, Background: true},
 		{Key: []string{"type"}, Background: true},

--- a/data/storeDEPRECATED/mongo/mongo.go
+++ b/data/storeDEPRECATED/mongo/mongo.go
@@ -51,6 +51,7 @@ type DataSession struct {
 
 func (d *DataSession) EnsureIndexes() error {
 	return d.EnsureAllIndexes([]mgo.Index{
+		// Additional indexes are also created in `tide-whisperer` and `jellyfish`
 		{Key: []string{"_userId", "_active", "type", "_schemaVersion", "-time"}, Background: true, Name: "UserIdTypeWeighted"},
 		{Key: []string{"origin.id", "type", "-deletedTime", "_active"}, Background: true, Name: "OriginId"},
 		{Key: []string{"uploadId", "type", "-deletedTime", "_active"}, Background: true, Name: "UploadId"},

--- a/user/store/structured/mongo/mongo.go
+++ b/user/store/structured/mongo/mongo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	mgo "github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 
 	"github.com/tidepool-org/platform/errors"
@@ -53,10 +52,8 @@ type Session struct {
 }
 
 func (s *Session) EnsureIndexes() error {
-	return s.EnsureAllIndexes([]mgo.Index{
-		// There is overlap with this call to `EnsureIndexes` and that in `shoreline`
-		{Key: []string{"userid"}, Background: true, Unique: true},
-	})
+	// Indexes are created in `shoreline`
+	return nil
 }
 
 func (s *Session) Get(ctx context.Context, id string, condition *request.Condition) (*user.User, error) {

--- a/user/store/structured/mongo/mongo_test.go
+++ b/user/store/structured/mongo/mongo_test.go
@@ -96,12 +96,8 @@ var _ = Describe("Mongo", func() {
 		Context("EnsureIndexes", func() {
 			It("returns successfully", func() {
 				Expect(store.EnsureIndexes()).To(Succeed())
-				indexes, err := mgoCollection.Indexes()
+				_, err := mgoCollection.Indexes()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("_id")}),
-					MatchFields(IgnoreExtras, Fields{"Key": ConsistOf("userid"), "Background": Equal(true), "Unique": Equal(true)}),
-				))
 			})
 		})
 

--- a/user/store/structured/mongo/mongo_test.go
+++ b/user/store/structured/mongo/mongo_test.go
@@ -96,8 +96,6 @@ var _ = Describe("Mongo", func() {
 		Context("EnsureIndexes", func() {
 			It("returns successfully", func() {
 				Expect(store.EnsureIndexes()).To(Succeed())
-				_, err := mgoCollection.Indexes()
-				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION

An index for `users.userid` was being created in both `shoreline` and
`platform/users`, tying changes tightly together.
Remove index creation from `platform`, and leaving it to `shoreline`.
Also add comments for other places where multiple services create
indexes for the same collections.

* Fixes BACK-1437