### PR TITLE
Fix quick deletion of new data causing summary update error

### DIFF
--- a/data/service/service/client.go
+++ b/data/service/service/client.go
@@ -76,6 +76,15 @@ func (c *Client) UpdateSummary(ctx context.Context, id string) (*summary.Summary
 		return nil, err
 	}
 
+	if status == nil {
+		// user's data is inactive/deleted, or this summary shouldn't have been created
+		logger.Warnf("User %s has an outdated summary with no data, skipping calc.", id)
+		userSummary.OutdatedSince = nil
+		userSummary.LastUpdatedDate = &time.Time{}
+		userSummary, err = summaryRepository.UpdateSummary(ctx, userSummary)
+		return userSummary, err
+	}
+
 	// remove 2 weeks for start time
 	startTime := status.LastData.AddDate(0, 0, -14)
 

--- a/data/store/mongo/mongo_data.go
+++ b/data/store/mongo/mongo_data.go
@@ -1001,7 +1001,7 @@ func (d *DataRepository) GetLastUpdatedForUser(ctx context.Context, id string) (
 
 	// if we still have no record
 	if len(dataSet) < 1 {
-		return nil, errors.Wrap(err, "No cbg records found for user")
+		return nil, nil
 	}
 
 	status.LastUpload, err = time.Parse(time.RFC3339Nano, *dataSet[0].CreatedTime)

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -416,6 +416,14 @@ var _ = Describe("Mongo", func() {
 							Expect(userLastUpdated.LastUpload.After(dataSetLastUpdated)).To(BeTrue())
 						})
 
+						It("returns right lastUpdated for user with no data", func() {
+							var userLastUpdated *summary.UserLastUpdated
+							userLastUpdated, err = repository.GetLastUpdatedForUser(ctx, "deadbeef")
+
+							Expect(err).ToNot(HaveOccurred())
+							Expect(userLastUpdated).To(BeNil())
+						})
+
 						It("returns right lastUpdated for user with far future data", func() {
 							dataSetLastUpdatedFuture := time.Now().UTC().AddDate(0, 0, 4).Truncate(time.Millisecond)
 							dataSetCGMFuture := NewDataSet(userID, deviceID)

--- a/data/summary/summary.go
+++ b/data/summary/summary.go
@@ -28,7 +28,7 @@ const (
 // Glucose reimplementation with only the fields we need, to avoid inheriting Base, which does
 // not belong in this collection
 type Glucose struct {
-	Units *string  `json:"units," bson:"units"`
+	Units *string  `json:"units" bson:"units"`
 	Value *float64 `json:"value" bson:"value"`
 }
 


### PR DESCRIPTION
fix an edge case where a user uploads data, but quickly deletes it before summary can be calculated