### PR TITLE
[BACK-1572] Fix Mongo ENV parsing

### DIFF
--- a/tool/mongo/tool.go
+++ b/tool/mongo/tool.go
@@ -75,6 +75,7 @@ func (t *Tool) ParseContext(ctx *cli.Context) bool {
 
 func (t *Tool) NewMongoConfig() *storeStructuredMongo.Config {
 	mongoConfig := storeStructuredMongo.NewConfig()
+	mongoConfig.Scheme = t.mongoConfig.Scheme
 	if t.mongoConfig.Addresses != nil {
 		mongoConfig.Addresses = append([]string{}, t.mongoConfig.Addresses...)
 	}
@@ -87,5 +88,7 @@ func (t *Tool) NewMongoConfig() *storeStructuredMongo.Config {
 	if t.mongoConfig.Password != nil {
 		mongoConfig.Password = pointer.FromString(*t.mongoConfig.Password)
 	}
+	mongoConfig.Timeout = t.mongoConfig.Timeout
+	mongoConfig.OptParams = t.mongoConfig.OptParams
 	return mongoConfig
 }


### PR DESCRIPTION
`Tool` did not previously parse the Mongo Scheme, Timeout or OptParams
from the environment, meaning that migrations could not connect to AtlasDB

* Fixes [BACK-1572]

[BACK-1572]: https://tidepool.atlassian.net/browse/BACK-1572