### PR TITLE
[BACK-1572] Generate ObjectIDHash based on the correct IDHash

### DIFF
--- a/migrations/back-1572/JellyfishHasher.go
+++ b/migrations/back-1572/JellyfishHasher.go
@@ -53,7 +53,7 @@ func JellyfishIDHash(bsonData bson.M) string {
 
 func JellyfishObjectIDHash(bsonData bson.M) string {
 	return makeJellyfishHash(
-		bsonData["id"].(string),
+		JellyfishIDHash(bsonData),
 		bsonData["_groupId"].(string),
 	)
 }


### PR DESCRIPTION
The ObjectIDHash was previously generated by the `id` present in the data,
but it should have been generated based on what the `id` _should_ be.

* Fixes [BACK-1572]

[BACK-1572]: https://tidepool.atlassian.net/browse/BACK-1572