### PR TITLE
Fix task claim race condition

### DIFF
--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -244,6 +244,11 @@ func (q *Queue) dispatchTask(ctx context.Context, tsk *task.Task) {
 	var err error
 	tsk, err = repository.UpdateFromState(ctx, tsk, task.TaskStatePending)
 	if err != nil {
+		if err == task.AlreadyClaimedTask {
+			logger.Infof("Failure to claim task %s (%s) as it is already in progress or is no longer available.", tsk.Name, tsk.ID)
+			return
+		}
+
 		logger.WithError(err).Error("Failure to update state during dispatch task")
 		return
 	}

--- a/task/store/mongo/mongo.go
+++ b/task/store/mongo/mongo.go
@@ -355,10 +355,13 @@ func (t *TaskRepository) UpdateFromState(ctx context.Context, tsk *task.Task, st
 		"id":    tsk.ID,
 		"state": state,
 	}
-	_, err := t.ReplaceOne(ctx, selector, tsk)
+	result, err := t.ReplaceOne(ctx, selector, tsk)
 	logger.WithField("duration", time.Since(now)/time.Microsecond).WithError(err).Debug("UpdateFromState")
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update from state")
+	}
+	if result.ModifiedCount != 1 {
+		return nil, task.AlreadyClaimedTask
 	}
 
 	TasksStateTotal.WithLabelValues(state, tsk.Type).Inc()

--- a/task/store/mongo/mongo.go
+++ b/task/store/mongo/mongo.go
@@ -364,7 +364,7 @@ func (t *TaskRepository) UpdateFromState(ctx context.Context, tsk *task.Task, st
 		return nil, task.AlreadyClaimedTask
 	}
 
-	TasksStateTotal.WithLabelValues(state, tsk.Type).Inc()
+	TasksStateTotal.WithLabelValues(tsk.State, tsk.Type).Inc()
 	return tsk, nil
 }
 

--- a/task/store/mongo/mongo_test.go
+++ b/task/store/mongo/mongo_test.go
@@ -205,7 +205,8 @@ var _ = Describe("Mongo", func() {
 					})
 
 					It("records metrics of completed tasks", func() {
-						completedTask, err := repository.UpdateFromState(ctx, updated, task.TaskStateCompleted)
+						updated.State = task.TaskStateCompleted
+						completedTask, err := repository.UpdateFromState(ctx, updated, tsk.State)
 
 						Expect(err).ToNot(HaveOccurred())
 
@@ -218,7 +219,8 @@ var _ = Describe("Mongo", func() {
 					})
 
 					It("records metrics of failed tasks", func() {
-						failedTask, err := repository.UpdateFromState(ctx, updated, task.TaskStateFailed)
+						updated.State = task.TaskStateFailed
+						failedTask, err := repository.UpdateFromState(ctx, updated, tsk.State)
 
 						Expect(err).ToNot(HaveOccurred())
 
@@ -231,7 +233,8 @@ var _ = Describe("Mongo", func() {
 					})
 
 					It("records metrics of running tasks", func() {
-						runningTask, err := repository.UpdateFromState(ctx, updated, task.TaskStateRunning)
+						updated.State = task.TaskStateRunning
+						runningTask, err := repository.UpdateFromState(ctx, updated, tsk.State)
 
 						Expect(err).ToNot(HaveOccurred())
 

--- a/task/store/mongo/mongo_test.go
+++ b/task/store/mongo/mongo_test.go
@@ -204,6 +204,16 @@ var _ = Describe("Mongo", func() {
 						Expect(result.Error).To(Equal(updated.Error))
 					})
 
+					It("returns error if task is updated from the same state multiple times", func() {
+						updated.State = task.TaskStatePending
+						_, err := repository.UpdateFromState(ctx, updated, tsk.State)
+						Expect(err).ToNot(HaveOccurred())
+
+						_, err = repository.UpdateFromState(ctx, updated, tsk.State)
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("Task has already been claimed or is now unavailable."))
+					})
+
 					It("records metrics of completed tasks", func() {
 						updated.State = task.TaskStateCompleted
 						completedTask, err := repository.UpdateFromState(ctx, updated, tsk.State)

--- a/task/task.go
+++ b/task/task.go
@@ -325,3 +325,5 @@ func (t Tasks) Sanitize(details request.Details) error {
 	}
 	return nil
 }
+
+var AlreadyClaimedTask = errors.New("Task has already been claimed or is now unavailable.")


### PR DESCRIPTION
Multiple workers can currently claim a single task and run it at the same time, this should fix that.