### PR TITLE
[IN-29] Add temporary index hint for the newly created unique upload id index

### DIFF
--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -180,7 +180,8 @@ func (d *DataRepository) GetDataSetByID(ctx context.Context, dataSetID string) (
 		"uploadId": dataSetID,
 		"type":     "upload",
 	}
-	err := d.FindOne(ctx, selector).Decode(&dataSet)
+	opts := options.FindOne().SetHint("UploadId")
+	err := d.FindOne(ctx, selector, opts).Decode(&dataSet)
 
 	loggerFields := log.Fields{"dataSetId": dataSetID, "duration": time.Since(now) / time.Microsecond}
 	log.LoggerFromContext(ctx).WithFields(loggerFields).WithError(err).Debug("GetDataSetByID")
@@ -846,7 +847,9 @@ func (d *DataRepository) GetDataSet(ctx context.Context, id string) (*data.DataS
 		"uploadId": id,
 		"type":     "upload",
 	}
-	err := d.FindOne(ctx, selector).Decode(&dataSet)
+
+	opts := options.FindOne().SetHint("UploadId")
+	err := d.FindOne(ctx, selector, opts).Decode(&dataSet)
 	logger.WithField("duration", time.Since(now)/time.Microsecond).WithError(err).Debug("GetDataSet")
 	if err == mongo.ErrNoDocuments {
 		return nil, nil

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -376,6 +376,8 @@ var _ = Describe("Mongo", func() {
 				Context("GetDataSetByID", func() {
 					BeforeEach(func() {
 						dataSet.CreatedTime = pointer.FromString("2016-09-01T11:00:00Z")
+						err := repository.EnsureIndexes()
+						Expect(err).ToNot(HaveOccurred())
 					})
 
 					It("returns an error if the data set id is missing", func() {


### PR DESCRIPTION
This will allows to restore the data service in a working state faster, by leveraging the index created on the primary, before secondaries have completed building the indexes and without having to drop the old (corrupted index).

It looks like Jellyfish and tide-whisperer do not make use of this index.