### PR TITLE
[BACK-2339] Replace existing with new provider session in oauth redirect

### DIFF
--- a/dexcom/client/client.go
+++ b/dexcom/client/client.go
@@ -16,7 +16,8 @@ import (
 )
 
 type Client struct {
-	client *oauthClient.Client
+	client        *oauthClient.Client
+	isSandboxData bool
 }
 
 func New(cfg *client.Config, tknSrcSrc oauth.TokenSourceSource) (*Client, error) {
@@ -29,13 +30,19 @@ func New(cfg *client.Config, tknSrcSrc oauth.TokenSourceSource) (*Client, error)
 	oauth2.RegisterBrokenAuthHeaderProvider(cfg.Address)
 
 	return &Client{
-		client: clnt,
+		client:        clnt,
+		isSandboxData: cfg.Address == "https://sandbox-api.dexcom.com",
 	}, nil
 }
 
 func (c *Client) GetCalibrations(ctx context.Context, startTime time.Time, endTime time.Time, tokenSource oauth.TokenSource) (*dexcom.CalibrationsResponse, error) {
 	calibrationsResponse := &dexcom.CalibrationsResponse{}
-	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL("p", "v2", "users", "self", "calibrations"), calibrationsResponse, tokenSource); err != nil {
+	paths := []string{"p", "v2", "users", "self", "calibrations"}
+	if c.isSandboxData {
+		paths = paths[1:]
+	}
+
+	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL(paths...), calibrationsResponse, tokenSource); err != nil {
 		return nil, errors.Wrap(err, "unable to get calibrations")
 	}
 
@@ -43,8 +50,13 @@ func (c *Client) GetCalibrations(ctx context.Context, startTime time.Time, endTi
 }
 
 func (c *Client) GetDevices(ctx context.Context, startTime time.Time, endTime time.Time, tokenSource oauth.TokenSource) (*dexcom.DevicesResponse, error) {
-	devicesResponse := &dexcom.DevicesResponse{}
-	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL("p", "v2", "users", "self", "devices"), devicesResponse, tokenSource); err != nil {
+	devicesResponse := &dexcom.DevicesResponse{IsSandboxData: c.isSandboxData}
+	paths := []string{"p", "v2", "users", "self", "devices"}
+	if c.isSandboxData {
+		paths = paths[1:]
+	}
+
+	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL(paths...), devicesResponse, tokenSource); err != nil {
 		return nil, errors.Wrap(err, "unable to get devices")
 	}
 
@@ -53,7 +65,12 @@ func (c *Client) GetDevices(ctx context.Context, startTime time.Time, endTime ti
 
 func (c *Client) GetEGVs(ctx context.Context, startTime time.Time, endTime time.Time, tokenSource oauth.TokenSource) (*dexcom.EGVsResponse, error) {
 	egvsResponse := &dexcom.EGVsResponse{}
-	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL("p", "v2", "users", "self", "egvs"), egvsResponse, tokenSource); err != nil {
+	paths := []string{"p", "v2", "users", "self", "egvs"}
+	if c.isSandboxData {
+		paths = paths[1:]
+	}
+
+	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL(paths...), egvsResponse, tokenSource); err != nil {
 		return nil, errors.Wrap(err, "unable to get egvs")
 	}
 
@@ -62,7 +79,12 @@ func (c *Client) GetEGVs(ctx context.Context, startTime time.Time, endTime time.
 
 func (c *Client) GetEvents(ctx context.Context, startTime time.Time, endTime time.Time, tokenSource oauth.TokenSource) (*dexcom.EventsResponse, error) {
 	eventsResponse := &dexcom.EventsResponse{}
-	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL("p", "v2", "users", "self", "events"), eventsResponse, tokenSource); err != nil {
+	paths := []string{"p", "v2", "users", "self", "events"}
+	if c.isSandboxData {
+		paths = paths[1:]
+	}
+
+	if err := c.sendDexcomRequest(ctx, startTime, endTime, "GET", c.client.ConstructURL(paths...), eventsResponse, tokenSource); err != nil {
 		return nil, errors.Wrap(err, "unable to get events")
 	}
 

--- a/dexcom/client/client.go
+++ b/dexcom/client/client.go
@@ -29,9 +29,14 @@ func New(cfg *client.Config, tknSrcSrc oauth.TokenSourceSource) (*Client, error)
 	// NOTE: Dexcom authorization server does not support HTTP Basic authentication
 	oauth2.RegisterBrokenAuthHeaderProvider(cfg.Address)
 
+	isSandboxData := false
+	if cfg != nil && cfg.Address == "https://sandbox-api.dexcom.com" {
+		isSandboxData = true
+	}
+
 	return &Client{
 		client:        clnt,
-		isSandboxData: cfg.Address == "https://sandbox-api.dexcom.com",
+		isSandboxData: isSandboxData,
 	}, nil
 }
 

--- a/dexcom/device.go
+++ b/dexcom/device.go
@@ -45,7 +45,8 @@ func DeviceTransmitterGenerations() []string {
 }
 
 type DevicesResponse struct {
-	Devices *Devices `json:"devices,omitempty"`
+	Devices       *Devices `json:"devices,omitempty"`
+	IsSandboxData bool
 }
 
 func ParseDevicesResponse(parser structure.ObjectParser) *DevicesResponse {
@@ -67,7 +68,9 @@ func (d *DevicesResponse) Parse(parser structure.ObjectParser) {
 
 func (d *DevicesResponse) Validate(validator structure.Validator) {
 	if devicesValidator := validator.WithReference("devices"); d.Devices != nil {
-		d.Devices.Validate(devicesValidator)
+		if !d.IsSandboxData {
+			d.Devices.Validate(devicesValidator)
+		}
 	} else {
 		devicesValidator.ReportError(structureValidator.ErrorValueNotExists())
 	}

--- a/dexcom/device.go
+++ b/dexcom/device.go
@@ -46,7 +46,7 @@ func DeviceTransmitterGenerations() []string {
 
 type DevicesResponse struct {
 	Devices       *Devices `json:"devices,omitempty"`
-	IsSandboxData bool
+	IsSandboxData bool     `json:"isSandboxData,omitempty"`
 }
 
 func ParseDevicesResponse(parser structure.ObjectParser) *DevicesResponse {

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -363,7 +363,7 @@ func (t *TaskRunner) updateDeviceHash(device *dexcom.Device) bool {
 		t.deviceHashes = map[string]string{}
 	}
 
-	if t.deviceHashes[*device.SerialNumber] != deviceHash {
+	if device.SerialNumber != nil && t.deviceHashes[*device.SerialNumber] != deviceHash {
 		t.deviceHashes[*device.SerialNumber] = deviceHash
 		return true
 	}


### PR DESCRIPTION
See [BACK-2339]

- Oauth redirect no longer returns early with error message if a user has a previous mathcing provider session.  This was preventing reconnection requests from the clinic to complete.  Now, the current data source is put into a `disconnected` state, and the current associated `task` and `provider_session` are replaced with new ones.  The method called here to do this is the same one that gets called if a patient clicks 'Disconnect' and then reconnects from their profile page, which was the current way we handle reconnection needs (this of course can't be done in the case of custodial users, which is why this is needed)
- Added a check on the dexcom client address to determine if we're accessing sandbox data, and updating the paths accordingly when that is the case.  Also, skips some device validation that fails when accessing the sandbox data. 

[BACK-2339]: https://tidepool.atlassian.net/browse/BACK-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ