### PR TITLE
Turn off platform access logging

### DIFF
--- a/service/api/api.go
+++ b/service/api/api.go
@@ -55,10 +55,10 @@ func (a *API) InitializeMiddleware() error {
 	if err != nil {
 		return err
 	}
-	accessLogMiddleware, err := middleware.NewAccessLog()
-	if err != nil {
-		return err
-	}
+	//accessLogMiddleware, err := middleware.NewAccessLog()
+	//if err != nil {
+		//return err
+	//}
 	recoverMiddleware, err := middleware.NewRecover()
 	if err != nil {
 		return err

--- a/service/api/api.go
+++ b/service/api/api.go
@@ -55,10 +55,6 @@ func (a *API) InitializeMiddleware() error {
 	if err != nil {
 		return err
 	}
-	//accessLogMiddleware, err := middleware.NewAccessLog()
-	//if err != nil {
-		//return err
-	//}
 	recoverMiddleware, err := middleware.NewRecover()
 	if err != nil {
 		return err
@@ -77,7 +73,6 @@ func (a *API) InitializeMiddleware() error {
 		loggerMiddleware,
 		errorMiddleware,
 		traceMiddleware,
-		accessLogMiddleware,
 		statusMiddleware,
 		timerMiddleware,
 		recorderMiddleware,


### PR DESCRIPTION
Tapani asked me to cut back on the sumo logging.  This is a major source.  It is redundant since we are doing access logging with Gloo.