### PR TITLE
Use mongo 4.0 in the tools image

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,8 +1,8 @@
 # Development
 FROM golang:1.15.2-alpine AS development
 WORKDIR /go/src/github.com/tidepool-org/platform
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/community' >> /etc/apk/repositories && \
-    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/main' >> /etc/apk/repositories && \
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories && \
+    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories && \
     apk --no-cache add git make tzdata mongodb && \
     apk add --no-cache ca-certificates tzdata && \
     go get github.com/githubnemo/CompileDaemon && \
@@ -21,8 +21,8 @@ RUN apk --no-cache update && \
     apk --no-cache upgrade && \
     apk add --no-cache ca-certificates tzdata && \
     adduser -D tidepool
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/community' >> /etc/apk/repositories && \
-    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.6/main' >> /etc/apk/repositories && \
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories && \
+    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories && \
     apk --no-cache update && \
     apk --no-cache upgrade && \
     apk add --no-cache mongodb


### PR DESCRIPTION
Newer version of mongo are not available for alpine. We might need to switch to a different image.