### PR TITLE
[BACK-1903] Support Tandem CIQ

### DIFF
--- a/data/types/basal/automated/automated_test.go
+++ b/data/types/basal/automated/automated_test.go
@@ -6,9 +6,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
-	"github.com/tidepool-org/platform/data/types/basal"
-	"github.com/tidepool-org/platform/data/types/basal/automated"
+	dataTypesBasal "github.com/tidepool-org/platform/data/types/basal"
+	dataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated"
 	dataTypesBasalAutomatedTest "github.com/tidepool-org/platform/data/types/basal/automated/test"
+	dataTypesBasalScheduledTest "github.com/tidepool-org/platform/data/types/basal/scheduled/test"
+	dataTypesBasalTemporaryTest "github.com/tidepool-org/platform/data/types/basal/temporary/test"
 	dataTypesBasalTest "github.com/tidepool-org/platform/data/types/basal/test"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
@@ -16,124 +18,161 @@ import (
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
+	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
 )
 
 func NewMeta() interface{} {
-	return &basal.Meta{
+	return &dataTypesBasal.Meta{
 		Type:         "basal",
 		DeliveryType: "automated",
 	}
 }
 
-func NewAutomated() *automated.Automated {
-	datum := automated.New()
-	datum.Basal = *dataTypesBasalTest.NewBasal()
-	datum.DeliveryType = "automated"
-	datum.Duration = pointer.FromInt(test.RandomIntFromRange(automated.DurationMinimum, automated.DurationMaximum))
-	datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, automated.DurationMaximum))
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
-	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(automated.RateMinimum, automated.RateMaximum))
-	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
-	return datum
-}
-
-func CloneAutomated(datum *automated.Automated) *automated.Automated {
-	if datum == nil {
-		return nil
-	}
-	clone := automated.New()
-	clone.Basal = *dataTypesBasalTest.CloneBasal(&datum.Basal)
-	clone.Duration = pointer.CloneInt(datum.Duration)
-	clone.DurationExpected = pointer.CloneInt(datum.DurationExpected)
-	clone.InsulinFormulation = dataTypesInsulinTest.CloneFormulation(datum.InsulinFormulation)
-	clone.Rate = pointer.CloneFloat64(datum.Rate)
-	clone.ScheduleName = pointer.CloneString(datum.ScheduleName)
-	return clone
-}
-
 var _ = Describe("Automated", func() {
 	It("DeliveryType is expected", func() {
-		Expect(automated.DeliveryType).To(Equal("automated"))
+		Expect(dataTypesBasalAutomated.DeliveryType).To(Equal("automated"))
 	})
 
 	It("DurationMaximum is expected", func() {
-		Expect(automated.DurationMaximum).To(Equal(604800000))
+		Expect(dataTypesBasalAutomated.DurationMaximum).To(Equal(604800000))
 	})
 
 	It("DurationMinimum is expected", func() {
-		Expect(automated.DurationMinimum).To(Equal(0))
+		Expect(dataTypesBasalAutomated.DurationMinimum).To(Equal(0))
 	})
 
 	It("RateMaximum is expected", func() {
-		Expect(automated.RateMaximum).To(Equal(100.0))
+		Expect(dataTypesBasalAutomated.RateMaximum).To(Equal(100.0))
 	})
 
 	It("RateMinimum is expected", func() {
-		Expect(automated.RateMinimum).To(Equal(0.0))
-	})
-
-	Context("New", func() {
-		It("returns the expected datum with all values initialized", func() {
-			datum := automated.New()
-			Expect(datum).ToNot(BeNil())
-			Expect(datum.Type).To(Equal("basal"))
-			Expect(datum.DeliveryType).To(Equal("automated"))
-			Expect(datum.Duration).To(BeNil())
-			Expect(datum.DurationExpected).To(BeNil())
-			Expect(datum.InsulinFormulation).To(BeNil())
-			Expect(datum.Rate).To(BeNil())
-			Expect(datum.ScheduleName).To(BeNil())
-		})
+		Expect(dataTypesBasalAutomated.RateMinimum).To(Equal(0.0))
 	})
 
 	Context("Automated", func() {
+		DescribeTable("serializes the datum as expected",
+			func(mutator func(datum *dataTypesBasalAutomated.Automated)) {
+				datum := dataTypesBasalAutomatedTest.RandomAutomated()
+				mutator(datum)
+				test.ExpectSerializedObjectJSON(datum, dataTypesBasalAutomatedTest.NewObjectFromAutomated(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataTypesBasalAutomatedTest.NewObjectFromAutomated(datum, test.ObjectFormatBSON))
+			},
+			Entry("succeeds",
+				func(datum *dataTypesBasalAutomated.Automated) {},
+			),
+			Entry("empty",
+				func(datum *dataTypesBasalAutomated.Automated) {
+					*datum = *dataTypesBasalAutomated.New()
+				},
+			),
+			Entry("all",
+				func(datum *dataTypesBasalAutomated.Automated) {
+					datum.Duration = pointer.FromInt(test.RandomIntFromRange(dataTypesBasalAutomated.DurationMinimum, dataTypesBasalAutomated.DurationMaximum))
+					datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, dataTypesBasalAutomated.DurationMaximum))
+					datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+					datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalAutomated.RateMinimum, dataTypesBasalAutomated.RateMaximum))
+					datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
+					datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
+				},
+			),
+		)
+
+		Context("New", func() {
+			It("returns the expected datum with all values initialized", func() {
+				datum := dataTypesBasalAutomated.New()
+				Expect(datum).ToNot(BeNil())
+				Expect(datum.Type).To(Equal("basal"))
+				Expect(datum.DeliveryType).To(Equal("automated"))
+				Expect(datum.Duration).To(BeNil())
+				Expect(datum.DurationExpected).To(BeNil())
+				Expect(datum.InsulinFormulation).To(BeNil())
+				Expect(datum.Rate).To(BeNil())
+				Expect(datum.ScheduleName).To(BeNil())
+				Expect(datum.Suppressed).To(BeNil())
+			})
+		})
+
 		Context("Parse", func() {
-			// TODO
+			DescribeTable("parses the datum",
+				func(mutator func(object map[string]interface{}, expectedDatum *dataTypesBasalAutomated.Automated), expectedErrors ...error) {
+					expectedDatum := dataTypesBasalAutomatedTest.RandomAutomatedForParser()
+					object := dataTypesBasalAutomatedTest.NewObjectFromAutomated(expectedDatum, test.ObjectFormatJSON)
+					mutator(object, expectedDatum)
+					datum := dataTypesBasalAutomated.New()
+					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					Expect(datum).To(Equal(expectedDatum))
+				},
+				Entry("succeeds",
+					func(object map[string]interface{}, expectedDatum *dataTypesBasalAutomated.Automated) {},
+				),
+				Entry("multiple errors",
+					func(object map[string]interface{}, expectedDatum *dataTypesBasalAutomated.Automated) {
+						object["duration"] = true
+						object["expectedDuration"] = true
+						object["insulinFormulation"] = true
+						object["rate"] = true
+						object["scheduleName"] = true
+						object["suppressed"] = dataTypesBasalTemporaryTest.NewObjectFromSuppressedTemporary(dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil), test.ObjectFormatJSON)
+						expectedDatum.Duration = nil
+						expectedDatum.DurationExpected = nil
+						expectedDatum.InsulinFormulation = nil
+						expectedDatum.Rate = nil
+						expectedDatum.ScheduleName = nil
+						expectedDatum.Suppressed = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotInt(true), "/duration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotInt(true), "/expectedDuration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotObject(true), "/insulinFormulation", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotFloat64(true), "/rate", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotString(true), "/scheduleName", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("temp", []string{"scheduled"}), "/suppressed/deliveryType", NewMeta()),
+				),
+			)
 		})
 
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
-				func(mutator func(datum *automated.Automated), expectedErrors ...error) {
-					datum := NewAutomated()
+				func(mutator func(datum *dataTypesBasalAutomated.Automated), expectedErrors ...error) {
+					datum := dataTypesBasalAutomatedTest.RandomAutomated()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
 				Entry("succeeds",
-					func(datum *automated.Automated) {},
+					func(datum *dataTypesBasalAutomated.Automated) {},
 				),
 				Entry("type missing",
-					func(datum *automated.Automated) { datum.Type = "" },
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &basal.Meta{DeliveryType: "automated"}),
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Type = "" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &dataTypesBasal.Meta{DeliveryType: "automated"}),
 				),
 				Entry("type invalid",
-					func(datum *automated.Automated) { datum.Type = "invalidType" },
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &basal.Meta{Type: "invalidType", DeliveryType: "automated"}),
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Type = "invalidType" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "automated"}),
 				),
 				Entry("type basal",
-					func(datum *automated.Automated) { datum.Type = "basal" },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Type = "basal" },
 				),
 				Entry("delivery type missing",
-					func(datum *automated.Automated) { datum.DeliveryType = "" },
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deliveryType", &basal.Meta{Type: "basal"}),
+					func(datum *dataTypesBasalAutomated.Automated) { datum.DeliveryType = "" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/deliveryType", &dataTypesBasal.Meta{Type: "basal"}),
 				),
 				Entry("delivery type invalid",
-					func(datum *automated.Automated) { datum.DeliveryType = "invalidDeliveryType" },
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType", &basal.Meta{Type: "basal", DeliveryType: "invalidDeliveryType"}),
+					func(datum *dataTypesBasalAutomated.Automated) { datum.DeliveryType = "invalidDeliveryType" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType", &dataTypesBasal.Meta{Type: "basal", DeliveryType: "invalidDeliveryType"}),
 				),
 				Entry("delivery type automated",
-					func(datum *automated.Automated) { datum.DeliveryType = "automated" },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.DeliveryType = "automated" },
 				),
 				Entry("duration missing; duration expected missing",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = nil
 						datum.DurationExpected = nil
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
 				),
 				Entry("duration missing; duration expected out of range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = nil
 						datum.DurationExpected = pointer.FromInt(-1)
 					},
@@ -141,21 +180,21 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration missing; duration expected in range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = nil
 						datum.DurationExpected = pointer.FromInt(0)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
 				),
 				Entry("duration missing; duration expected in range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = nil
 						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", NewMeta()),
 				),
 				Entry("duration missing; duration expected out of range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = nil
 						datum.DurationExpected = pointer.FromInt(604800001)
 					},
@@ -163,14 +202,14 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration out of range (lower); duration expected missing",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = nil
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration out of range (lower); duration expected out of range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = pointer.FromInt(-1)
 					},
@@ -178,21 +217,21 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration out of range (lower); duration expected in range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = pointer.FromInt(0)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration out of range (lower); duration expected in range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration out of range (lower); duration expected out of range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = pointer.FromInt(604800001)
 					},
@@ -200,78 +239,78 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration in range (lower); duration expected missing",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(0)
 						datum.DurationExpected = nil
 					},
 				),
 				Entry("duration in range (lower); duration expected out of range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(0)
 						datum.DurationExpected = pointer.FromInt(-1)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration in range (lower); duration expected in range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(0)
 						datum.DurationExpected = pointer.FromInt(0)
 					},
 				),
 				Entry("duration in range (lower); duration expected in range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(0)
 						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 				),
 				Entry("duration in range (lower); duration expected out of range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(0)
 						datum.DurationExpected = pointer.FromInt(604800001)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration in range (upper); duration expected missing",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800000)
 						datum.DurationExpected = nil
 					},
 				),
 				Entry("duration in range (upper); duration expected out of range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800000)
 						datum.DurationExpected = pointer.FromInt(604799999)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604799999, 604800000, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration in range (upper); duration expected in range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800000)
 						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 				),
 				Entry("duration in range (upper); duration expected in range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800000)
 						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 				),
 				Entry("duration in range (upper); duration expected out of range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800000)
 						datum.DurationExpected = pointer.FromInt(604800001)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 604800000, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration out of range (upper); duration expected missing",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800001)
 						datum.DurationExpected = nil
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration out of range (upper); duration expected out of range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800001)
 						datum.DurationExpected = pointer.FromInt(-1)
 					},
@@ -279,21 +318,21 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration out of range (upper); duration expected in range (lower)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800001)
 						datum.DurationExpected = pointer.FromInt(0)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration out of range (upper); duration expected in range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800001)
 						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration out of range (upper); duration expected out of range (upper)",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Duration = pointer.FromInt(604800001)
 						datum.DurationExpected = pointer.FromInt(604800001)
 					},
@@ -301,10 +340,10 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("insulin formulation missing",
-					func(datum *automated.Automated) { datum.InsulinFormulation = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.InsulinFormulation = nil },
 				),
 				Entry("insulin formulation invalid",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.InsulinFormulation.Compounds = nil
 						datum.InsulinFormulation.Name = nil
 						datum.InsulinFormulation.Simple = nil
@@ -312,37 +351,64 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple", NewMeta()),
 				),
 				Entry("insulin formulation valid",
-					func(datum *automated.Automated) { datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3) },
+					func(datum *dataTypesBasalAutomated.Automated) {
+						datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+					},
 				),
 				Entry("rate missing",
-					func(datum *automated.Automated) { datum.Rate = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Rate = nil },
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/rate", NewMeta()),
 				),
 				Entry("rate out of range (lower)",
-					func(datum *automated.Automated) { datum.Rate = pointer.FromFloat64(-0.1) },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Rate = pointer.FromFloat64(-0.1) },
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate", NewMeta()),
 				),
 				Entry("rate in range (lower)",
-					func(datum *automated.Automated) { datum.Rate = pointer.FromFloat64(0.0) },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Rate = pointer.FromFloat64(0.0) },
 				),
 				Entry("rate in range (upper)",
-					func(datum *automated.Automated) { datum.Rate = pointer.FromFloat64(100.0) },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Rate = pointer.FromFloat64(100.0) },
 				),
 				Entry("rate out of range (upper)",
-					func(datum *automated.Automated) { datum.Rate = pointer.FromFloat64(100.1) },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Rate = pointer.FromFloat64(100.1) },
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", NewMeta()),
 				),
 				Entry("schedule name empty",
-					func(datum *automated.Automated) { datum.ScheduleName = pointer.FromString("") },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.ScheduleName = pointer.FromString("") },
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/scheduleName", NewMeta()),
 				),
+				Entry("schedule name length; in range (upper)",
+					func(datum *dataTypesBasalAutomated.Automated) {
+						datum.ScheduleName = pointer.FromString(test.RandomStringFromRange(1000, 1000))
+					},
+				),
+				Entry("schedule name length; out of range (upper)",
+					func(datum *dataTypesBasalAutomated.Automated) {
+						datum.ScheduleName = pointer.FromString(test.RandomStringFromRange(1001, 1001))
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorLengthNotLessThanOrEqualTo(1001, 1000), "/scheduleName", NewMeta()),
+				),
 				Entry("schedule name valid",
-					func(datum *automated.Automated) {
-						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+					func(datum *dataTypesBasalAutomated.Automated) {
+						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
+					},
+				),
+				Entry("suppressed missing",
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Suppressed = nil },
+				),
+				Entry("suppressed invalid",
+					func(datum *dataTypesBasalAutomated.Automated) {
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotValid(), "/suppressed", NewMeta()),
+				),
+				Entry("suppressed valid",
+					func(datum *dataTypesBasalAutomated.Automated) {
+						datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 					},
 				),
 				Entry("multiple errors",
-					func(datum *automated.Automated) {
+					func(datum *dataTypesBasalAutomated.Automated) {
 						datum.Type = "invalidType"
 						datum.DeliveryType = "invalidDeliveryType"
 						datum.Duration = nil
@@ -352,25 +418,26 @@ var _ = Describe("Automated", func() {
 						datum.InsulinFormulation.Simple = nil
 						datum.Rate = pointer.FromFloat64(100.1)
 						datum.ScheduleName = pointer.FromString("")
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/scheduleName", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-				),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/scheduleName", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotValid(), "/suppressed", &dataTypesBasal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"})),
 			)
 		})
 
 		Context("Normalize", func() {
 			DescribeTable("normalizes the datum",
-				func(mutator func(datum *automated.Automated)) {
+				func(mutator func(datum *dataTypesBasalAutomated.Automated)) {
 					for _, origin := range structure.Origins() {
-						datum := NewAutomated()
+						datum := dataTypesBasalAutomatedTest.RandomAutomated()
 						mutator(datum)
-						expectedDatum := CloneAutomated(datum)
+						expectedDatum := dataTypesBasalAutomatedTest.CloneAutomated(datum)
 						normalizer := dataNormalizer.New()
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
@@ -380,98 +447,140 @@ var _ = Describe("Automated", func() {
 					}
 				},
 				Entry("does not modify the datum",
-					func(datum *automated.Automated) {},
+					func(datum *dataTypesBasalAutomated.Automated) {},
 				),
 				Entry("does not modify the datum; type missing",
-					func(datum *automated.Automated) { datum.Type = "" },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Type = "" },
 				),
 				Entry("does not modify the datum; delivery type missing",
-					func(datum *automated.Automated) { datum.DeliveryType = "" },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.DeliveryType = "" },
 				),
 				Entry("does not modify the datum; duration missing",
-					func(datum *automated.Automated) { datum.Duration = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Duration = nil },
 				),
 				Entry("does not modify the datum; duration expected missing",
-					func(datum *automated.Automated) { datum.DurationExpected = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.DurationExpected = nil },
 				),
 				Entry("does not modify the datum; insulin formulation missing",
-					func(datum *automated.Automated) { datum.InsulinFormulation = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.InsulinFormulation = nil },
 				),
 				Entry("does not modify the datum; rate missing",
-					func(datum *automated.Automated) { datum.Rate = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Rate = nil },
 				),
 				Entry("does not modify the datum; schedule name missing",
-					func(datum *automated.Automated) { datum.ScheduleName = nil },
+					func(datum *dataTypesBasalAutomated.Automated) { datum.ScheduleName = nil },
+				),
+				Entry("does not modify the datum; suppressed missing",
+					func(datum *dataTypesBasalAutomated.Automated) { datum.Suppressed = nil },
 				),
 			)
 		})
 	})
 
 	Context("ParseSuppressedAutomated", func() {
-		// TODO
-	})
+		DescribeTable("serializes the datum as expected",
+			func(mutator func(datum *dataTypesBasalAutomated.SuppressedAutomated)) {
+				datum := dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
+				mutator(datum)
+				test.ExpectSerializedObjectJSON(datum, dataTypesBasalAutomatedTest.NewObjectFromSuppressedAutomated(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataTypesBasalAutomatedTest.NewObjectFromSuppressedAutomated(datum, test.ObjectFormatBSON))
+			},
+			Entry("succeeds",
+				func(datum *dataTypesBasalAutomated.SuppressedAutomated) {},
+			),
+			Entry("empty",
+				func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+					*datum = *dataTypesBasalAutomated.NewSuppressedAutomated()
+				},
+			),
+			Entry("all",
+				func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+					datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+					datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalAutomated.RateMinimum, dataTypesBasalAutomated.RateMaximum))
+					datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
+					datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
+				},
+			),
+		)
 
-	Context("NewSuppressedAutomated", func() {
-		It("returns the expected datum", func() {
-			Expect(automated.NewSuppressedAutomated()).To(Equal(&automated.SuppressedAutomated{
-				Type:         pointer.FromString("basal"),
-				DeliveryType: pointer.FromString("automated"),
-			}))
+		Context("ParseSuppressedAutomated", func() {
+			It("returns nil when the object is missing", func() {
+				Expect(dataTypesBasalAutomated.ParseSuppressedAutomated(structureParser.NewObject(nil))).To(BeNil())
+			})
+
+			It("returns new datum when the object is valid", func() {
+				datum := dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
+				object := dataTypesBasalAutomatedTest.NewObjectFromSuppressedAutomated(datum, test.ObjectFormatJSON)
+				parser := structureParser.NewObject(&object)
+				Expect(dataTypesBasalAutomated.ParseSuppressedAutomated(parser)).To(Equal(datum))
+				Expect(parser.Error()).ToNot(HaveOccurred())
+			})
 		})
-	})
 
-	Context("SuppressedAutomated", func() {
-		Context("Parse", func() {
-			// TODO
+		Context("NewSuppressedAutomated", func() {
+			It("returns the expected datum with all values initialized", func() {
+				datum := dataTypesBasalAutomated.NewSuppressedAutomated()
+				Expect(datum).ToNot(BeNil())
+				Expect(datum.Type).To(Equal(pointer.FromString("basal")))
+				Expect(datum.DeliveryType).To(Equal(pointer.FromString("automated")))
+				Expect(datum.InsulinFormulation).To(BeNil())
+				Expect(datum.Rate).To(BeNil())
+				Expect(datum.ScheduleName).To(BeNil())
+				Expect(datum.Suppressed).To(BeNil())
+			})
 		})
 
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
-				func(mutator func(datum *automated.SuppressedAutomated), expectedErrors ...error) {
-					datum := dataTypesBasalAutomatedTest.NewSuppressedAutomated()
+				func(mutator func(datum *dataTypesBasalAutomated.SuppressedAutomated), expectedErrors ...error) {
+					datum := dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
 				Entry("succeeds",
-					func(datum *automated.SuppressedAutomated) {},
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {},
 				),
 				Entry("type missing",
-					func(datum *automated.SuppressedAutomated) { datum.Type = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Type = nil },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/type"),
 				),
 				Entry("type invalid",
-					func(datum *automated.SuppressedAutomated) { datum.Type = pointer.FromString("invalidType") },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.Type = pointer.FromString("invalidType")
+					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type"),
 				),
 				Entry("type basal",
-					func(datum *automated.SuppressedAutomated) { datum.Type = pointer.FromString("basal") },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Type = pointer.FromString("basal") },
 				),
 				Entry("delivery type missing",
-					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.DeliveryType = nil },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/deliveryType"),
 				),
 				Entry("delivery type invalid",
-					func(datum *automated.SuppressedAutomated) {
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
 						datum.DeliveryType = pointer.FromString("invalidDeliveryType")
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType"),
 				),
 				Entry("delivery type automated",
-					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = pointer.FromString("automated") },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.DeliveryType = pointer.FromString("automated")
+					},
 				),
 				Entry("annotations missing",
-					func(datum *automated.SuppressedAutomated) { datum.Annotations = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Annotations = nil },
 				),
 				Entry("annotations valid",
-					func(datum *automated.SuppressedAutomated) {
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
 						datum.Annotations = metadataTest.RandomMetadataArray()
 					},
 				),
 				Entry("insulin formulation missing",
-					func(datum *automated.SuppressedAutomated) { datum.InsulinFormulation = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.InsulinFormulation = nil },
 				),
 				Entry("insulin formulation invalid",
-					func(datum *automated.SuppressedAutomated) {
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
 						datum.InsulinFormulation.Compounds = nil
 						datum.InsulinFormulation.Name = nil
 						datum.InsulinFormulation.Simple = nil
@@ -479,57 +588,88 @@ var _ = Describe("Automated", func() {
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple"),
 				),
 				Entry("insulin formulation valid",
-					func(datum *automated.SuppressedAutomated) {
-						datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
 					},
 				),
 				Entry("rate missing",
-					func(datum *automated.SuppressedAutomated) { datum.Rate = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Rate = nil },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/rate"),
 				),
 				Entry("rate out of range (lower)",
-					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(-0.1) },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(-0.1) },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/rate"),
 				),
 				Entry("rate in range (lower)",
-					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(0.0) },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(0.0) },
 				),
 				Entry("rate in range (upper)",
-					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(100.0) },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(100.0) },
 				),
 				Entry("rate out of range (upper)",
-					func(datum *automated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(100.1) },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Rate = pointer.FromFloat64(100.1) },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate"),
 				),
 				Entry("schedule name empty",
-					func(datum *automated.SuppressedAutomated) { datum.ScheduleName = pointer.FromString("") },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.ScheduleName = pointer.FromString("") },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/scheduleName"),
 				),
+				Entry("schedule name length; in range (upper)",
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.ScheduleName = pointer.FromString(test.RandomStringFromRange(1000, 1000))
+					},
+				),
+				Entry("schedule name length; out of range (upper)",
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.ScheduleName = pointer.FromString(test.RandomStringFromRange(1001, 1001))
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorLengthNotLessThanOrEqualTo(1001, 1000), "/scheduleName"),
+				),
 				Entry("schedule name valid",
-					func(datum *automated.SuppressedAutomated) {
-						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
+					},
+				),
+				Entry("suppressed missing",
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Suppressed = nil },
+				),
+				Entry("suppressed invalid",
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotValid(), "/suppressed"),
+				),
+				Entry("suppressed valid",
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
+						datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 					},
 				),
 				Entry("multiple errors",
-					func(datum *automated.SuppressedAutomated) {
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {
 						datum.Type = pointer.FromString("invalidType")
 						datum.DeliveryType = pointer.FromString("invalidDeliveryType")
+						datum.InsulinFormulation.Compounds = nil
+						datum.InsulinFormulation.Name = nil
+						datum.InsulinFormulation.Simple = nil
 						datum.Rate = pointer.FromFloat64(100.1)
 						datum.ScheduleName = pointer.FromString("")
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "automated"), "/deliveryType"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/scheduleName"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotValid(), "/suppressed"),
 				),
 			)
 		})
 
 		Context("Normalize", func() {
 			DescribeTable("normalizes the datum",
-				func(mutator func(datum *automated.SuppressedAutomated)) {
+				func(mutator func(datum *dataTypesBasalAutomated.SuppressedAutomated)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesBasalAutomatedTest.NewSuppressedAutomated()
+						datum := dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 						mutator(datum)
 						expectedDatum := dataTypesBasalAutomatedTest.CloneSuppressedAutomated(datum)
 						normalizer := dataNormalizer.New()
@@ -541,25 +681,28 @@ var _ = Describe("Automated", func() {
 					}
 				},
 				Entry("does not modify the datum",
-					func(datum *automated.SuppressedAutomated) {},
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) {},
 				),
 				Entry("does not modify the datum; type missing",
-					func(datum *automated.SuppressedAutomated) { datum.Type = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Type = nil },
 				),
 				Entry("does not modify the datum; delivery type missing",
-					func(datum *automated.SuppressedAutomated) { datum.DeliveryType = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.DeliveryType = nil },
 				),
 				Entry("does not modify the datum; annotations missing",
-					func(datum *automated.SuppressedAutomated) { datum.Annotations = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Annotations = nil },
 				),
 				Entry("does not modify the datum; insulin formulation missing",
-					func(datum *automated.SuppressedAutomated) { datum.InsulinFormulation = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.InsulinFormulation = nil },
 				),
 				Entry("does not modify the datum; rate missing",
-					func(datum *automated.SuppressedAutomated) { datum.Rate = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Rate = nil },
 				),
 				Entry("does not modify the datum; schedule name missing",
-					func(datum *automated.SuppressedAutomated) { datum.ScheduleName = nil },
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.ScheduleName = nil },
+				),
+				Entry("does not modify the datum; suppressed missing",
+					func(datum *dataTypesBasalAutomated.SuppressedAutomated) { datum.Suppressed = nil },
 				),
 			)
 		})

--- a/data/types/basal/automated/test/automated.go
+++ b/data/types/basal/automated/test/automated.go
@@ -1,7 +1,9 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/basal/automated"
+	dataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated"
+	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
+	dataTypesBasalScheduledTest "github.com/tidepool-org/platform/data/types/basal/scheduled/test"
 	dataTypesBasalTest "github.com/tidepool-org/platform/data/types/basal/test"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
@@ -9,25 +11,138 @@ import (
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewSuppressedAutomated() *automated.SuppressedAutomated {
-	datum := automated.NewSuppressedAutomated()
-	datum.Annotations = metadataTest.RandomMetadataArray()
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
-	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(automated.RateMinimum, automated.RateMaximum))
-	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+func RandomAutomated() *dataTypesBasalAutomated.Automated {
+	datum := randomAutomated()
+	datum.Basal = *dataTypesBasalTest.RandomBasal()
+	datum.DeliveryType = "automated"
 	return datum
 }
 
-func CloneSuppressedAutomated(datum *automated.SuppressedAutomated) *automated.SuppressedAutomated {
+func RandomAutomatedForParser() *dataTypesBasalAutomated.Automated {
+	datum := randomAutomated()
+	datum.Basal = *dataTypesBasalTest.RandomBasalForParser()
+	datum.DeliveryType = "automated"
+	return datum
+}
+
+func randomAutomated() *dataTypesBasalAutomated.Automated {
+	datum := dataTypesBasalAutomated.New()
+	datum.Duration = pointer.FromInt(test.RandomIntFromRange(dataTypesBasalAutomated.DurationMinimum, dataTypesBasalAutomated.DurationMaximum))
+	datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, dataTypesBasalAutomated.DurationMaximum))
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalAutomated.RateMinimum, dataTypesBasalAutomated.RateMaximum))
+	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
+	datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
+	return datum
+}
+
+func CloneAutomated(datum *dataTypesBasalAutomated.Automated) *dataTypesBasalAutomated.Automated {
 	if datum == nil {
 		return nil
 	}
-	clone := automated.NewSuppressedAutomated()
+	clone := dataTypesBasalAutomated.New()
+	clone.Basal = *dataTypesBasalTest.CloneBasal(&datum.Basal)
+	clone.Duration = pointer.CloneInt(datum.Duration)
+	clone.DurationExpected = pointer.CloneInt(datum.DurationExpected)
+	clone.InsulinFormulation = dataTypesInsulinTest.CloneFormulation(datum.InsulinFormulation)
+	clone.Rate = pointer.CloneFloat64(datum.Rate)
+	clone.ScheduleName = pointer.CloneString(datum.ScheduleName)
+	if datum.Suppressed != nil {
+		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalScheduled.SuppressedScheduled:
+			clone.Suppressed = dataTypesBasalScheduledTest.CloneSuppressedScheduled(suppressed)
+		}
+	}
+	return clone
+}
+
+func NewObjectFromAutomated(datum *dataTypesBasalAutomated.Automated, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := dataTypesBasalTest.NewObjectFromBasal(&datum.Basal, objectFormat)
+	if datum.Duration != nil {
+		object["duration"] = test.NewObjectFromInt(*datum.Duration, objectFormat)
+	}
+	if datum.DurationExpected != nil {
+		object["expectedDuration"] = test.NewObjectFromInt(*datum.DurationExpected, objectFormat)
+	}
+	if datum.InsulinFormulation != nil {
+		object["insulinFormulation"] = dataTypesInsulinTest.NewObjectFromFormulation(datum.InsulinFormulation, objectFormat)
+	}
+	if datum.Rate != nil {
+		object["rate"] = test.NewObjectFromFloat64(*datum.Rate, objectFormat)
+	}
+	if datum.ScheduleName != nil {
+		object["scheduleName"] = test.NewObjectFromString(*datum.ScheduleName, objectFormat)
+	}
+	if datum.Suppressed != nil {
+		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalScheduled.SuppressedScheduled:
+			object["suppressed"] = dataTypesBasalScheduledTest.NewObjectFromSuppressedScheduled(suppressed, objectFormat)
+		}
+	}
+	return object
+}
+
+func RandomSuppressedAutomated() *dataTypesBasalAutomated.SuppressedAutomated {
+	datum := dataTypesBasalAutomated.NewSuppressedAutomated()
+	datum.Annotations = metadataTest.RandomMetadataArray()
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalAutomated.RateMinimum, dataTypesBasalAutomated.RateMaximum))
+	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
+	datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
+	return datum
+}
+
+func CloneSuppressedAutomated(datum *dataTypesBasalAutomated.SuppressedAutomated) *dataTypesBasalAutomated.SuppressedAutomated {
+	if datum == nil {
+		return nil
+	}
+	clone := dataTypesBasalAutomated.NewSuppressedAutomated()
 	clone.Type = datum.Type
 	clone.DeliveryType = datum.DeliveryType
 	clone.Annotations = metadataTest.CloneMetadataArray(datum.Annotations)
 	clone.InsulinFormulation = dataTypesInsulinTest.CloneFormulation(datum.InsulinFormulation)
 	clone.Rate = pointer.CloneFloat64(datum.Rate)
 	clone.ScheduleName = pointer.CloneString(datum.ScheduleName)
+	if datum.Suppressed != nil {
+		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalScheduled.SuppressedScheduled:
+			clone.Suppressed = dataTypesBasalScheduledTest.CloneSuppressedScheduled(suppressed)
+		}
+	}
 	return clone
+}
+
+func NewObjectFromSuppressedAutomated(datum *dataTypesBasalAutomated.SuppressedAutomated, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Type != nil {
+		object["type"] = test.NewObjectFromString(*datum.Type, objectFormat)
+	}
+	if datum.DeliveryType != nil {
+		object["deliveryType"] = test.NewObjectFromString(*datum.DeliveryType, objectFormat)
+	}
+	if datum.Annotations != nil {
+		object["annotations"] = metadataTest.NewArrayFromMetadataArray(datum.Annotations, objectFormat)
+	}
+	if datum.InsulinFormulation != nil {
+		object["insulinFormulation"] = dataTypesInsulinTest.NewObjectFromFormulation(datum.InsulinFormulation, objectFormat)
+	}
+	if datum.Rate != nil {
+		object["rate"] = test.NewObjectFromFloat64(*datum.Rate, objectFormat)
+	}
+	if datum.ScheduleName != nil {
+		object["scheduleName"] = test.NewObjectFromString(*datum.ScheduleName, objectFormat)
+	}
+	if datum.Suppressed != nil {
+		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalScheduled.SuppressedScheduled:
+			object["suppressed"] = dataTypesBasalScheduledTest.NewObjectFromSuppressedScheduled(suppressed, objectFormat)
+		}
+	}
+	return object
 }

--- a/data/types/basal/basal.go
+++ b/data/types/basal/basal.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	Type = "basal"
+
+	ScheduleNameLengthMaximum = 1000
 )
 
 type Basal struct {

--- a/data/types/basal/basal_test.go
+++ b/data/types/basal/basal_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Basal", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *basal.Basal), expectedErrors ...error) {
-					datum := dataTypesBasalTest.NewBasal()
+					datum := dataTypesBasalTest.RandomBasal()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -92,7 +92,7 @@ var _ = Describe("Basal", func() {
 			var datum *basal.Basal
 
 			BeforeEach(func() {
-				datum = dataTypesBasalTest.NewBasal()
+				datum = dataTypesBasalTest.RandomBasal()
 			})
 
 			It("returns error if user id is missing", func() {

--- a/data/types/basal/scheduled/scheduled_test.go
+++ b/data/types/basal/scheduled/scheduled_test.go
@@ -29,13 +29,13 @@ func NewMeta() interface{} {
 
 func NewScheduled() *scheduled.Scheduled {
 	datum := scheduled.New()
-	datum.Basal = *dataTypesBasalTest.NewBasal()
+	datum.Basal = *dataTypesBasalTest.RandomBasal()
 	datum.DeliveryType = "scheduled"
 	datum.Duration = pointer.FromInt(test.RandomIntFromRange(scheduled.DurationMinimum, scheduled.DurationMaximum))
 	datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, scheduled.DurationMaximum))
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
 	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(scheduled.RateMinimum, scheduled.RateMaximum))
-	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
 	return datum
 }
 
@@ -312,7 +312,7 @@ var _ = Describe("Scheduled", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple", NewMeta()),
 				),
 				Entry("insulin formulation valid",
-					func(datum *scheduled.Scheduled) { datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3) },
+					func(datum *scheduled.Scheduled) { datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3) },
 				),
 				Entry("rate missing",
 					func(datum *scheduled.Scheduled) { datum.Rate = nil },
@@ -338,7 +338,7 @@ var _ = Describe("Scheduled", func() {
 				),
 				Entry("schedule name valid",
 					func(datum *scheduled.Scheduled) {
-						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
 					},
 				),
 				Entry("multiple errors",
@@ -428,7 +428,7 @@ var _ = Describe("Scheduled", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *scheduled.SuppressedScheduled), expectedErrors ...error) {
-					datum := dataTypesBasalScheduledTest.NewSuppressedScheduled()
+					datum := dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -480,7 +480,7 @@ var _ = Describe("Scheduled", func() {
 				),
 				Entry("insulin formulation valid",
 					func(datum *scheduled.SuppressedScheduled) {
-						datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+						datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
 					},
 				),
 				Entry("rate missing",
@@ -507,7 +507,7 @@ var _ = Describe("Scheduled", func() {
 				),
 				Entry("schedule name valid",
 					func(datum *scheduled.SuppressedScheduled) {
-						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+						datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
 					},
 				),
 				Entry("multiple errors",
@@ -533,7 +533,7 @@ var _ = Describe("Scheduled", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *scheduled.SuppressedScheduled)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesBasalScheduledTest.NewSuppressedScheduled()
+						datum := dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 						mutator(datum)
 						expectedDatum := dataTypesBasalScheduledTest.CloneSuppressedScheduled(datum)
 						normalizer := dataNormalizer.New()

--- a/data/types/basal/scheduled/test/scheduled.go
+++ b/data/types/basal/scheduled/test/scheduled.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/basal/scheduled"
+	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
 	dataTypesBasalTest "github.com/tidepool-org/platform/data/types/basal/test"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
@@ -9,20 +9,20 @@ import (
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewSuppressedScheduled() *scheduled.SuppressedScheduled {
-	datum := scheduled.NewSuppressedScheduled()
+func RandomSuppressedScheduled() *dataTypesBasalScheduled.SuppressedScheduled {
+	datum := dataTypesBasalScheduled.NewSuppressedScheduled()
 	datum.Annotations = metadataTest.RandomMetadataArray()
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
-	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(scheduled.RateMinimum, scheduled.RateMaximum))
-	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalScheduled.RateMinimum, dataTypesBasalScheduled.RateMaximum))
+	datum.ScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
 	return datum
 }
 
-func CloneSuppressedScheduled(datum *scheduled.SuppressedScheduled) *scheduled.SuppressedScheduled {
+func CloneSuppressedScheduled(datum *dataTypesBasalScheduled.SuppressedScheduled) *dataTypesBasalScheduled.SuppressedScheduled {
 	if datum == nil {
 		return nil
 	}
-	clone := scheduled.NewSuppressedScheduled()
+	clone := dataTypesBasalScheduled.NewSuppressedScheduled()
 	clone.Type = datum.Type
 	clone.DeliveryType = datum.DeliveryType
 	clone.Annotations = metadataTest.CloneMetadataArray(datum.Annotations)
@@ -30,4 +30,30 @@ func CloneSuppressedScheduled(datum *scheduled.SuppressedScheduled) *scheduled.S
 	clone.Rate = pointer.CloneFloat64(datum.Rate)
 	clone.ScheduleName = pointer.CloneString(datum.ScheduleName)
 	return clone
+}
+
+func NewObjectFromSuppressedScheduled(datum *dataTypesBasalScheduled.SuppressedScheduled, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Type != nil {
+		object["type"] = test.NewObjectFromString(*datum.Type, objectFormat)
+	}
+	if datum.DeliveryType != nil {
+		object["deliveryType"] = test.NewObjectFromString(*datum.DeliveryType, objectFormat)
+	}
+	if datum.Annotations != nil {
+		object["annotations"] = metadataTest.NewArrayFromMetadataArray(datum.Annotations, objectFormat)
+	}
+	if datum.InsulinFormulation != nil {
+		object["insulinFormulation"] = dataTypesInsulinTest.NewObjectFromFormulation(datum.InsulinFormulation, objectFormat)
+	}
+	if datum.Rate != nil {
+		object["rate"] = test.NewObjectFromFloat64(*datum.Rate, objectFormat)
+	}
+	if datum.ScheduleName != nil {
+		object["scheduleName"] = test.NewObjectFromString(*datum.ScheduleName, objectFormat)
+	}
+	return object
 }

--- a/data/types/basal/suspend/suspend.go
+++ b/data/types/basal/suspend/suspend.go
@@ -98,7 +98,7 @@ func parseSuppressed(parser structure.ObjectParser) Suppressed {
 		case dataTypesBasalTemporary.DeliveryType:
 			return dataTypesBasalTemporary.ParseSuppressedTemporary(parser)
 		default:
-			parser.WithReferenceErrorReporter("type").ReportError(structureValidator.ErrorValueStringNotOneOf(*deliveryType, suppressedDeliveryTypes))
+			parser.WithReferenceErrorReporter("deliveryType").ReportError(structureValidator.ErrorValueStringNotOneOf(*deliveryType, suppressedDeliveryTypes))
 		}
 	}
 	return nil
@@ -114,7 +114,7 @@ func validateSuppressed(validator structure.Validator, suppressed Suppressed) {
 		case *dataTypesBasalTemporary.SuppressedTemporary:
 			suppressed.Validate(validator)
 		default:
-			validator.ReportError(structureValidator.ErrorValueExists()) // TODO: Better error?
+			validator.ReportError(structureValidator.ErrorValueNotValid())
 		}
 	}
 }

--- a/data/types/basal/suspend/suspend_test.go
+++ b/data/types/basal/suspend/suspend_test.go
@@ -32,11 +32,11 @@ func NewMeta() interface{} {
 
 func NewSuspend() *suspend.Suspend {
 	datum := suspend.New()
-	datum.Basal = *dataTypesBasalTest.NewBasal()
+	datum.Basal = *dataTypesBasalTest.RandomBasal()
 	datum.DeliveryType = "suspend"
 	datum.Duration = pointer.FromInt(test.RandomIntFromRange(suspend.DurationMinimum, suspend.DurationMaximum))
 	datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, suspend.DurationMaximum))
-	datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalScheduledTest.NewSuppressedScheduled())
+	datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalScheduledTest.RandomSuppressedScheduled())
 	return datum
 }
 
@@ -303,35 +303,34 @@ var _ = Describe("Suspend", func() {
 				),
 				Entry("suppressed automated",
 					func(datum *suspend.Suspend) {
-						datum.Suppressed = dataTypesBasalAutomatedTest.NewSuppressedAutomated()
+						datum.Suppressed = dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 					},
 				),
 				Entry("suppressed scheduled",
 					func(datum *suspend.Suspend) {
-						datum.Suppressed = dataTypesBasalScheduledTest.NewSuppressedScheduled()
+						datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 					},
 				),
 				Entry("suppressed temporary with suppressed missing",
 					func(datum *suspend.Suspend) {
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil)
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
 				),
 				Entry("suppressed temporary with suppressed automated",
 					func(datum *suspend.Suspend) {
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalAutomatedTest.NewSuppressedAutomated())
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalAutomatedTest.RandomSuppressedAutomated())
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
 				),
 				Entry("suppressed temporary with suppressed scheduled",
 					func(datum *suspend.Suspend) {
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalScheduledTest.NewSuppressedScheduled())
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalScheduledTest.RandomSuppressedScheduled())
 					},
 				),
 				Entry("suppressed temporary with suppressed temporary with suppressed missing",
 					func(datum *suspend.Suspend) {
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil))
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil))
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed/suppressed", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotValid(), "/suppressed/suppressed", NewMeta()),
 				),
 				Entry("multiple errors",
 					func(datum *suspend.Suspend) {
@@ -339,13 +338,13 @@ var _ = Describe("Suspend", func() {
 						datum.DeliveryType = "invalidDeliveryType"
 						datum.Duration = nil
 						datum.DurationExpected = pointer.FromInt(604800001)
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil))
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil))
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "suspend"), "/deliveryType", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/duration", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed/suppressed", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotValid(), "/suppressed/suppressed", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 				),
 			)
 		})

--- a/data/types/basal/temporary/temporary_test.go
+++ b/data/types/basal/temporary/temporary_test.go
@@ -31,14 +31,14 @@ func NewMeta() interface{} {
 
 func NewTemporary() *temporary.Temporary {
 	datum := temporary.New()
-	datum.Basal = *dataTypesBasalTest.NewBasal()
+	datum.Basal = *dataTypesBasalTest.RandomBasal()
 	datum.DeliveryType = "temp"
 	datum.Duration = pointer.FromInt(test.RandomIntFromRange(temporary.DurationMinimum, temporary.DurationMaximum))
 	datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, temporary.DurationMaximum))
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
 	datum.Percent = pointer.FromFloat64(test.RandomFloat64FromRange(temporary.PercentMinimum, temporary.PercentMaximum))
 	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(temporary.RateMinimum, temporary.RateMaximum))
-	datum.Suppressed = dataTypesBasalScheduledTest.NewSuppressedScheduled()
+	datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 	return datum
 }
 
@@ -330,7 +330,7 @@ var _ = Describe("Temporary", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple", NewMeta()),
 				),
 				Entry("insulin formulation valid",
-					func(datum *temporary.Temporary) { datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3) },
+					func(datum *temporary.Temporary) { datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3) },
 				),
 				Entry("percent missing",
 					func(datum *temporary.Temporary) { datum.Percent = nil },
@@ -372,20 +372,19 @@ var _ = Describe("Temporary", func() {
 				),
 				Entry("suppressed automated",
 					func(datum *temporary.Temporary) {
-						datum.Suppressed = dataTypesBasalAutomatedTest.NewSuppressedAutomated()
+						datum.Suppressed = dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed", NewMeta()),
 				),
 				Entry("suppressed scheduled",
 					func(datum *temporary.Temporary) {
-						datum.Suppressed = dataTypesBasalScheduledTest.NewSuppressedScheduled()
+						datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 					},
 				),
 				Entry("suppressed temporary with suppressed missing",
 					func(datum *temporary.Temporary) {
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil)
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotValid(), "/suppressed", NewMeta()),
 				),
 				Entry("multiple errors",
 					func(datum *temporary.Temporary) {
@@ -398,7 +397,7 @@ var _ = Describe("Temporary", func() {
 						datum.InsulinFormulation.Simple = nil
 						datum.Percent = pointer.FromFloat64(10.1)
 						datum.Rate = pointer.FromFloat64(100.1)
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil)
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "temp"), "/deliveryType", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
@@ -407,7 +406,7 @@ var _ = Describe("Temporary", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(10.1, 0.0, 10.0), "/percent", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/suppressed", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotValid(), "/suppressed", &basal.Meta{Type: "invalidType", DeliveryType: "invalidDeliveryType"}),
 				),
 			)
 		})
@@ -479,7 +478,7 @@ var _ = Describe("Temporary", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *temporary.SuppressedTemporary), expectedErrors ...error) {
-					datum := dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalScheduledTest.NewSuppressedScheduled())
+					datum := dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalScheduledTest.RandomSuppressedScheduled())
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -523,7 +522,7 @@ var _ = Describe("Temporary", func() {
 				),
 				Entry("insulin formulation valid",
 					func(datum *temporary.SuppressedTemporary) {
-						datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+						datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
 					},
 				),
 				Entry("percent missing",
@@ -566,20 +565,19 @@ var _ = Describe("Temporary", func() {
 				),
 				Entry("suppressed automated",
 					func(datum *temporary.SuppressedTemporary) {
-						datum.Suppressed = dataTypesBasalAutomatedTest.NewSuppressedAutomated()
+						datum.Suppressed = dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/suppressed"),
 				),
 				Entry("suppressed scheduled",
 					func(datum *temporary.SuppressedTemporary) {
-						datum.Suppressed = dataTypesBasalScheduledTest.NewSuppressedScheduled()
+						datum.Suppressed = dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 					},
 				),
 				Entry("suppressed temporary with suppressed missing",
 					func(datum *temporary.SuppressedTemporary) {
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil)
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/suppressed"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotValid(), "/suppressed"),
 				),
 				Entry("multiple errors",
 					func(datum *temporary.SuppressedTemporary) {
@@ -590,14 +588,14 @@ var _ = Describe("Temporary", func() {
 						datum.InsulinFormulation.Simple = nil
 						datum.Percent = pointer.FromFloat64(10.1)
 						datum.Rate = pointer.FromFloat64(100.1)
-						datum.Suppressed = dataTypesBasalTemporaryTest.NewSuppressedTemporary(nil)
+						datum.Suppressed = dataTypesBasalTemporaryTest.RandomSuppressedTemporary(nil)
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidType", "basal"), "/type"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotEqualTo("invalidDeliveryType", "temp"), "/deliveryType"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(10.1, 0.0, 10.0), "/percent"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/rate"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/suppressed"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotValid(), "/suppressed"),
 				),
 			)
 		})
@@ -606,7 +604,7 @@ var _ = Describe("Temporary", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *temporary.SuppressedTemporary)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesBasalTemporaryTest.NewSuppressedTemporary(dataTypesBasalScheduledTest.NewSuppressedScheduled())
+						datum := dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalScheduledTest.RandomSuppressedScheduled())
 						mutator(datum)
 						expectedDatum := dataTypesBasalTemporaryTest.CloneSuppressedTemporary(datum)
 						normalizer := dataNormalizer.New()

--- a/data/types/basal/temporary/test/temporary.go
+++ b/data/types/basal/temporary/test/temporary.go
@@ -1,30 +1,32 @@
 package test
 
 import (
+	dataTypesBasalAutomated "github.com/tidepool-org/platform/data/types/basal/automated"
+	dataTypesBasalAutomatedTest "github.com/tidepool-org/platform/data/types/basal/automated/test"
 	dataTypesBasalScheduled "github.com/tidepool-org/platform/data/types/basal/scheduled"
 	dataTypesBasalScheduledTest "github.com/tidepool-org/platform/data/types/basal/scheduled/test"
-	"github.com/tidepool-org/platform/data/types/basal/temporary"
+	dataTypesBasalTemporary "github.com/tidepool-org/platform/data/types/basal/temporary"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewSuppressedTemporary(suppressed temporary.Suppressed) *temporary.SuppressedTemporary {
-	datum := temporary.NewSuppressedTemporary()
+func RandomSuppressedTemporary(suppressed dataTypesBasalTemporary.Suppressed) *dataTypesBasalTemporary.SuppressedTemporary {
+	datum := dataTypesBasalTemporary.NewSuppressedTemporary()
 	datum.Annotations = metadataTest.RandomMetadataArray()
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
-	datum.Percent = pointer.FromFloat64(test.RandomFloat64FromRange(temporary.PercentMinimum, temporary.PercentMaximum))
-	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(temporary.RateMinimum, temporary.RateMaximum))
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+	datum.Percent = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalTemporary.PercentMinimum, dataTypesBasalTemporary.PercentMaximum))
+	datum.Rate = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBasalTemporary.RateMinimum, dataTypesBasalTemporary.RateMaximum))
 	datum.Suppressed = suppressed
 	return datum
 }
 
-func CloneSuppressedTemporary(datum *temporary.SuppressedTemporary) *temporary.SuppressedTemporary {
+func CloneSuppressedTemporary(datum *dataTypesBasalTemporary.SuppressedTemporary) *dataTypesBasalTemporary.SuppressedTemporary {
 	if datum == nil {
 		return nil
 	}
-	clone := temporary.NewSuppressedTemporary()
+	clone := dataTypesBasalTemporary.NewSuppressedTemporary()
 	clone.Type = datum.Type
 	clone.DeliveryType = datum.DeliveryType
 	clone.Annotations = metadataTest.CloneMetadataArray(datum.Annotations)
@@ -33,9 +35,45 @@ func CloneSuppressedTemporary(datum *temporary.SuppressedTemporary) *temporary.S
 	clone.Rate = pointer.CloneFloat64(datum.Rate)
 	if datum.Suppressed != nil {
 		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalAutomated.SuppressedAutomated:
+			clone.Suppressed = dataTypesBasalAutomatedTest.CloneSuppressedAutomated(suppressed)
 		case *dataTypesBasalScheduled.SuppressedScheduled:
 			clone.Suppressed = dataTypesBasalScheduledTest.CloneSuppressedScheduled(suppressed)
 		}
 	}
 	return clone
+}
+
+func NewObjectFromSuppressedTemporary(datum *dataTypesBasalTemporary.SuppressedTemporary, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Type != nil {
+		object["type"] = test.NewObjectFromString(*datum.Type, objectFormat)
+	}
+	if datum.DeliveryType != nil {
+		object["deliveryType"] = test.NewObjectFromString(*datum.DeliveryType, objectFormat)
+	}
+	if datum.Annotations != nil {
+		object["annotations"] = metadataTest.NewArrayFromMetadataArray(datum.Annotations, objectFormat)
+	}
+	if datum.InsulinFormulation != nil {
+		object["insulinFormulation"] = dataTypesInsulinTest.NewObjectFromFormulation(datum.InsulinFormulation, objectFormat)
+	}
+	if datum.Percent != nil {
+		object["percent"] = test.NewObjectFromFloat64(*datum.Percent, objectFormat)
+	}
+	if datum.Rate != nil {
+		object["rate"] = test.NewObjectFromFloat64(*datum.Rate, objectFormat)
+	}
+	if datum.Suppressed != nil {
+		switch suppressed := datum.Suppressed.(type) {
+		case *dataTypesBasalAutomated.SuppressedAutomated:
+			object["suppressed"] = dataTypesBasalAutomatedTest.NewObjectFromSuppressedAutomated(suppressed, objectFormat)
+		case *dataTypesBasalScheduled.SuppressedScheduled:
+			object["suppressed"] = dataTypesBasalScheduledTest.NewObjectFromSuppressedScheduled(suppressed, objectFormat)
+		}
+	}
+	return object
 }

--- a/data/types/basal/test/basal.go
+++ b/data/types/basal/test/basal.go
@@ -1,29 +1,50 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/basal"
+	dataTypesBasal "github.com/tidepool-org/platform/data/types/basal"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewBasal() *basal.Basal {
-	datum := &basal.Basal{}
+func RandomBasal() *dataTypesBasal.Basal {
+	datum := randomBasal()
 	datum.Base = *dataTypesTest.RandomBase()
 	datum.Type = "basal"
+	return datum
+}
+
+func RandomBasalForParser() *dataTypesBasal.Basal {
+	datum := randomBasal()
+	datum.Base = *dataTypesTest.RandomBaseForParser()
+	datum.Type = "basal"
+	return datum
+}
+
+func randomBasal() *dataTypesBasal.Basal {
+	datum := &dataTypesBasal.Basal{}
 	datum.DeliveryType = dataTypesTest.NewType()
 	return datum
 }
 
-func CloneBasal(datum *basal.Basal) *basal.Basal {
+func CloneBasal(datum *dataTypesBasal.Basal) *dataTypesBasal.Basal {
 	if datum == nil {
 		return nil
 	}
-	clone := &basal.Basal{}
+	clone := &dataTypesBasal.Basal{}
 	clone.Base = *dataTypesTest.CloneBase(&datum.Base)
 	clone.DeliveryType = datum.DeliveryType
 	return clone
 }
 
-func NewScheduleName() string {
-	return test.RandomStringFromRange(1, 32)
+func NewObjectFromBasal(datum *dataTypesBasal.Basal, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := dataTypesTest.NewObjectFromBase(&datum.Base, objectFormat)
+	object["deliveryType"] = test.NewObjectFromString(datum.DeliveryType, objectFormat)
+	return object
+}
+
+func RandomScheduleName() string {
+	return test.RandomStringFromRange(1, dataTypesBasal.ScheduleNameLengthMaximum)
 }

--- a/data/types/bolus/automated/automated.go
+++ b/data/types/bolus/automated/automated.go
@@ -1,0 +1,69 @@
+package automated
+
+import (
+	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/types/bolus"
+	"github.com/tidepool-org/platform/structure"
+)
+
+const (
+	SubType = "automated" // TODO: Rename Type to "bolus/automated"; remove SubType
+
+	NormalMaximum = 100.0
+	NormalMinimum = 0.0
+)
+
+type Automated struct {
+	bolus.Bolus `bson:",inline"`
+
+	Normal         *float64 `json:"normal,omitempty" bson:"normal,omitempty"`
+	NormalExpected *float64 `json:"expectedNormal,omitempty" bson:"expectedNormal,omitempty"`
+}
+
+func New() *Automated {
+	return &Automated{
+		Bolus: bolus.New(SubType),
+	}
+}
+
+func (a *Automated) Parse(parser structure.ObjectParser) {
+	if !parser.HasMeta() {
+		parser = parser.WithMeta(a.Meta())
+	}
+
+	a.Bolus.Parse(parser)
+
+	a.Normal = parser.Float64("normal")
+	a.NormalExpected = parser.Float64("expectedNormal")
+}
+
+func (a *Automated) Validate(validator structure.Validator) {
+	if !validator.HasMeta() {
+		validator = validator.WithMeta(a.Meta())
+	}
+
+	a.Bolus.Validate(validator)
+
+	if a.SubType != "" {
+		validator.String("subType", &a.SubType).EqualTo(SubType)
+	}
+
+	validator.Float64("normal", a.Normal).Exists().InRange(NormalMinimum, NormalMaximum)
+	normalExpectedValidator := validator.Float64("expectedNormal", a.NormalExpected)
+	if a.Normal != nil && *a.Normal >= NormalMinimum && *a.Normal <= NormalMaximum {
+		if *a.Normal == NormalMinimum {
+			normalExpectedValidator.Exists()
+		}
+		normalExpectedValidator.InRange(*a.Normal, NormalMaximum)
+	} else {
+		normalExpectedValidator.InRange(NormalMinimum, NormalMaximum)
+	}
+}
+
+func (a *Automated) Normalize(normalizer data.Normalizer) {
+	if !normalizer.HasMeta() {
+		normalizer = normalizer.WithMeta(a.Meta())
+	}
+
+	a.Bolus.Normalize(normalizer)
+}

--- a/data/types/bolus/automated/automated_suite_test.go
+++ b/data/types/bolus/automated/automated_suite_test.go
@@ -1,0 +1,11 @@
+package automated_test
+
+import (
+	"testing"
+
+	"github.com/tidepool-org/platform/test"
+)
+
+func TestSuite(t *testing.T) {
+	test.Test(t)
+}

--- a/data/types/bolus/automated/automated_test.go
+++ b/data/types/bolus/automated/automated_test.go
@@ -1,0 +1,358 @@
+package automated_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
+	dataTypesBolus "github.com/tidepool-org/platform/data/types/bolus"
+	dataTypesBolusAutomated "github.com/tidepool-org/platform/data/types/bolus/automated"
+	dataTypesBolusAutomatedTest "github.com/tidepool-org/platform/data/types/bolus/automated/test"
+	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/structure"
+	structureParser "github.com/tidepool-org/platform/structure/parser"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/test"
+)
+
+func NewMeta() interface{} {
+	return &dataTypesBolus.Meta{
+		Type:    "bolus",
+		SubType: "automated",
+	}
+}
+
+var _ = Describe("Automated", func() {
+	It("SubType is expected", func() {
+		Expect(dataTypesBolusAutomated.SubType).To(Equal("automated"))
+	})
+
+	It("NormalMaximum is expected", func() {
+		Expect(dataTypesBolusAutomated.NormalMaximum).To(Equal(100.0))
+	})
+
+	It("NormalMinimum is expected", func() {
+		Expect(dataTypesBolusAutomated.NormalMinimum).To(Equal(0.0))
+	})
+
+	Context("Automated", func() {
+		DescribeTable("serializes the datum as expected",
+			func(mutator func(datum *dataTypesBolusAutomated.Automated)) {
+				datum := dataTypesBolusAutomatedTest.RandomAutomated()
+				mutator(datum)
+				test.ExpectSerializedObjectJSON(datum, dataTypesBolusAutomatedTest.NewObjectFromAutomated(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataTypesBolusAutomatedTest.NewObjectFromAutomated(datum, test.ObjectFormatBSON))
+			},
+			Entry("succeeds",
+				func(datum *dataTypesBolusAutomated.Automated) {},
+			),
+			Entry("empty",
+				func(datum *dataTypesBolusAutomated.Automated) {
+					*datum = *dataTypesBolusAutomated.New()
+				},
+			),
+			Entry("all",
+				func(datum *dataTypesBolusAutomated.Automated) {
+					datum.Normal = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBolusAutomated.NormalMinimum, dataTypesBolusAutomated.NormalMaximum))
+					datum.NormalExpected = pointer.FromFloat64(test.RandomFloat64FromRange(*datum.Normal, dataTypesBolusAutomated.NormalMaximum))
+				},
+			),
+		)
+
+		Context("New", func() {
+			It("returns the expected datum with all values initialized", func() {
+				datum := dataTypesBolusAutomated.New()
+				Expect(datum).ToNot(BeNil())
+				Expect(datum.Type).To(Equal("bolus"))
+				Expect(datum.SubType).To(Equal("automated"))
+				Expect(datum.Normal).To(BeNil())
+				Expect(datum.NormalExpected).To(BeNil())
+			})
+		})
+
+		Context("Parse", func() {
+			DescribeTable("parses the datum",
+				func(mutator func(object map[string]interface{}, expectedDatum *dataTypesBolusAutomated.Automated), expectedErrors ...error) {
+					expectedDatum := dataTypesBolusAutomatedTest.RandomAutomatedForParser()
+					object := dataTypesBolusAutomatedTest.NewObjectFromAutomated(expectedDatum, test.ObjectFormatJSON)
+					mutator(object, expectedDatum)
+					datum := dataTypesBolusAutomated.New()
+					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					Expect(datum).To(Equal(expectedDatum))
+				},
+				Entry("succeeds",
+					func(object map[string]interface{}, expectedDatum *dataTypesBolusAutomated.Automated) {},
+				),
+				Entry("multiple errors",
+					func(object map[string]interface{}, expectedDatum *dataTypesBolusAutomated.Automated) {
+						object["normal"] = true
+						object["expectedNormal"] = true
+						expectedDatum.Normal = nil
+						expectedDatum.NormalExpected = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotFloat64(true), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureParser.ErrorTypeNotFloat64(true), "/expectedNormal", NewMeta()),
+				),
+			)
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *dataTypesBolusAutomated.Automated), expectedErrors ...error) {
+					datum := dataTypesBolusAutomatedTest.RandomAutomated()
+					mutator(datum)
+					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *dataTypesBolusAutomated.Automated) {},
+				),
+				Entry("type missing",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.Type = "" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &dataTypesBolus.Meta{SubType: "automated"}),
+				),
+				Entry("type invalid",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.Type = "invalidType" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "bolus"), "/type", &dataTypesBolus.Meta{Type: "invalidType", SubType: "automated"}),
+				),
+				Entry("type bolus",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.Type = "bolus" },
+				),
+				Entry("sub type missing",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.SubType = "" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/subType", &dataTypesBolus.Meta{Type: "bolus"}),
+				),
+				Entry("sub type invalid",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.SubType = "invalidSubType" },
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidSubType", "automated"), "/subType", &dataTypesBolus.Meta{Type: "bolus", SubType: "invalidSubType"}),
+				),
+				Entry("sub type automated",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.SubType = "automated" },
+				),
+				Entry("normal missing; normal expected missing",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = nil
+						datum.NormalExpected = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/normal", NewMeta()),
+				),
+				Entry("normal missing; normal expected out of range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = nil
+						datum.NormalExpected = pointer.FromFloat64(-0.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal missing; normal expected in range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = nil
+						datum.NormalExpected = pointer.FromFloat64(0.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/normal", NewMeta()),
+				),
+				Entry("normal missing; normal expected in range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = nil
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/normal", NewMeta()),
+				),
+				Entry("normal missing; normal expected out of range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = nil
+						datum.NormalExpected = pointer.FromFloat64(100.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal out of range (lower); normal expected missing",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(-0.1)
+						datum.NormalExpected = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta()),
+				),
+				Entry("normal out of range (lower); normal expected out of range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(-0.1)
+						datum.NormalExpected = pointer.FromFloat64(-0.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal out of range (lower); normal expected in range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(-0.1)
+						datum.NormalExpected = pointer.FromFloat64(0.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta()),
+				),
+				Entry("normal out of range (lower); normal expected in range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(-0.1)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta()),
+				),
+				Entry("normal out of range (lower); normal expected out of range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(-0.1)
+						datum.NormalExpected = pointer.FromFloat64(100.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal in range (lower); normal expected missing",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal in range (lower); normal expected out of range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(-0.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal in range (lower); normal expected in range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(0.0)
+					},
+				),
+				Entry("normal in range (lower); normal expected in range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+				),
+				Entry("normal in range (lower); normal expected out of range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(0.0)
+						datum.NormalExpected = pointer.FromFloat64(100.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal in range (upper); normal expected missing",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.0)
+						datum.NormalExpected = nil
+					},
+				),
+				Entry("normal in range (upper); normal expected out of range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.0)
+						datum.NormalExpected = pointer.FromFloat64(99.9)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(99.9, 100.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal in range (upper); normal expected in range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.0)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+				),
+				Entry("normal in range (upper); normal expected in range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.0)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+				),
+				Entry("normal in range (upper); normal expected out of range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.0)
+						datum.NormalExpected = pointer.FromFloat64(100.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 100.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal out of range (upper); normal expected missing",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.1)
+						datum.NormalExpected = nil
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta()),
+				),
+				Entry("normal out of range (upper); normal expected out of range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.1)
+						datum.NormalExpected = pointer.FromFloat64(-0.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("normal out of range (upper); normal expected in range (lower)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.1)
+						datum.NormalExpected = pointer.FromFloat64(0.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta()),
+				),
+				Entry("normal out of range (upper); normal expected in range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.1)
+						datum.NormalExpected = pointer.FromFloat64(100.0)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta()),
+				),
+				Entry("normal out of range (upper); normal expected out of range (upper)",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Normal = pointer.FromFloat64(100.1)
+						datum.NormalExpected = pointer.FromFloat64(100.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/normal", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedNormal", NewMeta()),
+				),
+				Entry("multiple errors",
+					func(datum *dataTypesBolusAutomated.Automated) {
+						datum.Type = "invalidType"
+						datum.SubType = "invalidSubType"
+						datum.Normal = nil
+						datum.NormalExpected = pointer.FromFloat64(100.1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "bolus"), "/type", &dataTypesBolus.Meta{Type: "invalidType", SubType: "invalidSubType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidSubType", "automated"), "/subType", &dataTypesBolus.Meta{Type: "invalidType", SubType: "invalidSubType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/normal", &dataTypesBolus.Meta{Type: "invalidType", SubType: "invalidSubType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, 0.0, 100.0), "/expectedNormal", &dataTypesBolus.Meta{Type: "invalidType", SubType: "invalidSubType"}),
+				),
+			)
+		})
+
+		Context("Normalize", func() {
+			DescribeTable("normalizes the datum",
+				func(mutator func(datum *dataTypesBolusAutomated.Automated)) {
+					for _, origin := range structure.Origins() {
+						datum := dataTypesBolusAutomatedTest.RandomAutomated()
+						mutator(datum)
+						expectedDatum := dataTypesBolusAutomatedTest.CloneAutomated(datum)
+						normalizer := dataNormalizer.New()
+						Expect(normalizer).ToNot(BeNil())
+						datum.Normalize(normalizer.WithOrigin(origin))
+						Expect(normalizer.Error()).To(BeNil())
+						Expect(normalizer.Data()).To(BeEmpty())
+						Expect(datum).To(Equal(expectedDatum))
+					}
+				},
+				Entry("does not modify the datum",
+					func(datum *dataTypesBolusAutomated.Automated) {},
+				),
+				Entry("does not modify the datum; type missing",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.Type = "" },
+				),
+				Entry("does not modify the datum; sub type missing",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.SubType = "" },
+				),
+				Entry("does not modify the datum; normal missing",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.Normal = nil },
+				),
+				Entry("does not modify the datum; normal expected missing",
+					func(datum *dataTypesBolusAutomated.Automated) { datum.NormalExpected = nil },
+				),
+			)
+		})
+	})
+})

--- a/data/types/bolus/automated/test/automated.go
+++ b/data/types/bolus/automated/test/automated.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	dataTypesBolusAutomated "github.com/tidepool-org/platform/data/types/bolus/automated"
+	dataTypesBolusTest "github.com/tidepool-org/platform/data/types/bolus/test"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/test"
+)
+
+func RandomAutomated() *dataTypesBolusAutomated.Automated {
+	datum := randomAutomated()
+	datum.Bolus = *dataTypesBolusTest.RandomBolus()
+	datum.SubType = "automated"
+	return datum
+}
+
+func RandomAutomatedForParser() *dataTypesBolusAutomated.Automated {
+	datum := randomAutomated()
+	datum.Bolus = *dataTypesBolusTest.RandomBolusForParser()
+	datum.SubType = "automated"
+	return datum
+}
+
+func randomAutomated() *dataTypesBolusAutomated.Automated {
+	datum := dataTypesBolusAutomated.New()
+	datum.Normal = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypesBolusAutomated.NormalMinimum, dataTypesBolusAutomated.NormalMaximum))
+	datum.NormalExpected = pointer.FromFloat64(test.RandomFloat64FromRange(*datum.Normal, dataTypesBolusAutomated.NormalMaximum))
+	return datum
+}
+
+func CloneAutomated(datum *dataTypesBolusAutomated.Automated) *dataTypesBolusAutomated.Automated {
+	if datum == nil {
+		return nil
+	}
+	clone := dataTypesBolusAutomated.New()
+	clone.Bolus = *dataTypesBolusTest.CloneBolus(&datum.Bolus)
+	clone.Normal = pointer.CloneFloat64(datum.Normal)
+	clone.NormalExpected = pointer.CloneFloat64(datum.NormalExpected)
+	return clone
+}
+
+func NewObjectFromAutomated(datum *dataTypesBolusAutomated.Automated, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := dataTypesBolusTest.NewObjectFromBolus(&datum.Bolus, objectFormat)
+	if datum.Normal != nil {
+		object["normal"] = test.NewObjectFromFloat64(*datum.Normal, objectFormat)
+	}
+	if datum.NormalExpected != nil {
+		object["expectedNormal"] = test.NewObjectFromFloat64(*datum.NormalExpected, objectFormat)
+	}
+	return object
+}

--- a/data/types/bolus/bolus_test.go
+++ b/data/types/bolus/bolus_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Bolus", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *bolus.Bolus), expectedErrors ...error) {
-					datum := dataTypesBolusTest.NewBolus()
+					datum := dataTypesBolusTest.RandomBolus()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -92,7 +92,7 @@ var _ = Describe("Bolus", func() {
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/insulinFormulation/simple"),
 				),
 				Entry("insulin formulation valid",
-					func(datum *bolus.Bolus) { datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3) },
+					func(datum *bolus.Bolus) { datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3) },
 				),
 				Entry("multiple errors",
 					func(datum *bolus.Bolus) {
@@ -113,7 +113,7 @@ var _ = Describe("Bolus", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *bolus.Bolus)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesBolusTest.NewBolus()
+						datum := dataTypesBolusTest.RandomBolus()
 						mutator(datum)
 						expectedDatum := dataTypesBolusTest.CloneBolus(datum)
 						normalizer := dataNormalizer.New()
@@ -143,7 +143,7 @@ var _ = Describe("Bolus", func() {
 			var datum *bolus.Bolus
 
 			BeforeEach(func() {
-				datum = dataTypesBolusTest.NewBolus()
+				datum = dataTypesBolusTest.RandomBolus()
 			})
 
 			It("returns error if user id is missing", func() {

--- a/data/types/bolus/combination/test/combination.go
+++ b/data/types/bolus/combination/test/combination.go
@@ -9,7 +9,7 @@ import (
 
 func NewCombination() *combination.Combination {
 	datum := combination.New()
-	datum.Bolus = *dataTypesBolusTest.NewBolus()
+	datum.Bolus = *dataTypesBolusTest.RandomBolus()
 	datum.SubType = "dual/square"
 	datum.Duration = pointer.FromInt(test.RandomIntFromRange(combination.DurationMinimum, combination.DurationMaximum))
 	datum.Extended = pointer.FromFloat64(test.RandomFloat64FromRange(combination.ExtendedMinimum, combination.ExtendedMaximum))

--- a/data/types/bolus/extended/test/extended.go
+++ b/data/types/bolus/extended/test/extended.go
@@ -9,7 +9,7 @@ import (
 
 func NewExtended() *extended.Extended {
 	datum := extended.New()
-	datum.Bolus = *dataTypesBolusTest.NewBolus()
+	datum.Bolus = *dataTypesBolusTest.RandomBolus()
 	datum.SubType = "square"
 	datum.Duration = pointer.FromInt(test.RandomIntFromRange(extended.DurationMinimum, extended.DurationMaximum))
 	datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(*datum.Duration, extended.DurationMaximum))

--- a/data/types/bolus/normal/test/normal.go
+++ b/data/types/bolus/normal/test/normal.go
@@ -9,7 +9,7 @@ import (
 
 func NewNormal() *normal.Normal {
 	datum := normal.New()
-	datum.Bolus = *dataTypesBolusTest.NewBolus()
+	datum.Bolus = *dataTypesBolusTest.RandomBolus()
 	datum.SubType = "normal"
 	datum.Normal = pointer.FromFloat64(test.RandomFloat64FromRange(normal.NormalMinimum, normal.NormalMaximum))
 	datum.NormalExpected = pointer.FromFloat64(test.RandomFloat64FromRange(*datum.Normal, normal.NormalMaximum))

--- a/data/types/bolus/test/bolus.go
+++ b/data/types/bolus/test/bolus.go
@@ -1,27 +1,52 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/bolus"
+	dataTypesBolus "github.com/tidepool-org/platform/data/types/bolus"
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
+	"github.com/tidepool-org/platform/test"
 )
 
-func NewBolus() *bolus.Bolus {
-	datum := &bolus.Bolus{}
+func RandomBolus() *dataTypesBolus.Bolus {
+	datum := randomBolus()
 	datum.Base = *dataTypesTest.RandomBase()
 	datum.Type = "bolus"
-	datum.SubType = dataTypesTest.NewType()
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
 	return datum
 }
 
-func CloneBolus(datum *bolus.Bolus) *bolus.Bolus {
+func RandomBolusForParser() *dataTypesBolus.Bolus {
+	datum := randomBolus()
+	datum.Base = *dataTypesTest.RandomBaseForParser()
+	datum.Type = "bolus"
+	return datum
+}
+
+func randomBolus() *dataTypesBolus.Bolus {
+	datum := &dataTypesBolus.Bolus{}
+	datum.SubType = dataTypesTest.NewType()
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
+	return datum
+}
+
+func CloneBolus(datum *dataTypesBolus.Bolus) *dataTypesBolus.Bolus {
 	if datum == nil {
 		return nil
 	}
-	clone := &bolus.Bolus{}
+	clone := &dataTypesBolus.Bolus{}
 	clone.Base = *dataTypesTest.CloneBase(&datum.Base)
 	clone.SubType = datum.SubType
 	clone.InsulinFormulation = dataTypesInsulinTest.CloneFormulation(datum.InsulinFormulation)
 	return clone
+}
+
+func NewObjectFromBolus(datum *dataTypesBolus.Bolus, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := dataTypesTest.NewObjectFromBase(&datum.Base, objectFormat)
+	object["subType"] = test.NewObjectFromString(datum.SubType, objectFormat)
+	if datum.InsulinFormulation != nil {
+		object["insulinFormulation"] = dataTypesInsulinTest.NewObjectFromFormulation(datum.InsulinFormulation, objectFormat)
+	}
+	return object
 }

--- a/data/types/device/override/settings/pump/pump.go
+++ b/data/types/device/override/settings/pump/pump.go
@@ -110,14 +110,11 @@ func (p *Pump) Validate(validator structure.Validator) {
 	}
 	validator.String("method", p.Method).OneOf(Methods()...)
 	validator.Int("duration", p.Duration).InRange(DurationMinimum, DurationMaximum)
-	if expectedDurationValidator := validator.Int("expectedDuration", p.DurationExpected); p.Duration != nil {
-		if *p.Duration >= DurationMinimum && *p.Duration <= DurationMaximum {
-			expectedDurationValidator.InRange(*p.Duration, DurationMaximum)
-		} else {
-			expectedDurationValidator.InRange(DurationMinimum, DurationMaximum)
-		}
+	expectedDurationValidator := validator.Int("expectedDuration", p.DurationExpected)
+	if p.Duration != nil && *p.Duration >= DurationMinimum && *p.Duration <= DurationMaximum {
+		expectedDurationValidator.InRange(*p.Duration, DurationMaximum)
 	} else {
-		expectedDurationValidator.NotExists()
+		expectedDurationValidator.InRange(DurationMinimum, DurationMaximum)
 	}
 	if p.BloodGlucoseTarget != nil {
 		p.BloodGlucoseTarget.Validate(validator.WithReference("bgTarget"), unitsBloodGlucose)

--- a/data/types/device/override/settings/pump/pump_test.go
+++ b/data/types/device/override/settings/pump/pump_test.go
@@ -394,20 +394,42 @@ var _ = Describe("Pump", func() {
 					},
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604801, 0, 604800), "/duration", NewMeta()),
 				),
-				Entry("duration expected exists",
-					pointer.FromString("mmol/L"),
-					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
-						datum.Duration = nil
-						datum.DurationExpected = pointer.FromInt(test.RandomIntFromRange(0, 604800))
-					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/expectedDuration", NewMeta()),
-				),
 				Entry("duration expected missing",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
 						datum.Duration = pointer.FromInt(test.RandomIntFromRange(0, 604800))
 						datum.DurationExpected = nil
 					},
+				),
+				Entry("duration expected; duration missing; out of range (lower)",
+					pointer.FromString("mmol/L"),
+					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.FromInt(-1)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/expectedDuration", NewMeta()),
+				),
+				Entry("duration expected; duration missing; in range (lower)",
+					pointer.FromString("mmol/L"),
+					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.FromInt(0)
+					},
+				),
+				Entry("duration expected; duration missing; in range (upper)",
+					pointer.FromString("mmol/L"),
+					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.FromInt(604800)
+					},
+				),
+				Entry("duration expected; duration missing; out of range (upper)",
+					pointer.FromString("mmol/L"),
+					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
+						datum.Duration = nil
+						datum.DurationExpected = pointer.FromInt(604801)
+					},
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604801, 0, 604800), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration expected; duration out of range; out of range (lower)",
 					pointer.FromString("mmol/L"),

--- a/data/types/insulin/compound_test.go
+++ b/data/types/insulin/compound_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Compound", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *insulin.Compound), expectedErrors ...error) {
-					datum := dataTypesInsulinTest.NewCompound(3)
+					datum := dataTypesInsulinTest.RandomCompound(3)
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -65,7 +65,7 @@ var _ = Describe("Compound", func() {
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/formulation/name"),
 				),
 				Entry("formulation valid",
-					func(datum *insulin.Compound) { datum.Formulation = dataTypesInsulinTest.NewFormulation(3) },
+					func(datum *insulin.Compound) { datum.Formulation = dataTypesInsulinTest.RandomFormulation(3) },
 				),
 				Entry("multiple errors",
 					func(datum *insulin.Compound) {
@@ -82,7 +82,7 @@ var _ = Describe("Compound", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *insulin.Compound)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesInsulinTest.NewCompound(3)
+						datum := dataTypesInsulinTest.RandomCompound(3)
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneCompound(datum)
 						normalizer := dataNormalizer.New()
@@ -142,7 +142,7 @@ var _ = Describe("Compound", func() {
 				),
 				Entry("single invalid",
 					func(datum *insulin.CompoundArray) {
-						invalid := dataTypesInsulinTest.NewCompound(3)
+						invalid := dataTypesInsulinTest.RandomCompound(3)
 						invalid.Amount = nil
 						*datum = append(*datum, invalid)
 					},
@@ -150,42 +150,42 @@ var _ = Describe("Compound", func() {
 				),
 				Entry("single valid",
 					func(datum *insulin.CompoundArray) {
-						*datum = append(*datum, dataTypesInsulinTest.NewCompound(3))
+						*datum = append(*datum, dataTypesInsulinTest.RandomCompound(3))
 					},
 				),
 				Entry("multiple invalid",
 					func(datum *insulin.CompoundArray) {
-						invalid := dataTypesInsulinTest.NewCompound(3)
+						invalid := dataTypesInsulinTest.RandomCompound(3)
 						invalid.Amount = nil
-						*datum = append(*datum, dataTypesInsulinTest.NewCompound(3), invalid, dataTypesInsulinTest.NewCompound(3))
+						*datum = append(*datum, dataTypesInsulinTest.RandomCompound(3), invalid, dataTypesInsulinTest.RandomCompound(3))
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/1/amount"),
 				),
 				Entry("multiple valid",
 					func(datum *insulin.CompoundArray) {
-						*datum = append(*datum, dataTypesInsulinTest.NewCompound(3), dataTypesInsulinTest.NewCompound(3), dataTypesInsulinTest.NewCompound(3))
+						*datum = append(*datum, dataTypesInsulinTest.RandomCompound(3), dataTypesInsulinTest.RandomCompound(3), dataTypesInsulinTest.RandomCompound(3))
 					},
 				),
 				Entry("multiple; length in range (upper)",
 					func(datum *insulin.CompoundArray) {
 						for len(*datum) < 100 {
-							*datum = append(*datum, dataTypesInsulinTest.NewCompound(1))
+							*datum = append(*datum, dataTypesInsulinTest.RandomCompound(1))
 						}
 					},
 				),
 				Entry("multiple; length out of range (upper)",
 					func(datum *insulin.CompoundArray) {
 						for len(*datum) < 101 {
-							*datum = append(*datum, dataTypesInsulinTest.NewCompound(1))
+							*datum = append(*datum, dataTypesInsulinTest.RandomCompound(1))
 						}
 					},
 					structureValidator.ErrorLengthNotLessThanOrEqualTo(101, 100),
 				),
 				Entry("multiple errors",
 					func(datum *insulin.CompoundArray) {
-						invalid := dataTypesInsulinTest.NewCompound(3)
+						invalid := dataTypesInsulinTest.RandomCompound(3)
 						invalid.Amount = nil
-						*datum = append(*datum, nil, invalid, dataTypesInsulinTest.NewCompound(3))
+						*datum = append(*datum, nil, invalid, dataTypesInsulinTest.RandomCompound(3))
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/0"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/1/amount"),
@@ -197,7 +197,7 @@ var _ = Describe("Compound", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *insulin.CompoundArray)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesInsulinTest.NewCompoundArray(3)
+						datum := dataTypesInsulinTest.RandomCompoundArray(3)
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneCompoundArray(datum)
 						normalizer := dataNormalizer.New()

--- a/data/types/insulin/concentration_test.go
+++ b/data/types/insulin/concentration_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Concentration", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *insulin.Concentration), expectedErrors ...error) {
-					datum := dataTypesInsulinTest.NewConcentration()
+					datum := dataTypesInsulinTest.RandomConcentration()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -193,7 +193,7 @@ var _ = Describe("Concentration", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *insulin.Concentration)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesInsulinTest.NewConcentration()
+						datum := dataTypesInsulinTest.RandomConcentration()
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneConcentration(datum)
 						normalizer := dataNormalizer.New()

--- a/data/types/insulin/formulation_test.go
+++ b/data/types/insulin/formulation_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Formulation", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *insulin.Formulation), expectedErrors ...error) {
-					datum := dataTypesInsulinTest.NewFormulation(3)
+					datum := dataTypesInsulinTest.RandomFormulation(3)
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -63,7 +63,7 @@ var _ = Describe("Formulation", func() {
 				Entry("compounds missing; simple invalid",
 					func(datum *insulin.Formulation) {
 						datum.Compounds = nil
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 						datum.Simple.ActingType = nil
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/simple/actingType"),
@@ -71,7 +71,7 @@ var _ = Describe("Formulation", func() {
 				Entry("compounds missing; simple valid",
 					func(datum *insulin.Formulation) {
 						datum.Compounds = nil
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 					},
 				),
 				Entry("compounds invalid; simple missing",
@@ -86,7 +86,7 @@ var _ = Describe("Formulation", func() {
 					func(datum *insulin.Formulation) {
 						datum.Compounds = insulin.NewCompoundArray()
 						*datum.Compounds = append(*datum.Compounds, nil)
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 						datum.Simple.ActingType = nil
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/compounds"),
@@ -96,20 +96,20 @@ var _ = Describe("Formulation", func() {
 					func(datum *insulin.Formulation) {
 						datum.Compounds = insulin.NewCompoundArray()
 						*datum.Compounds = append(*datum.Compounds, nil)
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/compounds"),
 				),
 				Entry("compounds valid; simple missing",
 					func(datum *insulin.Formulation) {
-						datum.Compounds = dataTypesInsulinTest.NewCompoundArray(3)
+						datum.Compounds = dataTypesInsulinTest.RandomCompoundArray(3)
 						datum.Simple = nil
 					},
 				),
 				Entry("compounds valid; simple invalid",
 					func(datum *insulin.Formulation) {
-						datum.Compounds = dataTypesInsulinTest.NewCompoundArray(3)
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Compounds = dataTypesInsulinTest.RandomCompoundArray(3)
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 						datum.Simple.ActingType = nil
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/compounds"),
@@ -117,8 +117,8 @@ var _ = Describe("Formulation", func() {
 				),
 				Entry("compounds valid; simple valid",
 					func(datum *insulin.Formulation) {
-						datum.Compounds = dataTypesInsulinTest.NewCompoundArray(3)
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Compounds = dataTypesInsulinTest.RandomCompoundArray(3)
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/compounds"),
 				),
@@ -140,9 +140,9 @@ var _ = Describe("Formulation", func() {
 				),
 				Entry("multiple errors",
 					func(datum *insulin.Formulation) {
-						datum.Compounds = dataTypesInsulinTest.NewCompoundArray(3)
+						datum.Compounds = dataTypesInsulinTest.RandomCompoundArray(3)
 						datum.Name = pointer.FromString("")
-						datum.Simple = dataTypesInsulinTest.NewSimple()
+						datum.Simple = dataTypesInsulinTest.RandomSimple()
 						datum.Simple.ActingType = nil
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueExists(), "/compounds"),
@@ -156,7 +156,7 @@ var _ = Describe("Formulation", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *insulin.Formulation)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesInsulinTest.NewFormulation(3)
+						datum := dataTypesInsulinTest.RandomFormulation(3)
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneFormulation(datum)
 						normalizer := dataNormalizer.New()

--- a/data/types/insulin/insulin_test.go
+++ b/data/types/insulin/insulin_test.go
@@ -28,7 +28,7 @@ func NewInsulin() *insulin.Insulin {
 	datum.Base = *dataTypesTest.RandomBase()
 	datum.Type = "insulin"
 	datum.Dose = dataTypesInsulinTest.NewDose()
-	datum.Formulation = dataTypesInsulinTest.NewFormulation(3)
+	datum.Formulation = dataTypesInsulinTest.RandomFormulation(3)
 	datum.Site = pointer.FromString(test.RandomStringFromRange(1, 100))
 	return datum
 }
@@ -107,7 +107,7 @@ var _ = Describe("Insulin", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/formulation/name", NewMeta()),
 				),
 				Entry("formulation valid",
-					func(datum *insulin.Insulin) { datum.Formulation = dataTypesInsulinTest.NewFormulation(3) },
+					func(datum *insulin.Insulin) { datum.Formulation = dataTypesInsulinTest.RandomFormulation(3) },
 				),
 				Entry("site missing",
 					func(datum *insulin.Insulin) { datum.Site = nil },

--- a/data/types/insulin/simple_test.go
+++ b/data/types/insulin/simple_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Simple", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(mutator func(datum *insulin.Simple), expectedErrors ...error) {
-					datum := dataTypesInsulinTest.NewSimple()
+					datum := dataTypesInsulinTest.RandomSimple()
 					mutator(datum)
 					dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 				},
@@ -108,7 +108,7 @@ var _ = Describe("Simple", func() {
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/concentration/units"),
 				),
 				Entry("concentration valid",
-					func(datum *insulin.Simple) { datum.Concentration = dataTypesInsulinTest.NewConcentration() },
+					func(datum *insulin.Simple) { datum.Concentration = dataTypesInsulinTest.RandomConcentration() },
 				),
 				Entry("multiple errors",
 					func(datum *insulin.Simple) {
@@ -127,7 +127,7 @@ var _ = Describe("Simple", func() {
 			DescribeTable("normalizes the datum",
 				func(mutator func(datum *insulin.Simple)) {
 					for _, origin := range structure.Origins() {
-						datum := dataTypesInsulinTest.NewSimple()
+						datum := dataTypesInsulinTest.RandomSimple()
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneSimple(datum)
 						normalizer := dataNormalizer.New()

--- a/data/types/insulin/test/compound.go
+++ b/data/types/insulin/test/compound.go
@@ -3,46 +3,71 @@ package test
 import (
 	"math"
 
-	"github.com/tidepool-org/platform/data/types/insulin"
+	dataTypeInsulin "github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewCompound(compoundArrayDepthLimit int) *insulin.Compound {
-	datum := insulin.NewCompound()
+func RandomCompound(compoundArrayDepthLimit int) *dataTypeInsulin.Compound {
+	datum := dataTypeInsulin.NewCompound()
 	datum.Amount = pointer.FromFloat64(test.RandomFloat64FromRange(0.0, math.MaxFloat64))
-	datum.Formulation = NewFormulation(compoundArrayDepthLimit)
+	datum.Formulation = RandomFormulation(compoundArrayDepthLimit)
 	return datum
 }
 
-func CloneCompound(datum *insulin.Compound) *insulin.Compound {
+func CloneCompound(datum *dataTypeInsulin.Compound) *dataTypeInsulin.Compound {
 	if datum == nil {
 		return nil
 	}
-	clone := insulin.NewCompound()
+	clone := dataTypeInsulin.NewCompound()
 	clone.Amount = pointer.CloneFloat64(datum.Amount)
 	clone.Formulation = CloneFormulation(datum.Formulation)
 	return clone
 }
 
-func NewCompoundArray(compoundArrayDepthLimit int) *insulin.CompoundArray {
+func NewObjectFromCompound(datum *dataTypeInsulin.Compound, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Amount != nil {
+		object["amount"] = test.NewObjectFromFloat64(*datum.Amount, objectFormat)
+	}
+	if datum.Formulation != nil {
+		object["formulation"] = NewObjectFromFormulation(datum.Formulation, objectFormat)
+	}
+	return object
+}
+
+func RandomCompoundArray(compoundArrayDepthLimit int) *dataTypeInsulin.CompoundArray {
 	if compoundArrayDepthLimit--; compoundArrayDepthLimit <= 0 {
 		return nil
 	}
-	datum := insulin.NewCompoundArray()
+	datum := dataTypeInsulin.NewCompoundArray()
 	for count := 0; count < test.RandomIntFromRange(1, 3); count++ {
-		*datum = append(*datum, NewCompound(compoundArrayDepthLimit))
+		*datum = append(*datum, RandomCompound(compoundArrayDepthLimit))
 	}
 	return datum
 }
 
-func CloneCompoundArray(datumArray *insulin.CompoundArray) *insulin.CompoundArray {
+func CloneCompoundArray(datumArray *dataTypeInsulin.CompoundArray) *dataTypeInsulin.CompoundArray {
 	if datumArray == nil {
 		return nil
 	}
-	clone := insulin.NewCompoundArray()
+	clone := dataTypeInsulin.NewCompoundArray()
 	for _, datum := range *datumArray {
 		*clone = append(*clone, CloneCompound(datum))
 	}
 	return clone
+}
+
+func NewArrayFromCompoundArray(datumArray *dataTypeInsulin.CompoundArray, objectFormat test.ObjectFormat) []interface{} {
+	if datumArray == nil {
+		return nil
+	}
+	array := []interface{}{}
+	for _, datum := range *datumArray {
+		array = append(array, NewObjectFromCompound(datum, objectFormat))
+	}
+	return array
 }

--- a/data/types/insulin/test/concentration.go
+++ b/data/types/insulin/test/concentration.go
@@ -1,24 +1,38 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/insulin"
+	dataTypeInsulin "github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewConcentration() *insulin.Concentration {
-	datum := insulin.NewConcentration()
-	datum.Units = pointer.FromString(test.RandomStringFromArray(insulin.ConcentrationUnits()))
-	datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(insulin.ConcentrationValueRangeForUnits(datum.Units)))
+func RandomConcentration() *dataTypeInsulin.Concentration {
+	datum := dataTypeInsulin.NewConcentration()
+	datum.Units = pointer.FromString(test.RandomStringFromArray(dataTypeInsulin.ConcentrationUnits()))
+	datum.Value = pointer.FromFloat64(test.RandomFloat64FromRange(dataTypeInsulin.ConcentrationValueRangeForUnits(datum.Units)))
 	return datum
 }
 
-func CloneConcentration(datum *insulin.Concentration) *insulin.Concentration {
+func CloneConcentration(datum *dataTypeInsulin.Concentration) *dataTypeInsulin.Concentration {
 	if datum == nil {
 		return nil
 	}
-	clone := insulin.NewConcentration()
+	clone := dataTypeInsulin.NewConcentration()
 	clone.Units = pointer.CloneString(datum.Units)
 	clone.Value = pointer.CloneFloat64(datum.Value)
 	return clone
+}
+
+func NewObjectFromConcentration(datum *dataTypeInsulin.Concentration, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Units != nil {
+		object["units"] = test.NewObjectFromString(*datum.Units, objectFormat)
+	}
+	if datum.Value != nil {
+		object["value"] = test.NewObjectFromFloat64(*datum.Value, objectFormat)
+	}
+	return object
 }

--- a/data/types/insulin/test/formulation.go
+++ b/data/types/insulin/test/formulation.go
@@ -1,31 +1,48 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/insulin"
+	dataTypeInsulin "github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewFormulation(compoundArrayDepthLimit int) *insulin.Formulation {
+func RandomFormulation(compoundArrayDepthLimit int) *dataTypeInsulin.Formulation {
 	simple := test.RandomBool()
-	datum := insulin.NewFormulation()
+	datum := dataTypeInsulin.NewFormulation()
 	if !simple {
-		datum.Compounds = NewCompoundArray(compoundArrayDepthLimit)
+		datum.Compounds = RandomCompoundArray(compoundArrayDepthLimit)
 	}
 	datum.Name = pointer.FromString(test.RandomStringFromRange(1, 100))
 	if simple {
-		datum.Simple = NewSimple()
+		datum.Simple = RandomSimple()
 	}
 	return datum
 }
 
-func CloneFormulation(datum *insulin.Formulation) *insulin.Formulation {
+func CloneFormulation(datum *dataTypeInsulin.Formulation) *dataTypeInsulin.Formulation {
 	if datum == nil {
 		return nil
 	}
-	clone := insulin.NewFormulation()
+	clone := dataTypeInsulin.NewFormulation()
 	clone.Compounds = CloneCompoundArray(datum.Compounds)
 	clone.Name = pointer.CloneString(datum.Name)
 	clone.Simple = CloneSimple(datum.Simple)
 	return clone
+}
+
+func NewObjectFromFormulation(datum *dataTypeInsulin.Formulation, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.Compounds != nil {
+		object["compounds"] = NewArrayFromCompoundArray(datum.Compounds, objectFormat)
+	}
+	if datum.Name != nil {
+		object["name"] = test.NewObjectFromString(*datum.Name, objectFormat)
+	}
+	if datum.Simple != nil {
+		object["simple"] = NewObjectFromSimple(datum.Simple, objectFormat)
+	}
+	return object
 }

--- a/data/types/insulin/test/insulin.go
+++ b/data/types/insulin/test/insulin.go
@@ -12,7 +12,7 @@ func NewInsulin() *insulin.Insulin {
 	datum.Base = *dataTypesTest.RandomBase()
 	datum.Type = "insulin"
 	datum.Dose = NewDose()
-	datum.Formulation = NewFormulation(3)
+	datum.Formulation = RandomFormulation(3)
 	datum.Site = pointer.FromString(test.RandomStringFromRange(1, 100))
 	return datum
 }

--- a/data/types/insulin/test/simple.go
+++ b/data/types/insulin/test/simple.go
@@ -1,26 +1,43 @@
 package test
 
 import (
-	"github.com/tidepool-org/platform/data/types/insulin"
+	dataTypeInsulin "github.com/tidepool-org/platform/data/types/insulin"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewSimple() *insulin.Simple {
-	datum := insulin.NewSimple()
-	datum.ActingType = pointer.FromString(test.RandomStringFromArray(insulin.SimpleActingTypes()))
+func RandomSimple() *dataTypeInsulin.Simple {
+	datum := dataTypeInsulin.NewSimple()
+	datum.ActingType = pointer.FromString(test.RandomStringFromArray(dataTypeInsulin.SimpleActingTypes()))
 	datum.Brand = pointer.FromString(test.RandomStringFromRange(1, 100))
-	datum.Concentration = NewConcentration()
+	datum.Concentration = RandomConcentration()
 	return datum
 }
 
-func CloneSimple(datum *insulin.Simple) *insulin.Simple {
+func CloneSimple(datum *dataTypeInsulin.Simple) *dataTypeInsulin.Simple {
 	if datum == nil {
 		return nil
 	}
-	clone := insulin.NewSimple()
+	clone := dataTypeInsulin.NewSimple()
 	clone.ActingType = pointer.CloneString(datum.ActingType)
 	clone.Brand = pointer.CloneString(datum.Brand)
 	clone.Concentration = CloneConcentration(datum.Concentration)
 	return clone
+}
+
+func NewObjectFromSimple(datum *dataTypeInsulin.Simple, objectFormat test.ObjectFormat) map[string]interface{} {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]interface{}{}
+	if datum.ActingType != nil {
+		object["actingType"] = test.NewObjectFromString(*datum.ActingType, objectFormat)
+	}
+	if datum.Brand != nil {
+		object["brand"] = test.NewObjectFromString(*datum.Brand, objectFormat)
+	}
+	if datum.Concentration != nil {
+		object["concentration"] = NewObjectFromConcentration(datum.Concentration, objectFormat)
+	}
+	return object
 }

--- a/data/types/settings/pump/pump_test.go
+++ b/data/types/settings/pump/pump_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Pump", func() {
 				Entry("active schedule name valid",
 					pointer.FromString("mmol/L"),
 					func(datum *pump.Pump, unitsBloodGlucose *string) {
-						datum.ActiveScheduleName = pointer.FromString(dataTypesBasalTest.NewScheduleName())
+						datum.ActiveScheduleName = pointer.FromString(dataTypesBasalTest.RandomScheduleName())
 					},
 				),
 				Entry("automated delivery missing",
@@ -400,7 +400,7 @@ var _ = Describe("Pump", func() {
 				Entry("insulin formulation valid",
 					pointer.FromString("mmol/L"),
 					func(datum *pump.Pump, unitsBloodGlucose *string) {
-						datum.InsulinFormulation = dataTypesInsulinTests.NewFormulation(3)
+						datum.InsulinFormulation = dataTypesInsulinTests.RandomFormulation(3)
 					},
 				),
 				Entry("insulin model missing",

--- a/data/types/settings/pump/test/basal_rate_start.go
+++ b/data/types/settings/pump/test/basal_rate_start.go
@@ -49,7 +49,7 @@ func CloneBasalRateStartArray(datumArray *pump.BasalRateStartArray) *pump.BasalR
 
 func NewBasalRateStartArrayMap() *pump.BasalRateStartArrayMap {
 	datum := pump.NewBasalRateStartArrayMap()
-	datum.Set(dataTypesBasalTest.NewScheduleName(), NewBasalRateStartArray())
+	datum.Set(dataTypesBasalTest.RandomScheduleName(), NewBasalRateStartArray())
 	return datum
 }
 

--- a/data/types/settings/pump/test/blood_glucose_target_start.go
+++ b/data/types/settings/pump/test/blood_glucose_target_start.go
@@ -65,7 +65,7 @@ func CloneBloodGlucoseTargetStartArrayMap(datumArrayMap *dataTypesSettingsPump.B
 
 func NewBloodGlucoseTargetStartArrayMap(units *string) *dataTypesSettingsPump.BloodGlucoseTargetStartArrayMap {
 	datum := dataTypesSettingsPump.NewBloodGlucoseTargetStartArrayMap()
-	datum.Set(dataTypesBasalTest.NewScheduleName(), RandomBloodGlucoseTargetStartArray(units))
+	datum.Set(dataTypesBasalTest.RandomScheduleName(), RandomBloodGlucoseTargetStartArray(units))
 	return datum
 }
 

--- a/data/types/settings/pump/test/carbohydrate_ratio_start.go
+++ b/data/types/settings/pump/test/carbohydrate_ratio_start.go
@@ -49,7 +49,7 @@ func CloneCarbohydrateRatioStartArray(datumArray *pump.CarbohydrateRatioStartArr
 
 func NewCarbohydrateRatioStartArrayMap() *pump.CarbohydrateRatioStartArrayMap {
 	datum := pump.NewCarbohydrateRatioStartArrayMap()
-	datum.Set(dataTypesBasalTest.NewScheduleName(), NewCarbohydrateRatioStartArray())
+	datum.Set(dataTypesBasalTest.RandomScheduleName(), NewCarbohydrateRatioStartArray())
 	return datum
 }
 

--- a/data/types/settings/pump/test/insulin_sensitivity_start.go
+++ b/data/types/settings/pump/test/insulin_sensitivity_start.go
@@ -51,7 +51,7 @@ func CloneInsulinSensitivityStartArray(datumArray *pump.InsulinSensitivityStartA
 
 func NewInsulinSensitivityStartArrayMap(units *string) *pump.InsulinSensitivityStartArrayMap {
 	datum := pump.NewInsulinSensitivityStartArrayMap()
-	datum.Set(dataTypesBasalTest.NewScheduleName(), NewInsulinSensitivityStartArray(units))
+	datum.Set(dataTypesBasalTest.RandomScheduleName(), NewInsulinSensitivityStartArray(units))
 	return datum
 }
 

--- a/data/types/settings/pump/test/pump.go
+++ b/data/types/settings/pump/test/pump.go
@@ -34,7 +34,7 @@ func NewManufacturers(minimumLength int, maximumLength int) []string {
 }
 
 func NewPump(unitsBloodGlucose *string) *pump.Pump {
-	scheduleName := dataTypesBasalTest.NewScheduleName()
+	scheduleName := dataTypesBasalTest.RandomScheduleName()
 	datum := pump.New()
 	datum.Base = *dataTypesTest.RandomBase()
 	datum.Type = "pumpSettings"
@@ -54,7 +54,7 @@ func NewPump(unitsBloodGlucose *string) *pump.Pump {
 	datum.Display = NewDisplay()
 	datum.FirmwareVersion = pointer.FromString(test.RandomStringFromRange(1, pump.FirmwareVersionLengthMaximum))
 	datum.HardwareVersion = pointer.FromString(test.RandomStringFromRange(1, pump.HardwareVersionLengthMaximum))
-	datum.InsulinFormulation = dataTypesInsulinTest.NewFormulation(3)
+	datum.InsulinFormulation = dataTypesInsulinTest.RandomFormulation(3)
 	datum.InsulinModel = RandomInsulinModel()
 	datum.InsulinSensitivitySchedules = pump.NewInsulinSensitivityStartArrayMap()
 	datum.InsulinSensitivitySchedules.Set(scheduleName, NewInsulinSensitivityStartArray(unitsBloodGlucose))


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/BACK-1903
- Add bolus/automated
- Allow basal/automated to be suppressed by basal/temp
- Add suppressed to basal/automated
- Limit length of schedule name
- Update parsing and validation errors for suppressed Basals
- Fix validation for pumpSettingsOverride expected duration
- Update tests