### PR TITLE
Do not return a validation errors if there are unparsed fields

### DIFF
--- a/structure/parser/object_parser.go
+++ b/structure/parser/object_parser.go
@@ -70,7 +70,7 @@ func (o *Object) Exists() bool {
 
 func (o *Object) Parse(objectParsable structure.ObjectParsable) error {
 	objectParsable.Parse(o)
-	return o.NotParsed()
+	return o.Error()
 }
 
 func (o *Object) References() []string {


### PR DESCRIPTION
The object parser returns errors if there are unparsed field in an object. This causes unexpected errors every time a new field is added from a third-party provider even if their change is backward compatible. For this reason I believe it's better if we don't default to this.

Dexcom added a new field to their responses which is undocumented, thus not parsed by us. This resulted in sync failures for all tasks in the last ~20h.