### PR TITLE
[BACK-1927] Disallow "1" in access code

### DIFF
--- a/prescription/access_code.go
+++ b/prescription/access_code.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	accessCodeLength = 6
-	characters       = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789"
+	characters       = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 )
 
 func GenerateAccessCode() string {

--- a/prescription/access_code_test.go
+++ b/prescription/access_code_test.go
@@ -10,8 +10,8 @@ import (
 var _ = Describe("GenerateAccessCode", func() {
 	It("generates an alphanumeric code", func() {
 		code := prescription.GenerateAccessCode()
-		// I, O and 0 are excluded
-		Expect(code).To(MatchRegexp("^[A-HJ-NP-Z1-9]+$"))
+		// I, 1, O and 0 are excluded
+		Expect(code).To(MatchRegexp("^[A-HJ-NP-Z2-9]+$"))
 	})
 
 	It("generates a code with length of 6 characters", func() {


### PR DESCRIPTION
Darin noticed that we allow "1" in the prescription access code, while disallowing "I", "0", and "O". For symmetry with "0" and "O" and to avoid input mistakes, we should disallow "1" as well.