### PR TITLE
Enable error logging

### DIFF
--- a/service/api/api.go
+++ b/service/api/api.go
@@ -55,6 +55,10 @@ func (a *API) InitializeMiddleware() error {
 	if err != nil {
 		return err
 	}
+	accessLogMiddleware, err := middleware.NewAccessLog(middleware.AccessLogConfig{LogOnlyErrors: true})
+	if err != nil {
+		return err
+	}
 	recoverMiddleware, err := middleware.NewRecover()
 	if err != nil {
 		return err
@@ -73,6 +77,7 @@ func (a *API) InitializeMiddleware() error {
 		loggerMiddleware,
 		errorMiddleware,
 		traceMiddleware,
+		accessLogMiddleware,
 		statusMiddleware,
 		timerMiddleware,
 		recorderMiddleware,

--- a/service/middleware/access_log.go
+++ b/service/middleware/access_log.go
@@ -11,7 +11,13 @@ import (
 	"github.com/tidepool-org/platform/service"
 )
 
-type AccessLog struct{}
+type AccessLog struct {
+	config AccessLogConfig
+}
+
+type AccessLogConfig struct {
+	LogOnlyErrors bool
+}
 
 const (
 	_LogErrors           = "errors"
@@ -34,11 +40,19 @@ const (
 	_RequestEnvStatusCode   = "STATUS_CODE"
 )
 
-func NewAccessLog() (*AccessLog, error) {
-	return &AccessLog{}, nil
+func NewAccessLog(config AccessLogConfig) (*AccessLog, error) {
+	return &AccessLog{
+		config: config,
+	}, nil
 }
 
 func (a *AccessLog) ignore(req *rest.Request) bool {
+	if a.config.LogOnlyErrors {
+		if err := request.GetErrorFromContext(req.Context()); err == nil {
+			return true
+		}
+	}
+
 	// ignore liveness and readiness probes
 	if req.URL.RequestURI() == "/status" {
 		return true

--- a/service/middleware/access_log_test.go
+++ b/service/middleware/access_log_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("AccessLog", func() {
 	Context("NewAccessLog", func() {
 		It("returns successfully", func() {
-			Expect(middleware.NewAccessLog()).ToNot(BeNil())
+			Expect(middleware.NewAccessLog(middleware.AccessLogConfig{})).ToNot(BeNil())
 		})
 	})
 
@@ -30,7 +30,7 @@ var _ = Describe("AccessLog", func() {
 
 		BeforeEach(func() {
 			var err error
-			accessLogMiddleware, err = middleware.NewAccessLog()
+			accessLogMiddleware, err = middleware.NewAccessLog(middleware.AccessLogConfig{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(accessLogMiddleware).ToNot(BeNil())
 			hndlr = func(res rest.ResponseWriter, req *rest.Request) {}


### PR DESCRIPTION
https://github.com/tidepool-org/platform/pull/529 completely disabled error logging. This re-enabled access logging only if the request results in an error.