### PR TITLE
[BACK-2328] dexcom validation updates

### DIFF
--- a/dexcom/alert.go
+++ b/dexcom/alert.go
@@ -158,22 +158,22 @@ func (a *AlertSchedules) Parse(parser structure.ArrayParser) {
 }
 
 func (a *AlertSchedules) Validate(validator structure.Validator) {
-	if len(*a) == 0 {
-		validator.ReportError(structureValidator.ErrorValueEmpty())
-	}
-	var hasDefault bool
-	for index, alertSchedule := range *a {
-		if alertScheduleValidator := validator.WithReference(strconv.Itoa(index)); alertSchedule != nil {
-			alertSchedule.Validate(alertScheduleValidator)
-			if alertSchedule.IsDefault() {
-				if !hasDefault {
-					hasDefault = true
-				} else {
-					alertScheduleValidator.ReportError(structureValidator.ErrorValueDuplicate())
+	// it is valid for a receiver to send an empty list
+	if len(*a) != 0 {
+		var hasDefault bool
+		for index, alertSchedule := range *a {
+			if alertScheduleValidator := validator.WithReference(strconv.Itoa(index)); alertSchedule != nil {
+				alertSchedule.Validate(alertScheduleValidator)
+				if alertSchedule.IsDefault() {
+					if !hasDefault {
+						hasDefault = true
+					} else {
+						alertScheduleValidator.ReportError(structureValidator.ErrorValueDuplicate())
+					}
 				}
+			} else {
+				alertScheduleValidator.ReportError(structureValidator.ErrorValueNotExists())
 			}
-		} else {
-			alertScheduleValidator.ReportError(structureValidator.ErrorValueNotExists())
 		}
 	}
 }
@@ -660,19 +660,3 @@ func ErrorValueStringAsAlertScheduleSettingsTimeNotValid(value string) error {
 }
 
 var alertScheduleSettingsTimeExpression = regexp.MustCompile("^([0-9][0-9]):([0-9][0-9])$")
-
-func generateFloatRange(min float64, max float64, step float64) []float64 {
-	r := []float64{}
-	for v := min; v <= max; v += step {
-		r = append(r, v)
-	}
-	return r
-}
-
-func generateIntegerRange(min int, max int, step int) []int {
-	r := []int{}
-	for v := min; v <= max; v += step {
-		r = append(r, v)
-	}
-	return r
-}

--- a/dexcom/alert_test.go
+++ b/dexcom/alert_test.go
@@ -269,4 +269,16 @@ var _ = Describe("Alert", func() {
 			Entry("is ErrorValueStringAsAlertScheduleSettingsTimeNotValid with non-empty string", dexcom.ErrorValueStringAsAlertScheduleSettingsTimeNotValid("XX:XX"), "value-not-valid", "value is not valid", `value "XX:XX" is not valid as alert schedule settings time`),
 		)
 	})
+	Context("AlertSchedules can be", func() {
+		DescribeTable("empty",
+			func(value *dexcom.AlertSchedules) {
+				Expect(value).ToNot(BeNil())
+				testValidator := structureValidator.New()
+				value.Validate(testValidator)
+				Expect(testValidator.HasError()).To(BeFalse())
+				Expect(len(*value)).To(Equal(0))
+			},
+			Entry("valid if empty", dexcom.NewAlertSchedules()),
+		)
+	})
 })

--- a/dexcom/dexcom.go
+++ b/dexcom/dexcom.go
@@ -24,7 +24,9 @@ func TransmitterIDValidator(value string, errorReporter structure.ErrorReporter)
 
 func ValidateTransmitterID(value string) error {
 	if value == "" {
-		return structureValidator.ErrorValueEmpty()
+		// dexcom started sending empty transmitter id on a very small portion of users which recently were created
+		// and is also no longer sent from g7
+		return nil
 	} else if !transmitterIDExpression.MatchString(value) {
 		return ErrorValueStringAsTransmitterIDNotValid(value)
 	}

--- a/dexcom/dexcom_test.go
+++ b/dexcom/dexcom_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/tidepool-org/platform/dexcom"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	structureTest "github.com/tidepool-org/platform/structure/test"
-	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
 )
 
@@ -32,9 +31,9 @@ var _ = Describe("Dexcom", func() {
 				errorsTest.ExpectEqual(errorReporter.Error(), expectedErrors...)
 				errorsTest.ExpectEqual(dexcom.ValidateTransmitterID(value), expectedErrors...)
 			},
-			Entry("is an empty string", "", structureValidator.ErrorValueEmpty()),
-			Entry("has string length out of range (lower)", "0123", dexcom.ErrorValueStringAsTransmitterIDNotValid("0123")),
+			Entry("is an empty string", ""),
 			Entry("has string length in range", test.RandomStringFromRangeAndCharset(5, 6, test.CharsetNumeric+test.CharsetUppercase)),
+			Entry("has string length out of range (lower)", "0123", dexcom.ErrorValueStringAsTransmitterIDNotValid("0123")),
 			Entry("has string length out of range (upper)", "0123456", dexcom.ErrorValueStringAsTransmitterIDNotValid("0123456")),
 			Entry("has lowercase characters", "abcdef", dexcom.ErrorValueStringAsTransmitterIDNotValid("abcdef")),
 			Entry("has symbols", "$%^&*(", dexcom.ErrorValueStringAsTransmitterIDNotValid("$%^&*(")),


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/BACK-2328

- remove validation for dexcom device ID if its not sent
- allow AlertSchedules to be empty
- remove dead code 