### PR TITLE
[BACK-2029] Add Dexcom G6 Pro to the list of devices we can import through Dexcom Clarity

### DIFF
--- a/dexcom/device.go
+++ b/dexcom/device.go
@@ -19,9 +19,10 @@ const (
 	DeviceDisplayDeviceShareReceiver       = "shareReceiver"
 	DeviceDisplayDeviceTouchscreenReceiver = "touchscreenReceiver"
 
-	DeviceTransmitterGenerationG4 = "g4"
-	DeviceTransmitterGenerationG5 = "g5"
-	DeviceTransmitterGenerationG6 = "g6"
+	DeviceTransmitterGenerationG4    = "g4"
+	DeviceTransmitterGenerationG5    = "g5"
+	DeviceTransmitterGenerationG6    = "g6"
+	DeviceTransmitterGenerationG6Pro = "g6 pro"
 )
 
 func DeviceDisplayDevices() []string {
@@ -39,6 +40,7 @@ func DeviceTransmitterGenerations() []string {
 		DeviceTransmitterGenerationG4,
 		DeviceTransmitterGenerationG5,
 		DeviceTransmitterGenerationG6,
+		DeviceTransmitterGenerationG6Pro,
 	}
 }
 

--- a/dexcom/device_test.go
+++ b/dexcom/device_test.go
@@ -40,11 +40,15 @@ var _ = Describe("Device", func() {
 		Expect(dexcom.DeviceTransmitterGenerationG6).To(Equal("g6"))
 	})
 
+	It("DeviceTransmitterGenerationG6Pro is expected", func() {
+		Expect(dexcom.DeviceTransmitterGenerationG6Pro).To(Equal("g6 pro"))
+	})
+
 	It("DeviceDisplayDevices returns expected", func() {
 		Expect(dexcom.DeviceDisplayDevices()).To(Equal([]string{"android", "iOS", "receiver", "shareReceiver", "touchscreenReceiver"}))
 	})
 
 	It("DeviceTransmitterGenerations returns expected", func() {
-		Expect(dexcom.DeviceTransmitterGenerations()).To(Equal([]string{"g4", "g5", "g6"}))
+		Expect(dexcom.DeviceTransmitterGenerations()).To(Equal([]string{"g4", "g5", "g6", "g6 pro"}))
 	})
 })


### PR DESCRIPTION
This adds "g6 pro" to the list of supported Dexcom CGM devices, so that data from those devices can be imported via Dexcom Clarity.