### PR TITLE
Summary calculation of overlapping and deleted+added data

### DIFF
--- a/data/service/service/client.go
+++ b/data/service/service/client.go
@@ -92,6 +92,17 @@ func (c *Client) UpdateSummary(ctx context.Context, id string) (*summary.Summary
 		userSummary = summary.New(id)
 	}
 
+	// check status.LastData for going back in time to prevent deleted data from causing issues
+	if status.LastData.Before(*userSummary.LastData) {
+		userSummary.OutdatedSince = nil
+		userSummary.LastUpdatedDate = &timestamp
+
+		userSummary, err = summaryRepository.UpdateSummary(ctx, userSummary)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// remove 2 weeks for start time
 	startTime := status.LastData.AddDate(0, 0, -14)
 

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -2,6 +2,7 @@ package mongo_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -382,6 +383,28 @@ var _ = Describe("Mongo", func() {
 					})
 
 					Context("GetCGMDataRange", func() {
+						It("returns empty if range is 0", func() {
+							var cgmRecords []*continuous.Continuous
+							dataSetFirstData = dataSetLastUpdated.AddDate(0, 0, -2)
+							cgmRecords, err = repository.GetCGMDataRange(ctx, userID, dataSetFirstData, dataSetFirstData)
+
+							Expect(err).ToNot(HaveOccurred())
+							Expect(len(cgmRecords)).To(Equal(0))
+						})
+
+						It("returns error if range is backwards", func() {
+							var cgmRecords []*continuous.Continuous
+							dataSetFirstData = dataSetLastUpdated.AddDate(0, 0, -2)
+							cgmRecords, err = repository.GetCGMDataRange(ctx, userID, dataSetLastUpdated, dataSetFirstData)
+
+							Expect(err).To(HaveOccurred())
+							Expect(cgmRecords).To(BeNil())
+							Expect(err).To(MatchError(
+								fmt.Sprintf("startTime (%s) after endTime (%s) for user %s",
+									dataSetLastUpdated, dataSetFirstData, userID),
+							))
+						})
+
 						It("returns right count for the requested range", func() {
 							var cgmRecords []*continuous.Continuous
 							dataSetFirstData = dataSetLastUpdated.AddDate(0, 0, -2)

--- a/data/summary/summary.go
+++ b/data/summary/summary.go
@@ -295,9 +295,16 @@ func (userSummary *Summary) CalculateStats(userData []*continuous.Continuous) er
 			stats.LastRecordTime = userSummary.DailyStats[len(userSummary.DailyStats)-1].LastRecordTime
 		}
 
+		// duration has never been calculated, use current record's duration for this cycle
+		if duration == 0 {
+			duration = GetDuration(r)
+		}
+
+		// calculate skipWindow based on duration of previous value
+		skipWindow := time.Duration(duration)*time.Minute - 1*time.Second
+
 		// if we are too close to the previous value, skip
-		// 45 seconds is arbitrary, but under one minute to allow future devices with 1 minute readings
-		if recordTime.Sub(stats.LastRecordTime) > 45*time.Second {
+		if recordTime.Sub(stats.LastRecordTime) > skipWindow {
 			normalizedValue = *glucose.NormalizeValueForUnits(r.Value, pointer.FromString(summaryGlucoseUnits))
 			duration = GetDuration(r)
 

--- a/data/test/summary.go
+++ b/data/test/summary.go
@@ -24,7 +24,6 @@ func RandomSummary() *summary.Summary {
 	datum.DailyStats = make([]*summary.Stats, 2)
 	for i := 0; i < 2; i++ {
 		datum.DailyStats[i] = &summary.Stats{
-			DeviceID:        NewDeviceID(),
 			Date:            test.RandomTime(),
 			TargetMinutes:   test.RandomIntFromRange(0, 1440),
 			TargetRecords:   test.RandomIntFromRange(0, 288),


### PR DESCRIPTION
There are some workflows that add+remove data at the same time, along with some cases where duplicate data may not be marked inactive.

Many of these cases also lack a DeviceID (in reality, most do).

This PR removes DeviceID handling, replacing it with skipping of nearby records, and prevention of data deletion causing summary calculation to go back in time slightly and double calculate values.