### PR TITLE
[BACK-1779] Use bson value codec for errors

### DIFF
--- a/errors/test/errors.go
+++ b/errors/test/errors.go
@@ -55,7 +55,7 @@ func NewObjectFromSerializable(serializable *errors.Serializable, objectFormat t
 
 	switch objectFormat {
 	case test.ObjectFormatBSON:
-		if bites, err := bson.Marshal(serializable); err != nil {
+		if t, bites, err := serializable.MarshalBSONValue(); err != nil || t != bson.TypeEmbeddedDocument {
 			return nil
 		} else if err = bson.Unmarshal(bites, &object); err != nil {
 			return nil

--- a/store/structured/mongo/config_test.go
+++ b/store/structured/mongo/config_test.go
@@ -156,6 +156,7 @@ var _ = Describe("Config", func() {
 			config = &mongo.Config{}
 			var err error
 			reporter, err = env.NewDefaultReporter()
+			Expect(err).ToNot(HaveOccurred())
 			reporter = reporter.WithScopes("alt", "store")
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -168,7 +169,8 @@ var _ = Describe("Config", func() {
 		})
 
 		It("errors if database not set in environment", func() {
-			Expect(config.SetDatabaseFromReporter(reporter)).To(MatchError("key \"TIDEPOOL_ALT_STORE_DATABASE\" not found"))
+			reporter := reporter.WithScopes("empty")
+			Expect(config.SetDatabaseFromReporter(reporter)).To(MatchError("key \"TIDEPOOL_ALT_STORE_EMPTY_DATABASE\" not found"))
 			Expect(config.Database).To(Equal(""))
 		})
 	})


### PR DESCRIPTION
Faulty serailization of errors affects the task service, because we serialize failures in the task document. When multiple errors occur during a sync, we can't serialize/desiarilize documents correctly, because of change of the interfaces provided by the official mongo driver.

Serialized errors are polymorphic and can be documents (when the type is `object`), arrays (when the type is `array`) or strings (when the std lib error is used). `mgo` supported marshalling and unmarshalling through a single interface, but this is now illegal with the official mongo driver. `MarshalBSON` and `UnmarshalBSON` should only be used on types that can be serialized as top-level documents - this is not the case for strings and arrays.

The right way to do this is to use `MarshalBSONValue` and `UnmarshalBSONValue` - the implication is that errors cannot be serialized as top-level documents - this is not an issue in our case, because strings and arrays are not valid top-level structures anyway.