### PR TITLE
Summary service tuning for live data

### DIFF
--- a/data/client/client.go
+++ b/data/client/client.go
@@ -34,7 +34,7 @@ type Client interface {
 	GetSummary(ctx context.Context, id string) (*summary.Summary, error)
 	UpdateSummary(ctx context.Context, id string) (*summary.Summary, error)
 	GetOutdatedUserIDs(ctx context.Context, pagination *page.Pagination) ([]string, error)
-	BackfillSummaries(ctx context.Context) (int64, error)
+	BackfillSummaries(ctx context.Context) (int, error)
 }
 
 type ClientImpl struct {
@@ -173,8 +173,8 @@ func (c *ClientImpl) UpdateSummary(ctx context.Context, id string) (*summary.Sum
 	return summary, nil
 }
 
-func (c *ClientImpl) BackfillSummaries(ctx context.Context) (int64, error) {
-	var count int64
+func (c *ClientImpl) BackfillSummaries(ctx context.Context) (int, error) {
+	var count int
 	url := c.extendedTimeoutClient.ConstructURL("v1", "summaries")
 
 	if err := c.extendedTimeoutClient.RequestData(ctx, http.MethodPost, url, nil, nil, &count); err != nil {

--- a/data/service/service/client.go
+++ b/data/service/service/client.go
@@ -108,20 +108,20 @@ func (c *Client) UpdateSummary(ctx context.Context, id string) (*summary.Summary
 	return userSummary, err
 }
 
-func (c *Client) BackfillSummaries(ctx context.Context) (int64, error) {
+func (c *Client) BackfillSummaries(ctx context.Context) (int, error) {
 	var empty struct{}
 	var userIDsReqBackfill []string
-	var count int64 = 0
+	var count = 0
 
 	summaryRepository := c.dataStore.NewSummaryRepository()
 	dataRepository := c.dataStore.NewDataRepository()
 
-	distinctSummaryIDs, err := summaryRepository.DistinctSummaryIDs(ctx)
+	distinctDataUserIDs, err := dataRepository.DistinctCGMUserIDs(ctx)
 	if err != nil {
 		return count, err
 	}
 
-	distinctDataUserIDs, err := dataRepository.DistinctCGMUserIDs(ctx)
+	distinctSummaryIDs, err := summaryRepository.DistinctSummaryIDs(ctx)
 	if err != nil {
 		return count, err
 	}

--- a/data/store/mongo/mongo_summary.go
+++ b/data/store/mongo/mongo_summary.go
@@ -96,7 +96,6 @@ func (d *SummaryRepository) DeleteSummary(ctx context.Context, id string) error 
 }
 
 func (d *SummaryRepository) GetOutdatedUserIDs(ctx context.Context, page *page.Pagination) ([]string, error) {
-	var userIDs []string
 	var summaries []*summary.Summary
 
 	if ctx == nil {
@@ -127,8 +126,9 @@ func (d *SummaryRepository) GetOutdatedUserIDs(ctx context.Context, page *page.P
 		return nil, errors.Wrap(err, "unable to decode outdated summaries")
 	}
 
-	for _, v := range summaries {
-		userIDs = append(userIDs, v.UserID)
+	var userIDs = make([]string, len(summaries))
+	for i := 0; i < len(summaries); i++ {
+		userIDs[i] = summaries[i].UserID
 	}
 
 	return userIDs, nil

--- a/data/store/mongo/mongo_summary.go
+++ b/data/store/mongo/mongo_summary.go
@@ -218,7 +218,7 @@ func (d *SummaryRepository) DistinctSummaryIDs(ctx context.Context) ([]string, e
 	return userIDs, nil
 }
 
-func (d *SummaryRepository) CreateSummaries(ctx context.Context, summaries []*summary.Summary) (int64, error) {
+func (d *SummaryRepository) CreateSummaries(ctx context.Context, summaries []*summary.Summary) (int, error) {
 	if ctx == nil {
 		return 0, errors.New("context is missing")
 	}
@@ -226,16 +226,16 @@ func (d *SummaryRepository) CreateSummaries(ctx context.Context, summaries []*su
 		return 0, errors.New("summaries for create missing")
 	}
 
-	var insertData []mongo.WriteModel
+	insertData := make([]interface{}, len(summaries))
 
-	for _, userSummary := range summaries {
-		insertData = append(insertData, mongo.NewInsertOneModel().SetDocument(userSummary))
+	for i := 0; i < len(summaries); i++ {
+		insertData[i] = *summaries[i]
 	}
 
-	opts := options.BulkWrite().SetOrdered(false)
+	opts := options.InsertMany().SetOrdered(false)
 
-	writeResult, err := d.BulkWrite(ctx, insertData, opts)
-	count := writeResult.InsertedCount
+	writeResult, err := d.InsertMany(ctx, insertData, opts)
+	count := len(writeResult.InsertedIDs)
 
 	if err != nil {
 		if count > 0 {

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -415,6 +415,24 @@ var _ = Describe("Mongo", func() {
 							Expect(userLastUpdated.LastData).To(Equal(dataSetLastUpdated))
 							Expect(userLastUpdated.LastUpload.After(dataSetLastUpdated)).To(BeTrue())
 						})
+
+						It("returns right lastUpdated for user with far future data", func() {
+							dataSetLastUpdatedFuture := time.Now().UTC().AddDate(0, 0, 4).Truncate(time.Millisecond)
+							dataSetCGMFuture := NewDataSet(userID, deviceID)
+							dataSetCGMFuture.CreatedTime = pointer.FromString(time.Now().UTC().AddDate(0, 0, 4).Format(time.RFC3339Nano))
+							dataSetCGMDataFuture := NewDataSetCGMData(deviceID, dataSetLastUpdatedFuture, 1)
+
+							_, err = collection.InsertOne(context.Background(), dataSetCGMFuture)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(repository.CreateDataSetData(ctx, dataSetCGMFuture, dataSetCGMDataFuture)).To(Succeed())
+
+							var userLastUpdated *summary.UserLastUpdated
+							userLastUpdated, err = repository.GetLastUpdatedForUser(ctx, userID)
+
+							Expect(err).ToNot(HaveOccurred())
+							Expect(userLastUpdated.LastData).To(Equal(dataSetLastUpdated))
+							Expect(userLastUpdated.LastUpload.After(dataSetLastUpdated)).To(BeTrue())
+						})
 					})
 
 					Context("DistinctCGMUserIDs", func() {

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -551,7 +551,7 @@ var _ = Describe("Mongo", func() {
 						summaries := []*summary.Summary{randomSummary}
 						count, err := summaryRepository.CreateSummaries(nil, summaries)
 
-						Expect(count).To(Equal(int64(0)))
+						Expect(count).To(Equal(0))
 						Expect(err).To(HaveOccurred())
 						Expect(err).To(MatchError("context is missing"))
 					})
@@ -560,7 +560,7 @@ var _ = Describe("Mongo", func() {
 						summaries := []*summary.Summary{}
 						count, err := summaryRepository.CreateSummaries(ctx, summaries)
 
-						Expect(count).To(Equal(int64(0)))
+						Expect(count).To(Equal(0))
 						Expect(err).To(HaveOccurred())
 						Expect(err).To(MatchError("summaries for create missing"))
 					})
@@ -570,7 +570,7 @@ var _ = Describe("Mongo", func() {
 						count, err := summaryRepository.CreateSummaries(ctx, summaries)
 
 						Expect(err).ToNot(HaveOccurred())
-						Expect(count).To(Equal(int64(1)))
+						Expect(count).To(Equal(1))
 
 						newSummary, err := summaryRepository.GetSummary(ctx, randomSummary.UserID)
 						Expect(err).ToNot(HaveOccurred())
@@ -585,7 +585,7 @@ var _ = Describe("Mongo", func() {
 						count, err := summaryRepository.CreateSummaries(ctx, summaries)
 
 						Expect(err).ToNot(HaveOccurred())
-						Expect(count).To(Equal(int64(2)))
+						Expect(count).To(Equal(2))
 
 						for _, insertedSummary := range summaries {
 							newSummary, err := summaryRepository.GetSummary(ctx, insertedSummary.UserID)

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -75,5 +75,5 @@ type SummaryRepository interface {
 	GetOutdatedUserIDs(ctx context.Context, page *page.Pagination) ([]string, error)
 	UpdateSummary(ctx context.Context, summary *summary.Summary) (*summary.Summary, error)
 	DistinctSummaryIDs(ctx context.Context) ([]string, error)
-	CreateSummaries(ctx context.Context, summaries []*summary.Summary) (int64, error)
+	CreateSummaries(ctx context.Context, summaries []*summary.Summary) (int, error)
 }

--- a/data/summary/summary.go
+++ b/data/summary/summary.go
@@ -467,7 +467,7 @@ func (userSummary *Summary) Update(ctx context.Context, status *UserLastUpdated,
 			}
 
 			if recordTime.Before(*userSummary.LastData) {
-				skip = i
+				skip = i + 1
 			} else {
 				break
 			}

--- a/data/summary/summary.go
+++ b/data/summary/summary.go
@@ -461,7 +461,7 @@ func (userSummary *Summary) Update(ctx context.Context, status *UserLastUpdated,
 	if userSummary.LastData != nil {
 		var skip int
 		for i := 0; i < len(userData); i++ {
-			recordTime, err := time.Parse(time.RFC3339Nano, *userData[0].Time)
+			recordTime, err := time.Parse(time.RFC3339Nano, *userData[i].Time)
 			if err != nil {
 				return err
 			}

--- a/data/summary/summary_test.go
+++ b/data/summary/summary_test.go
@@ -773,6 +773,24 @@ var _ = Describe("Summary", func() {
 				Expect(userSummary.Periods["14d"].GlucoseManagementIndicator).To(BeNil())
 				Expect(userSummary.OutdatedSince).To(BeNil())
 			})
+
+			It("Returns correctly calculated summary with userData records before summary LastData", func() {
+				summaryLastData := datumTime.AddDate(0, 0, -7)
+				userData = NewDataSetCGMDataAvg(deviceID, datumTime, 14, requestedAvgGlucose)
+				userSummary = summary.New(userID)
+				userSummary.OutdatedSince = &datumTime
+				userSummary.LastData = &summaryLastData
+
+				status = &summary.UserLastUpdated{
+					LastData:   datumTime,
+					LastUpload: datumTime,
+				}
+
+				err = userSummary.Update(ctx, status, userData)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*userSummary.TotalDays).To(Equal(7))
+				Expect(userSummary.OutdatedSince).To(BeNil())
+			})
 		})
 	})
 })


### PR DESCRIPTION
Current sticking points fixed by this PR:
1. varying precision of date strings from different data sources can result in "past" data being pulled into a query due to db string comparison
2. backfill checks summary table first, resulting in unique key errors if a user uploads new data in the lengthy gap between the distinct summary query and insert, as getting distinct deviceData cgm users takes significant time.
3. summary will calculate far-future data, resulting in data which can be made to not match tidepool web