### PR TITLE
Add temporary fix for incomplete user parsing

### DIFF
--- a/user/store/structured/mongo/mongo.go
+++ b/user/store/structured/mongo/mongo.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
-	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -176,10 +175,6 @@ func (u *UserRepository) get(ctx context.Context, logger log.Logger, id string, 
 	} else if err != nil {
 		logger.WithError(err).Error("Unable to get user")
 		return nil, errors.Wrap(err, "unable to get user")
-	}
-
-	if result.Revision == nil {
-		result.Revision = pointer.FromInt(0)
 	}
 
 	return result, nil

--- a/user/test/user.go
+++ b/user/test/user.go
@@ -9,7 +9,6 @@ import (
 
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
-	requestTest "github.com/tidepool-org/platform/request/test"
 	"github.com/tidepool-org/platform/test"
 	"github.com/tidepool-org/platform/user"
 )
@@ -48,12 +47,11 @@ func RandomUser() *user.User {
 	datum := &user.User{}
 	datum.UserID = pointer.FromString(RandomID())
 	datum.Username = pointer.FromString(RandomUsername())
-	datum.Authenticated = pointer.FromBool(test.RandomBool())
+	datum.EmailVerified = pointer.FromBool(test.RandomBool())
 	datum.TermsAccepted = pointer.FromString(test.RandomTimeFromRange(test.RandomTimeMinimum(), time.Now()).Format(time.RFC3339Nano))
 	datum.Roles = nil
 	datum.CreatedTime = pointer.FromTime(test.RandomTimeFromRange(test.RandomTimeMinimum(), time.Now()).Truncate(time.Second))
 	datum.ModifiedTime = pointer.FromTime(test.RandomTimeFromRange(*datum.CreatedTime, time.Now()).Truncate(time.Second))
-	datum.Revision = pointer.FromInt(requestTest.RandomRevision())
 	return datum
 }
 
@@ -65,13 +63,12 @@ func CloneUser(datum *user.User) *user.User {
 	clone.UserID = pointer.CloneString(datum.UserID)
 	clone.Username = pointer.CloneString(datum.Username)
 	clone.PasswordHash = pointer.CloneString(datum.PasswordHash)
-	clone.Authenticated = pointer.CloneBool(datum.Authenticated)
+	clone.EmailVerified = pointer.CloneBool(datum.EmailVerified)
 	clone.TermsAccepted = pointer.CloneString(datum.TermsAccepted)
 	clone.Roles = pointer.CloneStringArray(datum.Roles)
 	clone.CreatedTime = pointer.CloneTime(datum.CreatedTime)
 	clone.ModifiedTime = pointer.CloneTime(datum.ModifiedTime)
 	clone.DeletedTime = pointer.CloneTime(datum.DeletedTime)
-	clone.Revision = pointer.CloneInt(datum.Revision)
 	return clone
 }
 
@@ -86,8 +83,8 @@ func NewObjectFromUser(datum *user.User, objectFormat test.ObjectFormat) map[str
 	if datum.Username != nil {
 		object["username"] = test.NewObjectFromString(*datum.Username, objectFormat)
 	}
-	if datum.Authenticated != nil {
-		object["authenticated"] = test.NewObjectFromBool(*datum.Authenticated, objectFormat)
+	if datum.EmailVerified != nil {
+		object["emailVerified"] = test.NewObjectFromBool(*datum.EmailVerified, objectFormat)
 	}
 	if datum.TermsAccepted != nil {
 		object["termsAccepted"] = test.NewObjectFromString(*datum.TermsAccepted, objectFormat)
@@ -104,9 +101,6 @@ func NewObjectFromUser(datum *user.User, objectFormat test.ObjectFormat) map[str
 	if datum.DeletedTime != nil {
 		object["deletedTime"] = test.NewObjectFromTime(*datum.DeletedTime, objectFormat)
 	}
-	if datum.Revision != nil {
-		object["revision"] = test.NewObjectFromInt(*datum.Revision, objectFormat)
-	}
 	return object
 }
 
@@ -118,13 +112,12 @@ func MatchUser(datum *user.User) gomegaTypes.GomegaMatcher {
 		"UserID":        gomega.Equal(datum.UserID),
 		"Username":      gomega.Equal(datum.Username),
 		"PasswordHash":  gomega.Equal(datum.PasswordHash),
-		"Authenticated": gomega.Equal(datum.Authenticated),
+		"EmailVerified": gomega.Equal(datum.EmailVerified),
 		"TermsAccepted": gomega.Equal(datum.TermsAccepted),
 		"Roles":         gomega.Equal(datum.Roles),
 		"CreatedTime":   test.MatchTime(datum.CreatedTime),
 		"ModifiedTime":  test.MatchTime(datum.ModifiedTime),
 		"DeletedTime":   test.MatchTime(datum.DeletedTime),
-		"Revision":      gomega.Equal(datum.Revision),
 	}))
 }
 

--- a/user/user.go
+++ b/user/user.go
@@ -46,25 +46,25 @@ type User struct {
 	UserID        *string    `json:"userid,omitempty" bson:"userid,omitempty"`     // TODO: Rename ID/id
 	Username      *string    `json:"username,omitempty" bson:"username,omitempty"` // TODO: Rename Email/email
 	PasswordHash  *string    `json:"-" bson:"pwhash,omitempty"`
-	Authenticated *bool      `json:"authenticated,omitempty" bson:"authenticated,omitempty"` // TODO: Rename EmaiLVerified/emailVerified
+	EmailVerified *bool      `json:"emailVerified,omitempty" bson:"emailVerified,omitempty"` // TODO: Rename EmaiLVerified/emailVerified
 	TermsAccepted *string    `json:"termsAccepted,omitempty" bson:"termsAccepted,omitempty"`
 	Roles         *[]string  `json:"roles,omitempty" bson:"roles,omitempty"`
 	CreatedTime   *time.Time `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
 	ModifiedTime  *time.Time `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
 	DeletedTime   *time.Time `json:"deletedTime,omitempty" bson:"deletedTime,omitempty"`
-	Revision      *int       `json:"revision,omitempty" bson:"revision,omitempty"`
 }
 
 func (u *User) Parse(parser structure.ObjectParser) {
 	u.UserID = parser.String("userid")
 	u.Username = parser.String("username")
-	u.Authenticated = parser.Bool("authenticated")
+	u.EmailVerified = parser.Bool("emailVerified")
 	u.TermsAccepted = parser.String("termsAccepted")
 	u.Roles = parser.StringArray("roles")
 	u.CreatedTime = parser.Time("createdTime", time.RFC3339Nano)
 	u.ModifiedTime = parser.Time("modifiedTime", time.RFC3339Nano)
 	u.DeletedTime = parser.Time("deletedTime", time.RFC3339Nano)
-	u.Revision = parser.Int("revision")
+	parser.Bool("passwordExists")
+	parser.StringArray("emails")
 }
 
 func (u *User) Validate(validator structure.Validator) {
@@ -81,7 +81,6 @@ func (u *User) Validate(validator structure.Validator) {
 	if u.DeletedTime != nil {
 		validator.Time("deletedTime", u.DeletedTime).NotZero().BeforeNow(time.Second)
 	}
-	validator.Int("revision", u.Revision).Exists().GreaterThanOrEqualTo(0)
 }
 
 func (u *User) HasRole(role string) bool {
@@ -105,7 +104,7 @@ func (u *User) IsPatient() bool {
 func (u *User) Sanitize(details request.Details) error {
 	if details == nil || (!details.IsService() && details.UserID() != *u.UserID) {
 		u.Username = nil
-		u.Authenticated = nil
+		u.EmailVerified = nil
 		u.TermsAccepted = nil
 		u.Roles = nil
 	}


### PR DESCRIPTION
Now that the user service has been deprecated and it's not in use, we forward all requests to `/v1/users` to shoreline. However, shoreline responses contain extra fields that make the user object parser fail.

The user client is currently only used by the prescription service which is not in production. Its use will be replaced by external auth + clinic service client, so this temporary fix will never make it to production.