### PR TITLE
Added migration for back-393

### DIFF
--- a/migrations/back-393/back-393.go
+++ b/migrations/back-393/back-393.go
@@ -115,7 +115,7 @@ func (m *Migration) addSharerID(dataSession *storeStructuredMongo.Session) int {
 	var numChanged int
 
 	secret := os.Getenv("GATEKEEPER_SECRET")
-	err := dataSession.C().Find(bson.M{}).Select(bson.M{"_id": 1, "groupId": 1}).All(docs)
+	err := dataSession.C().Find(bson.M{}).Select(bson.M{"_id": 1, "groupId": 1}).All(&docs)
 	if err != nil {
 		logger.WithError(err).Error("Unable to find any shares")
 	} else {

--- a/migrations/back-393/back-393.go
+++ b/migrations/back-393/back-393.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/base64"
+	"os"
+	"time"
+
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+	"github.com/urfave/cli"
+
+	"github.com/tidepool-org/platform/application"
+	"github.com/tidepool-org/platform/crypto"
+	"github.com/tidepool-org/platform/errors"
+	migrationMongo "github.com/tidepool-org/platform/migration/mongo"
+	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
+)
+
+func main() {
+	application.RunAndExit(NewMigration())
+}
+
+type Migration struct {
+	*migrationMongo.Migration
+}
+
+func NewMigration() *Migration {
+	return &Migration{
+		Migration: migrationMongo.NewMigration(),
+	}
+}
+
+func (m *Migration) Initialize(provider application.Provider) error {
+	if err := m.Migration.Initialize(provider); err != nil {
+		return err
+	}
+
+	m.CLI().Usage = "BACK393: Add sharedId to existing gatekeeper.perms documents"
+	m.CLI().Description = "BACK393: Gatekeeper.perms records which accounts are shared with whom.\n" +
+		"   It encrypts the user id of the shared account for some unknown reasson.\n" +
+		"   This migration adds a new field, sharerId, which contains the unencrypted value of the shared user id."
+	m.CLI().Authors = []cli.Author{
+		{
+			Name:  "Derrick Burns",
+			Email: "derrick@tidepool.org",
+		},
+	}
+
+	m.CLI().Action = func(ctx *cli.Context) error {
+		if !m.ParseContext(ctx) {
+			return nil
+		}
+		return m.execute()
+	}
+
+	return nil
+}
+
+func (m *Migration) execute() error {
+	m.Logger().Debug("Add sharerId to gatekeeper. ")
+
+	mongoConfig := m.NewMongoConfig()
+	mongoConfig.Database = "gatekeeper"
+	mongoConfig.Timeout = 60 * time.Minute
+	dataStore, err := storeStructuredMongo.NewStore(mongoConfig, m.Logger())
+	if err != nil {
+		return errors.Wrap(err, "unable to create data store")
+	}
+	defer dataStore.Close()
+
+	m.Logger().Debug("Creating data session")
+
+	dataSession := dataStore.NewSession("perms")
+	defer dataSession.Close()
+
+	numChanged := m.addSharerID(dataSession)
+
+	m.Logger().Infof("Updated %d shares", numChanged)
+
+	return nil
+}
+
+// UserIDFromGroupID decrypt userid
+func UserIDFromGroupID(groupID string, secret string) (string, error) {
+	if groupID == "" {
+		return "", errors.New("group id is missing")
+	}
+	if secret == "" {
+		return "", errors.New("secret is missing")
+	}
+
+	groupIDBytes, err := base64.StdEncoding.DecodeString(groupID)
+	if err != nil {
+		return "", errors.New("unable to decode with Base64")
+	}
+
+	userIDBytes, err := crypto.DecryptWithAES256UsingPassphrase(groupIDBytes, []byte(secret))
+	if err != nil {
+		return "", errors.New("unable to decrypt with AES-256 using passphrase")
+	}
+
+	return string(userIDBytes), nil
+}
+
+func (m *Migration) addSharerID(dataSession *storeStructuredMongo.Session) int {
+	logger := m.Logger()
+
+	logger.Debug("Finding shares")
+
+	type doc struct {
+		ID      string `bson:"_id"`
+		GroupID string `bson:"groupId"`
+	}
+	var docs []doc
+	var numChanged int
+
+	secret := os.Getenv("GATEKEEPER_SECRET")
+	err := dataSession.C().Find(bson.M{}).Select(bson.M{"_id": 1, "groupId": 1}).All(docs)
+	if err != nil {
+		logger.WithError(err).Error("Unable to find any shares")
+	} else {
+		logger.Infof("Found %d shares", len(docs))
+		for _, doc := range docs {
+			logger.Debugf("Updating document id %s, groupID %s", doc.ID, doc.GroupID)
+
+			sharerID, err := UserIDFromGroupID(doc.GroupID, secret)
+			if err != nil {
+				logger.WithError(err).Error("failed to decode groupId")
+				continue
+			}
+			change := mgo.Change{
+				Update:    bson.M{"$set": bson.M{"sharerId": sharerID}},
+				ReturnNew: true,
+			}
+			var result interface{}
+			_, err = dataSession.C().Find(bson.M{"_id": doc.ID}).Apply(change, &result)
+
+			if err != nil {
+				logger.WithError(err).Errorf("Could not update share ID %s", doc.ID)
+				continue
+			}
+			numChanged++
+		}
+	}
+	return numChanged
+}

--- a/migrations/back-393/back-393.go
+++ b/migrations/back-393/back-393.go
@@ -108,8 +108,8 @@ func (m *Migration) addSharerID(dataSession *storeStructuredMongo.Session) int {
 	logger.Debug("Finding shares")
 
 	type doc struct {
-		ID      string `bson:"_id"`
-		GroupID string `bson:"groupId"`
+		ID      bson.ObjectId `bson:"_id"`
+		GroupID string        `bson:"groupId"`
 	}
 	docs := make([]doc, 0)
 	var numChanged int
@@ -133,7 +133,7 @@ func (m *Migration) addSharerID(dataSession *storeStructuredMongo.Session) int {
 				ReturnNew: true,
 			}
 			var result interface{}
-			_, err = dataSession.C().Find(bson.M{"_id": doc.ID}).Apply(change, &result)
+			_, err = dataSession.C().FindId(doc.ID).Apply(change, &result)
 
 			if err != nil {
 				logger.WithError(err).Errorf("Could not update share ID %s", doc.ID)

--- a/migrations/back-393/back-393.go
+++ b/migrations/back-393/back-393.go
@@ -111,7 +111,7 @@ func (m *Migration) addSharerID(dataSession *storeStructuredMongo.Session) int {
 		ID      string `bson:"_id"`
 		GroupID string `bson:"groupId"`
 	}
-	doc := make([]doc, 0)
+	docs := make([]doc, 0)
 	var numChanged int
 
 	secret := os.Getenv("GATEKEEPER_SECRET")

--- a/migrations/back-393/back-393.go
+++ b/migrations/back-393/back-393.go
@@ -111,7 +111,7 @@ func (m *Migration) addSharerID(dataSession *storeStructuredMongo.Session) int {
 		ID      string `bson:"_id"`
 		GroupID string `bson:"groupId"`
 	}
-	var docs []doc
+	doc := make([]doc, 0)
 	var numChanged int
 
 	secret := os.Getenv("GATEKEEPER_SECRET")

--- a/prescription/prescription_test.go
+++ b/prescription/prescription_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Prescription", func() {
 			})
 
 			It("sets the modified time", func() {
-				Expect(update.ModifiedTime).To(BeTemporally("~", time.Now()))
+				Expect(update.ModifiedTime).To(BeTemporally("~", time.Now(), 10*time.Millisecond))
 			})
 
 			It("sets the modified user id", func() {


### PR DESCRIPTION
This adds the `sharerId` field to existing gatekeeper.perms documents.