### PR TITLE
[BACK-1914] Fix combo boluses for 600 Series Medtronic Pumps

### DIFF
--- a/data/types/bolus/combination/combination.go
+++ b/data/types/bolus/combination/combination.go
@@ -67,10 +67,13 @@ func (c *Combination) Validate(validator structure.Validator) {
 		extendedExpectedValidator := validator.Float64("expectedExtended", c.ExtendedExpected)
 		extendedExpectedValidator.InRange(ExtendedMinimum, ExtendedMaximum)
 		if c.Normal != nil {
-			if *c.Normal != NormalMinimum {
-				extendedExpectedValidator.Exists()
-			} else {
+			if *c.Normal == NormalMinimum {
+				if c.ExtendedExpected == nil {
+					validator.Float64("expectedNormal", c.NormalExpected).GreaterThan(NormalMinimum)
+				}
 				extendedExpectedValidator.GreaterThan(ExtendedMinimum)
+			} else {
+				extendedExpectedValidator.Exists()
 			}
 		}
 	} else {
@@ -90,6 +93,9 @@ func (c *Combination) Validate(validator structure.Validator) {
 		expectedExtendedValidator := validator.Float64("expectedExtended", c.ExtendedExpected)
 		if c.Extended != nil && *c.Extended >= ExtendedMinimum && *c.Extended <= ExtendedMaximum {
 			if *c.Extended == ExtendedMinimum {
+				if c.Normal != nil && *c.Normal == NormalMinimum {
+					expectedExtendedValidator.GreaterThan(ExtendedMinimum)
+				}
 				expectedExtendedValidator.Exists()
 			}
 			expectedExtendedValidator.InRange(*c.Extended, ExtendedMaximum)

--- a/data/types/bolus/combination/combination.go
+++ b/data/types/bolus/combination/combination.go
@@ -64,7 +64,12 @@ func (c *Combination) Validate(validator structure.Validator) {
 		validator.Int("duration", c.Duration).Exists().EqualTo(DurationMinimum)
 		validator.Int("expectedDuration", c.DurationExpected).Exists().InRange(DurationMinimum, DurationMaximum)
 		validator.Float64("extended", c.Extended).Exists().EqualTo(ExtendedMinimum)
-		validator.Float64("expectedExtended", c.ExtendedExpected).Exists().InRange(ExtendedMinimum, ExtendedMaximum)
+		extendedExpectedValidator := validator.Float64("expectedExtended", c.ExtendedExpected)
+		extendedExpectedValidator.InRange(ExtendedMinimum, ExtendedMaximum)
+		if c.Normal != nil && *c.Normal != NormalMinimum {
+			extendedExpectedValidator.Exists()
+		}
+
 	} else {
 		validator.Int("duration", c.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
 		expectedDurationValidator := validator.Int("expectedDuration", c.DurationExpected)
@@ -96,7 +101,7 @@ func (c *Combination) Validate(validator structure.Validator) {
 			// If Normal is zero, then _either_:
 			if c.Extended != nil {
 				if c.NormalExpected == nil {
-					validator.Float64("extended", c.Extended).GreaterThan(ExtendedMinimum)
+					validator.Float64("extended", c.Extended).GreaterThanOrEqualTo(ExtendedMinimum)
 				} else {
 					validator.Float64("extended", c.Extended).Exists()
 				}

--- a/data/types/bolus/combination/combination.go
+++ b/data/types/bolus/combination/combination.go
@@ -66,10 +66,13 @@ func (c *Combination) Validate(validator structure.Validator) {
 		validator.Float64("extended", c.Extended).Exists().EqualTo(ExtendedMinimum)
 		extendedExpectedValidator := validator.Float64("expectedExtended", c.ExtendedExpected)
 		extendedExpectedValidator.InRange(ExtendedMinimum, ExtendedMaximum)
-		if c.Normal != nil && *c.Normal != NormalMinimum {
-			extendedExpectedValidator.Exists()
+		if c.Normal != nil {
+			if *c.Normal != NormalMinimum {
+				extendedExpectedValidator.Exists()
+			} else {
+				extendedExpectedValidator.GreaterThan(ExtendedMinimum)
+			}
 		}
-
 	} else {
 		validator.Int("duration", c.Duration).Exists().InRange(DurationMinimum, DurationMaximum)
 		expectedDurationValidator := validator.Int("expectedDuration", c.DurationExpected)

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -1148,12 +1148,13 @@ var _ = Describe("Combination", func() {
 						datum.ExtendedExpected = nil
 					},
 				),
-				Entry("allow normal and extended to be 0 when normal expected is missing",
+				Entry("allow normal and extended to be 0 when normal expected is missing and extended expected is in range (upper)",
 					func(datum *combination.Combination) {
 						datum.Duration = pointer.FromInt(0)
 						datum.Extended = pointer.FromFloat64(0.0)
 						datum.Normal = pointer.FromFloat64(0.0)
 						datum.NormalExpected = nil
+						datum.ExtendedExpected = pointer.FromFloat64(100.0)
 					},
 				),
 				Entry("allow normal and extended to be 0 when both normal expected and extended expected are in range",

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -1119,6 +1119,31 @@ var _ = Describe("Combination", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta()),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
 				),
+				Entry("allow normal and extended to be 0 when extended expected is missing",
+					func(datum *combination.Combination) {
+						datum.Duration = pointer.FromInt(0)
+						datum.Extended = pointer.FromFloat64(0.0)
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+						datum.ExtendedExpected = nil
+					},
+				),
+				Entry("allow normal and extended to be 0 when normal expected is missing",
+					func(datum *combination.Combination) {
+						datum.Duration = pointer.FromInt(0)
+						datum.Extended = pointer.FromFloat64(0.0)
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = nil
+					},
+				),
+				Entry("allow normal and extended to be 0 when both normal expected and extended expected are in range",
+					func(datum *combination.Combination) {
+						datum.Duration = pointer.FromInt(0)
+						datum.Extended = pointer.FromFloat64(0.0)
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+				),
 				Entry("multiple errors",
 					func(datum *combination.Combination) {
 						datum.Type = "invalidType"

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -991,15 +991,6 @@ var _ = Describe("Combination", func() {
 						datum.NormalExpected = nil
 					},
 				),
-				Entry("normal in range (lower); normal expected missing, extended out of range (lower)",
-					func(datum *combination.Combination) {
-						datum.Duration = pointer.FromInt(0)
-						datum.Normal = pointer.FromFloat64(0.0)
-						datum.Extended = pointer.FromFloat64(0.0)
-						datum.NormalExpected = nil
-					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotGreaterThan(0.0, 0.0), "/extended", NewMeta()),
-				),
 				Entry("normal in range (lower); normal expected out of range (lower)",
 					func(datum *combination.Combination) {
 						datum.Duration = pointer.FromInt(0)

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -867,6 +867,16 @@ var _ = Describe("Combination", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo(0.1, 0.0), "/extended", NewMeta()),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedExtended", NewMeta()),
 				),
+				Entry("normal in range (lower); extended in range (lower); normal expected in range (lower); extended expected our of range (lower)",
+					func(datum *combination.Combination) {
+						datum.Duration = pointer.FromInt(0)
+						datum.Extended = pointer.FromFloat64(0.0)
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(0.0)
+						datum.ExtendedExpected = pointer.FromFloat64(0.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotGreaterThan(0.0, 0.0), "/expectedExtended", NewMeta()),
+				),
 				Entry("normal missing; normal expected missing",
 					func(datum *combination.Combination) {
 						datum.Normal = nil

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -867,7 +867,7 @@ var _ = Describe("Combination", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo(0.1, 0.0), "/extended", NewMeta()),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedExtended", NewMeta()),
 				),
-				Entry("normal in range (lower); extended in range (lower); normal expected in range (lower); extended expected our of range (lower)",
+				Entry("normal in range (lower); extended in range (lower); normal expected in range (lower); extended expected out of range (lower)",
 					func(datum *combination.Combination) {
 						datum.Duration = pointer.FromInt(0)
 						datum.Extended = pointer.FromFloat64(0.0)
@@ -973,6 +973,25 @@ var _ = Describe("Combination", func() {
 						datum.NormalExpected = nil
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/extended", NewMeta()),
+				),
+				Entry("normal in range (lower); extended in range (lower); extended expected missing, normal expected out of range (lower)",
+					func(datum *combination.Combination) {
+						datum.Duration = pointer.FromInt(0.0)
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.Extended = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(0.0)
+						datum.ExtendedExpected = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotGreaterThan(0.0, 0.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal in range (lower); extended in range (lower); extended expected missing, extended expected out of range (lower)",
+					func(datum *combination.Combination) {
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.Extended = pointer.FromFloat64(0.0)
+						datum.NormalExpected = nil
+						datum.ExtendedExpected = pointer.FromFloat64(0.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotGreaterThan(0.0, 0.0), "/expectedExtended", NewMeta()),
 				),
 				Entry("normal in range (lower); normal expected in range, extended missing",
 					func(datum *combination.Combination) {


### PR DESCRIPTION
Now the `bolus/combination` validator allows both `extended` and `normal` to be zero if either `expectedNormal` or `expectedExtended` are larger than 0. 