### PR TITLE
Fix bug introduced in last Dockerfile.tools change

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -23,7 +23,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/community' >> /etc/apk/repos
     echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/main' >> /etc/apk/repositories && \
     apk --no-cache update && \
     apk --no-cache upgrade && \
-    apk add --no-cache mongodb && \
+    apk add --no-cache mongodb
 WORKDIR /home/tidepool
 USER tidepool
 COPY --from=development --chown=tidepool /go/src/github.com/tidepool-org/platform/_bin/tools/ .


### PR DESCRIPTION
Production image wasn't building correctly due to a line continuation
that wasn't removed.