### PR TITLE
Fix order of elements in index options

### DIFF
--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -106,9 +106,9 @@ func (d *DataRepository) EnsureIndexes() error {
 			Options: options.Index().
 				SetBackground(true).
 				SetPartialFilterExpression(bson.D{
+					{Key: "deviceId", Value: bson.D{{Key: "$exists", Value: true}}},
 					{Key: "_active", Value: true},
 					{Key: "_deduplicator.hash", Value: bson.D{{Key: "$exists", Value: true}}},
-					{Key: "deviceId", Value: bson.D{{Key: "$exists", Value: true}}},
 				}).
 				SetName("DeduplicatorHash"),
 		},

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -220,9 +220,9 @@ var _ = Describe("Mongo", func() {
 						"Background": Equal(true),
 						"Name":       Equal("DeduplicatorHash"),
 						"PartialFilterExpression": Equal(bson.D{
+							{Key: "deviceId", Value: bson.D{{Key: "$exists", Value: true}}},
 							{Key: "_active", Value: true},
 							{Key: "_deduplicator.hash", Value: bson.D{{Key: "$exists", Value: true}}},
-							{Key: "deviceId", Value: bson.D{{Key: "$exists", Value: true}}},
 						}),
 					}),
 				))


### PR DESCRIPTION
The deployment of the data service failed on prod, because the index was created using the atlas ui, which spits out partial filter expression options in a random order

I deleted the indexes on all non-prod environments and let the application create them so they match prod