### PR TITLE
[BACK-2165] Add app assertion verification route.

### DIFF
--- a/appvalidate/appvalidate.go
+++ b/appvalidate/appvalidate.go
@@ -14,7 +14,7 @@ import (
 //go:generate mockgen -build_flags=--mod=mod -destination=./mock.go -package=appvalidate github.com/tidepool-org/platform/appvalidate Repository,ChallengeGenerator
 
 var (
-	// base64 regex that supports base64.URLEncoding ("+/" replaced by "-_") or base64.StdEncoding. Used for base64 payloads like the attestation object.
+	// base64 regex that supports base64.URLEncoding ("+/" replaced by "-_") or base64.StdEncoding. Used for base64 payloads like the attestation and assertion object.
 	base64Chars = regexp.MustCompile("^(?:[A-Za-z0-9+/\\-_]{4})*(?:[A-Za-z0-9+/\\-_]{2}==|[A-Za-z0-9+/\\-_]{3}=)?$")
 )
 

--- a/appvalidate/assertion.go
+++ b/appvalidate/assertion.go
@@ -48,13 +48,14 @@ func (av *AssertionVerify) Validate(v structure.Validator) {
 }
 
 func transformAssertion(av *AssertionVerify) (*appAssert.AuthenticatorAssertionResponse, error) {
-	var assertion appUtils.URLEncodedBase64
 	clientDataRaw, err := json.Marshal(av.ClientData)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := assertion.UnmarshalJSON([]byte(av.Assertion)); err != nil {
+	var assertion appUtils.URLEncodedBase64
+	assertionRaw := b64StdEncodingToURLEncoding(av.Assertion)
+	if err := assertion.UnmarshalJSON([]byte(assertionRaw)); err != nil {
 		return nil, err
 	}
 

--- a/appvalidate/assertion.go
+++ b/appvalidate/assertion.go
@@ -1,11 +1,71 @@
 package appvalidate
 
 import (
+	"encoding/json"
 	"time"
+
+	"github.com/tidepool-org/platform/structure"
+
+	appAssert "github.com/bas-d/appattest/assertion"
+	appUtils "github.com/bas-d/appattest/utils"
 )
 
+// AssertionVerify is the expected request body used by clients to complete
+// the assertion process. Assertion can only be done after attestation is
+// completed. The Assertion should be the base64 encoding of the binary CBOR
+// data returned from the iOS APIs.
+type AssertionVerify struct {
+	UserID     string              `json:"-"`
+	KeyID      string              `json:"keyId"`
+	ClientData AssertionClientData `json:"clientData"`
+	Assertion  string              `json:"assertion"`
+}
+
+// AssertionUpdate contains the assertion fields to update in an AppValidation
+// to pass to a repository.
 type AssertionUpdate struct {
 	Challenge        string    `bson:"assertionChallenge,omitempty"`
 	VerifiedTime     time.Time `bson:"assertionVerifiedTime,omitempty"`
 	AssertionCounter uint32    `bson:"assertionCounter,omitempty"`
+}
+
+type AssertionClientData struct {
+	Challenge string `json:"challenge"`
+}
+
+// AssertionResult is the response to a successful assertion. On success, a
+// secret of some kind will be returned to the user - key, passphrase, etc.
+type AssertionResult struct {
+	Secret string `json:"secret"`
+}
+
+func NewAssertionVerify(userID string) *AssertionVerify {
+	return &AssertionVerify{
+		UserID: userID,
+	}
+}
+
+func (av *AssertionVerify) Validate(v structure.Validator) {
+	v.String("assertion", &av.Assertion).NotEmpty().Matches(base64Chars)
+	v.String("clientData.challenge", &av.ClientData.Challenge).NotEmpty()
+
+	v.String("userId", &av.UserID).NotEmpty()
+	v.String("keyId", &av.KeyID).NotEmpty()
+}
+
+func transformAssertion(av *AssertionVerify) (*appAssert.AuthenticatorAssertionResponse, error) {
+	var assertion appUtils.URLEncodedBase64
+	clientDataRaw, err := json.Marshal(av.ClientData)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := assertion.UnmarshalJSON([]byte(av.Assertion)); err != nil {
+		return nil, err
+	}
+
+	return &appAssert.AuthenticatorAssertionResponse{
+		RawClientData: appUtils.URLEncodedBase64(clientDataRaw),
+		Assertion:     assertion,
+	}, nil
 }

--- a/appvalidate/assertion.go
+++ b/appvalidate/assertion.go
@@ -33,12 +33,6 @@ type AssertionClientData struct {
 	Challenge string `json:"challenge"`
 }
 
-// AssertionResult is the response to a successful assertion. On success, a
-// secret of some kind will be returned to the user - key, passphrase, etc.
-type AssertionResult struct {
-	Secret string `json:"secret"`
-}
-
 func NewAssertionVerify(userID string) *AssertionVerify {
 	return &AssertionVerify{
 		UserID: userID,

--- a/appvalidate/base64.go
+++ b/appvalidate/base64.go
@@ -1,0 +1,9 @@
+package appvalidate
+
+import (
+	"strings"
+)
+
+func b64StdEncodingToURLEncoding(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, "+", "-"), "/", "_"), "=", "\"")
+}

--- a/appvalidate/validator.go
+++ b/appvalidate/validator.go
@@ -17,9 +17,9 @@ var (
 )
 
 type ValidatorConfig struct {
-	AppleAppID               string `envconfig:"TIDEPOOL_APPVALIDATION_APPLE_APP_ID" default:"org.tidepool.app"`
-	UseProductionEnvironment bool   `envconfig:"TIDEPOOL_APPVALIDATION_USE_PRODUCTION" default:"false"`
-	ChallengeSize            int    `envconfig:"TIDEPOOL_APPVALIDATION_CHALLENGE_SIZE" default:"12"`
+	AppleAppID                string `envconfig:"TIDEPOOL_APPVALIDATION_APPLE_APP_ID" default:"org.tidepool.app"`
+	UseDevelopmentEnvironment bool   `envconfig:"TIDEPOOL_APPVALIDATION_USE_DEVELOPMENT" default:"false"`
+	ChallengeSize             int    `envconfig:"TIDEPOOL_APPVALIDATION_CHALLENGE_SIZE" default:"16"`
 }
 
 // Validator is the "service" that performs every flow or action associated
@@ -58,7 +58,7 @@ func NewValidator(r Repository, g ChallengeGenerator, cfg ValidatorConfig) (*Val
 		repo:          r,
 		generator:     g,
 		appleAppID:    cfg.AppleAppID,
-		isProduction:  cfg.UseProductionEnvironment,
+		isProduction:  !cfg.UseDevelopmentEnvironment,
 		challengeSize: cfg.ChallengeSize,
 	}, nil
 }

--- a/appvalidate/validator.go
+++ b/appvalidate/validator.go
@@ -10,6 +10,12 @@ import (
 	structValidator "github.com/tidepool-org/platform/structure/validator"
 )
 
+var (
+	ErrNotVerified                   = errors.New("attestation is not verified")
+	ErrAssertionVerificationFailed   = errors.New("unable to verify assertion object")
+	ErrAttestationVerificationFailed = errors.New("unable to verify attestation object")
+)
+
 type ValidatorConfig struct {
 	AppleAppID               string `envconfig:"TIDEPOOL_APPVALIDATION_APPLE_APP_ID" default:"org.tidepool.app"`
 	UseProductionEnvironment bool   `envconfig:"TIDEPOOL_APPVALIDATION_USE_PRODUCTION" default:"false"`
@@ -97,7 +103,7 @@ func (v *Validator) CreateAssertChallenge(ctx context.Context, c *ChallengeCreat
 	// is verified.
 	// https://developer.apple.com/documentation/devicecheck/establishing_your_app_s_integrity#3561591
 	if !verified {
-		return nil, errors.New("cannot request assertion if attestation is not verified")
+		return nil, ErrNotVerified
 	}
 
 	challenge, err := v.generator.GenerateChallenge(v.challengeSize)
@@ -138,7 +144,7 @@ func (v *Validator) VerifyAttestation(ctx context.Context, av *AttestationVerify
 	}
 	pubKey, receipt, err := attestation.Verify(v.appleAppID, v.isProduction)
 	if err != nil {
-		return err
+		return errors.Wrap(ErrAttestationVerificationFailed, err.Error())
 	}
 	update := AttestationUpdate{
 		PublicKey:              string(pubKey),
@@ -151,4 +157,46 @@ func (v *Validator) VerifyAttestation(ctx context.Context, av *AttestationVerify
 	}
 
 	return v.repo.UpdateAttestation(ctx, filter, update)
+}
+
+func (v *Validator) VerifyAssertion(ctx context.Context, av *AssertionVerify) (*AssertionResult, error) {
+	if err := structValidator.New().Validate(av); err != nil {
+		return nil, err
+	}
+
+	filter := Filter{UserID: av.UserID, KeyID: av.KeyID}
+	validation, err := v.repo.Get(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	// Can only do assertion if attestation is verified.
+	if !validation.Verified {
+		return nil, ErrNotVerified
+	}
+	if validation.AssertionChallenge == "" {
+		return nil, errors.New("found empty assertion challenge")
+	}
+
+	assertion, err := transformAssertion(av)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to transform assertion")
+	}
+	newCounter, err := assertion.Verify(validation.AssertionChallenge, v.appleAppID, validation.AssertionCounter, []byte(validation.PublicKey))
+	if err != nil {
+		return nil, errors.Wrap(ErrAssertionVerificationFailed, err.Error())
+	}
+
+	update := AssertionUpdate{
+		VerifiedTime:     time.Now(),
+		AssertionCounter: newCounter,
+	}
+	if err := v.repo.UpdateAssertion(ctx, filter, update); err != nil {
+		return nil, err
+	}
+
+	// Assertion has succeeded, at this point, we would access some secret
+	// from a DB, partner API, etc, depending on the AssertionVerify object.
+	return &AssertionResult{
+		Secret: "",
+	}, nil
 }

--- a/auth/service/api/v1/appvalidate.go
+++ b/auth/service/api/v1/appvalidate.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/ant0ine/go-json-rest/rest"
@@ -16,8 +17,9 @@ import (
 func (r *Router) AppValidateRoutes() []*rest.Route {
 	return []*rest.Route{
 		rest.Post("/v1/attestations/challenges", api.RequireUser(r.CreateAttestationChallenge)),
-		rest.Post("/v1/assertions/challenges", api.RequireUser(r.CreateAssertionChallenge)),
 		rest.Post("/v1/attestations/verifications", api.RequireUser(r.VerifyAttestation)),
+		rest.Post("/v1/assertions/challenges", api.RequireUser(r.CreateAssertionChallenge)),
+		rest.Post("/v1/assertions/verifications", api.RequireUser(r.VerifyAssertion)),
 	}
 }
 
@@ -54,12 +56,17 @@ func (r *Router) CreateAssertionChallenge(res rest.ResponseWriter, req *rest.Req
 	}
 
 	result, err := r.AppValidator().CreateAssertChallenge(ctx, challengeCreate)
-	if responder.RespondIfError(err) {
+	if err != nil {
 		fields := log.Fields{
 			"userID": details.UserID(),
 			"keyId":  challengeCreate.KeyID,
 		}
 		log.LoggerFromContext(ctx).WithFields(fields).WithError(err).Error("unable to create assertion challenge")
+		if errors.Is(err, appvalidate.ErrNotVerified) {
+			responder.Error(http.StatusBadRequest, err)
+			return
+		}
+		responder.RespondIfError(err)
 		return
 	}
 	responder.Data(http.StatusCreated, result)
@@ -76,15 +83,49 @@ func (r *Router) VerifyAttestation(res rest.ResponseWriter, req *rest.Request) {
 	}
 
 	err := r.AppValidator().VerifyAttestation(ctx, attestVerify)
-	if responder.RespondIfError(err) {
+	if err != nil {
 		fields := log.Fields{
 			"userID": details.UserID(),
 			"keyId":  attestVerify.KeyID,
 		}
 		log.LoggerFromContext(ctx).WithFields(fields).WithError(err).Error("unable to verify attestation")
+		if errors.Is(err, appvalidate.ErrAttestationVerificationFailed) {
+			responder.Error(http.StatusBadRequest, err)
+			return
+		}
+		responder.RespondIfError(err)
 		return
 	}
+
 	responder.Empty(http.StatusNoContent)
+}
+
+func (r *Router) VerifyAssertion(res rest.ResponseWriter, req *rest.Request) {
+	responder := request.MustNewResponder(res, req)
+	details := request.DetailsFromContext(req.Context())
+	ctx := req.Context()
+
+	assertVerify := appvalidate.NewAssertionVerify(details.UserID())
+	if decodeValidateBodyFailed(responder, req.Request, assertVerify) {
+		return
+	}
+
+	result, err := r.AppValidator().VerifyAssertion(ctx, assertVerify)
+	if err != nil {
+		fields := log.Fields{
+			"userID": details.UserID(),
+			"keyId":  assertVerify.KeyID,
+		}
+		log.LoggerFromContext(ctx).WithFields(fields).WithError(err).Error("unable to verify assertion")
+
+		if errors.Is(err, appvalidate.ErrAssertionVerificationFailed) || errors.Is(err, appvalidate.ErrNotVerified) {
+			responder.Error(http.StatusBadRequest, err)
+			return
+		}
+		responder.RespondIfError(err)
+		return
+	}
+	responder.Data(http.StatusOK, result)
 }
 
 func decodeValidateBodyFailed(responder *request.Responder, req *http.Request, body structure.Validatable) bool {

--- a/auth/service/api/v1/appvalidate.go
+++ b/auth/service/api/v1/appvalidate.go
@@ -19,6 +19,8 @@ func (r *Router) AppValidateRoutes() []*rest.Route {
 		rest.Post("/v1/attestations/challenges", api.RequireUser(r.CreateAttestationChallenge)),
 		rest.Post("/v1/attestations/verifications", api.RequireUser(r.VerifyAttestation)),
 		rest.Post("/v1/assertions/challenges", api.RequireUser(r.CreateAssertionChallenge)),
+
+		// Rename this route to show actual intent of retrieving secret?
 		rest.Post("/v1/assertions/verifications", api.RequireUser(r.VerifyAssertion)),
 	}
 }
@@ -110,8 +112,7 @@ func (r *Router) VerifyAssertion(res rest.ResponseWriter, req *rest.Request) {
 		return
 	}
 
-	result, err := r.AppValidator().VerifyAssertion(ctx, assertVerify)
-	if err != nil {
+	if err := r.AppValidator().VerifyAssertion(ctx, assertVerify); err != nil {
 		fields := log.Fields{
 			"userID": details.UserID(),
 			"keyId":  assertVerify.KeyID,
@@ -125,7 +126,10 @@ func (r *Router) VerifyAssertion(res rest.ResponseWriter, req *rest.Request) {
 		responder.RespondIfError(err)
 		return
 	}
-	responder.Data(http.StatusOK, result)
+	// Assertion has succeeded, at this point, we would access some secret
+	// from a DB, partner API, etc, depending on the AssertionVerify object.
+	// r.SecretGetter.GetSecret(...)
+	responder.Empty(http.StatusOK)
 }
 
 func decodeValidateBodyFailed(responder *request.Responder, req *http.Request, body structure.Validatable) bool {

--- a/auth/service/api/v1/appvalidate.go
+++ b/auth/service/api/v1/appvalidate.go
@@ -19,8 +19,7 @@ func (r *Router) AppValidateRoutes() []*rest.Route {
 		rest.Post("/v1/attestations/challenges", api.RequireUser(r.CreateAttestationChallenge)),
 		rest.Post("/v1/attestations/verifications", api.RequireUser(r.VerifyAttestation)),
 		rest.Post("/v1/assertions/challenges", api.RequireUser(r.CreateAssertionChallenge)),
-
-		// Rename this route to show actual intent of retrieving secret?
+		// Rename this route to show actual intent of retrieving secret when secret retrieval is implemented.
 		rest.Post("/v1/assertions/verifications", api.RequireUser(r.VerifyAssertion)),
 	}
 }

--- a/auth/service/api/v1/appvalidate_test.go
+++ b/auth/service/api/v1/appvalidate_test.go
@@ -205,7 +205,7 @@ var _ = Describe("App Validation", func() {
 			req := newRequest(http.MethodPost, "/v1/assertions/challenges", unattestedUser.SessionToken, body)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
-			Expect(w.Code).ToNot(Equal(http.StatusCreated))
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
 		})
 
 		It("succeeds only with a verified attested user", func() {
@@ -232,7 +232,7 @@ var _ = Describe("App Validation", func() {
 			req := newRequest(http.MethodPost, "/v1/assertions/challenges", unattestedUser.SessionToken, body)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
-			Expect(w.Code).ToNot(Equal(http.StatusCreated))
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
 		})
 
 		It("fails if unauthorized", func() {
@@ -276,14 +276,31 @@ var _ = Describe("App Validation", func() {
 		// 	Expect(w.Code).To(Equal(http.StatusNoContent))
 		// })
 
-		It("fails on attestation object that is not base64 encoded", func() {
+		It("fails on attestation that is not base64 encoded", func() {
 			body := &appvalidate.AttestationVerify{
-				KeyID:             attestedUser.KeyID,
-				Challenge:         challenge,
-				AttestationObject: `{"key": "field"}`,
+				KeyID:       attestedUser.KeyID,
+				Challenge:   challenge,
+				Attestation: `{"key": "field"}`,
 			}
 
 			req := newRequest(http.MethodPost, "/v1/attestations/verifications", attestedUser.SessionToken, body)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("POST /v1/assertions/verifications", func() {
+		It("fails on assertion that is not base64 encoded", func() {
+			body := &appvalidate.AssertionVerify{
+				KeyID: attestedVerifiedUser.KeyID,
+				ClientData: appvalidate.AssertionClientData{
+					Challenge: challenge,
+				},
+				Assertion: `{"key": "field"}`,
+			}
+
+			req := newRequest(http.MethodPost, "/v1/assertions/verifications", attestedVerifiedUser.SessionToken, body)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
 			Expect(w.Code).To(Equal(http.StatusBadRequest))

--- a/auth/service/api/v1/appvalidate_test.go
+++ b/auth/service/api/v1/appvalidate_test.go
@@ -46,21 +46,28 @@ var _ = Describe("App Validation", func() {
 
 	unattestedUser := user{
 		UserID:              "unattested",
-		SessionToken:        "unattestedSessionToken",
-		Details:             request.NewDetails(request.MethodSessionToken, "unattested", "unattestedSessionToken"),
+		SessionToken:        "unattestedToken",
+		Details:             request.NewDetails(request.MethodSessionToken, "unattested", "unattestedToken"),
 		AttestationVerified: false,
 	}
 	attestedUser := user{
 		UserID:              "attested",
-		SessionToken:        "attestedSessionToken",
-		Details:             request.NewDetails(request.MethodSessionToken, "attested", "attestedSessionToken"),
+		SessionToken:        "attestedToken",
+		Details:             request.NewDetails(request.MethodSessionToken, "attested", "attestedToken"),
 		KeyID:               "YWJjZGVmYWJjZGVm",
+		AttestationVerified: false,
+	}
+	attestedUnverifiedUser := user{
+		UserID:              "attestedUnverified",
+		SessionToken:        "attestedUnverifiedToken",
+		Details:             request.NewDetails(request.MethodSessionToken, "attestedUnverified", "attestedUnverified"),
+		KeyID:               "YWRzZmFkZg==",
 		AttestationVerified: false,
 	}
 	attestedVerifiedUser := user{
 		UserID:              "attestedVerified",
-		SessionToken:        "attestedVerifiedSessionToken",
-		Details:             request.NewDetails(request.MethodSessionToken, "attestedVerified", "attestedVerifiedSessionToken"),
+		SessionToken:        "attestedVerifiedToken",
+		Details:             request.NewDetails(request.MethodSessionToken, "attestedVerified", "attestedVerifiedToken"),
 		KeyID:               "YWJkZmRlZg=",
 		AttestationVerified: true,
 	}
@@ -68,10 +75,11 @@ var _ = Describe("App Validation", func() {
 		unattestedUser,
 		attestedUser,
 		attestedVerifiedUser,
+		attestedUnverifiedUser,
 	}
 
 	challenge := "challenge"
-	serverSessionToken := "serverSessionToken"
+	serverSessionToken := "serverToken"
 
 	initialValidations := make([]appvalidate.AppValidation, len(users))
 	for i, user := range users {
@@ -199,10 +207,10 @@ var _ = Describe("App Validation", func() {
 	Describe("POST /v1/assertions/challenges", func() {
 		It("fails with an unverified user", func() {
 			body := &appvalidate.ChallengeCreate{
-				KeyID: "YWJjZGVmZ2hpamFiY2RlZmdoaWphYmNkZWZnaGlq",
+				KeyID: attestedUnverifiedUser.KeyID,
 			}
 
-			req := newRequest(http.MethodPost, "/v1/assertions/challenges", unattestedUser.SessionToken, body)
+			req := newRequest(http.MethodPost, "/v1/assertions/challenges", attestedUnverifiedUser.SessionToken, body)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
 			Expect(w.Code).To(Equal(http.StatusBadRequest))

--- a/auth/service/api/v1/appvalidate_test.go
+++ b/auth/service/api/v1/appvalidate_test.go
@@ -269,21 +269,9 @@ var _ = Describe("App Validation", func() {
 	})
 
 	Describe("POST /v1/attestations/verifications", func() {
-		// Commented out tests right now because need an actual signed object
-		// to verify - will get once available from actual iOS device.
-		// It("succeeds on valid input", func() {
-		// 	body := &appvalidate.AttestationVerify{
-		// 		KeyID:             attestedUser.KeyID,
-		// 		Challenge:         challenge,
-		// 		AttestationObject: "YWJjZGVmZw==", // base64 encoded string of the binary CBOR data returned from iOS api.
-		// 	}
-
-		// 	req := newRequest(http.MethodPost, "/v1/attestations/verifications", attestedUser.SessionToken, body)
-		// 	w := httptest.NewRecorder()
-		// 	handler.ServeHTTP(w, req)
-		// 	Expect(w.Code).To(Equal(http.StatusNoContent))
-		// })
-
+		// Was going to use an actual signed object from apple
+		// but unfortunately the expiration time for that is only
+		// a few days so there is no integration test for that.
 		It("fails on attestation that is not base64 encoded", func() {
 			body := &appvalidate.AttestationVerify{
 				KeyID:       attestedUser.KeyID,

--- a/vendor/github.com/bas-d/appattest/assertion/assertion.go
+++ b/vendor/github.com/bas-d/appattest/assertion/assertion.go
@@ -1,0 +1,103 @@
+package assertion
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bas-d/appattest/authenticator"
+	"github.com/ugorji/go/codec"
+
+	"github.com/bas-d/appattest/utils"
+)
+
+type ClientData struct {
+	Challenge string `json:"challenge"`
+}
+
+type AuthenticatorAssertionResponse struct {
+	ClientDataJSON ClientData
+	RawClientData  utils.URLEncodedBase64 `json:"clientData"`
+	Assertion      utils.URLEncodedBase64 `json:"assertion"`
+}
+
+type Assertion struct {
+	AuthenticatorData    authenticator.AuthenticatorData
+	RawAuthenticatorData []byte `json:"authenticatorData"`
+	Signature            []byte `json:"signature"`
+}
+
+func (aar *AuthenticatorAssertionResponse) Verify(storedChallenge string, relyingPartyID string, previousCounter uint32, publicKey []byte) (uint32, error) {
+	a, err := aar.parse()
+	if err != nil {
+		return 0, err
+	}
+
+	// 1. Compute clientDataHash as the SHA256 hash of clientData.
+	clientDataHash := sha256.Sum256(aar.RawClientData)
+
+	// 2. Concatenate authenticatorData and clientDataHash and apply a SHA256 hash over the result to form nonce.
+	nonceData := append(a.RawAuthenticatorData, clientDataHash[:]...)
+	nonce := sha256.Sum256(nonceData)
+
+	// 3. Use the public key that you stored from the attestation object to verify that the assertion’s signature is valid for nonce.
+	x, y := elliptic.Unmarshal(elliptic.P256(), publicKey)
+	if x == nil {
+		return 0, utils.ErrParsingData.WithDetails("Failed to parse the public key")
+	}
+	pubkey := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     x,
+		Y:     y,
+	}
+	nonceHash := sha256.Sum256(nonce[:])
+	valid := ecdsa.VerifyASN1(pubkey, nonceHash[:], a.Signature)
+	if !valid {
+		return 0, utils.ErrAssertionSignature.WithDetails("Error validating the assertion signature.\n")
+	}
+
+	// 4. Compute the SHA256 hash of the client’s App ID, and verify that it matches the RP ID in the authenticator data.
+	rpIDHash := sha256.Sum256([]byte(relyingPartyID))
+	if !bytes.Equal(a.AuthenticatorData.RPIDHash[:], rpIDHash[:]) {
+		return 0, utils.ErrVerification.WithDetails(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x\n", a.AuthenticatorData.RPIDHash, rpIDHash))
+	}
+
+	// 5. Verify that the authenticator data’s counter value is greater than the value from the previous assertion, or greater than 0 on the first assertion.
+	if a.AuthenticatorData.Counter <= previousCounter {
+		return 0, utils.ErrVerification.WithDetails(fmt.Sprintf("Counter was not not greater than previous  %d\n", a.AuthenticatorData.Counter))
+	}
+
+	// 6. Verify that the challenge embedded in the client data matches the earlier challenge to the client.
+	if storedChallenge != aar.ClientDataJSON.Challenge {
+		err := utils.ErrChallengeMismatch.WithDetails("Error validating challenge")
+		return 0, err.WithDetails(fmt.Sprintf("Expected b Value: %#v\nReceived b: %#v\n", storedChallenge, aar.ClientDataJSON))
+	}
+
+	return a.AuthenticatorData.Counter, nil
+}
+
+func (aar *AuthenticatorAssertionResponse) parse() (*Assertion, error) {
+	var a Assertion
+
+	cborHandler := codec.CborHandle{}
+
+	// Decode the attestation data with unmarshalled auth data
+	err := codec.NewDecoderBytes(aar.Assertion, &cborHandler).Decode(&a)
+	if err != nil {
+		return nil, utils.ErrParsingData.WithDetails(err.Error())
+	}
+
+	err = a.AuthenticatorData.Unmarshal(a.RawAuthenticatorData)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding auth data: %v", err)
+	}
+
+	if err := json.Unmarshal(aar.RawClientData, &aar.ClientDataJSON); err != nil {
+		return nil, fmt.Errorf("error decoding client data: %v", err)
+	}
+
+	return &a, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,6 +62,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bas-d/appattest v0.1.0
 ## explicit; go 1.15
+github.com/bas-d/appattest/assertion
 github.com/bas-d/appattest/attestation
 github.com/bas-d/appattest/authenticator
 github.com/bas-d/appattest/utils


### PR DESCRIPTION
This commit adds app assertion verification. The user can get an assertion verified only after being attested and only after generating an assertion challenge. Once the assertion is verified, the user will be granted access to some private or sensitive information.