### PR TITLE
BACK-2328 allow for 12hr time format

### DIFF
--- a/dexcom/alert.go
+++ b/dexcom/alert.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
+	"time"
 
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	"github.com/tidepool-org/platform/errors"
@@ -627,15 +629,17 @@ func (a *AlertSetting) validateUrgentLowSoon(validator structure.Validator) {
 }
 
 func ParseAlertScheduleSettingsTime(value string) (int, int, bool) {
-	if submatch := alertScheduleSettingsTimeExpression.FindStringSubmatch(value); len(submatch) != 3 {
-		return 0, 0, false
-	} else if hour, hourErr := strconv.Atoi(submatch[1]); hourErr != nil || hour < 0 || hour > 23 {
-		return 0, 0, false
-	} else if minute, minuteErr := strconv.Atoi(submatch[2]); minuteErr != nil || minute < 0 || minute > 59 {
-		return 0, 0, false
-	} else {
-		return hour, minute, true
+	timeFormat := "15:04"
+	value = strings.ToUpper(value)
+	if strings.Contains(value, "AM") || strings.Contains(value, "PM") {
+		timeFormat = "3:04PM"
+		value = strings.ReplaceAll(value, " ", "")
 	}
+	t, err := time.Parse(timeFormat, value)
+	if err != nil {
+		return 0, 0, false
+	}
+	return t.Hour(), t.Minute(), true
 }
 
 func IsValidAlertScheduleSettingsTime(value string) bool {

--- a/dexcom/alert_test.go
+++ b/dexcom/alert_test.go
@@ -231,13 +231,19 @@ var _ = Describe("Alert", func() {
 			},
 			Entry("is an empty string", "", 0, 0, false),
 			Entry("contains non-numbers", "a$: b", 0, 0, false),
-			Entry("does not exactly match format", "1:23", 0, 0, false),
+			Entry("does not exactly match format", "1;23", 0, 0, false),
 			Entry("has hour in range (lower)", "00:00", 0, 0, true),
 			Entry("has hour in range (upper)", "23:59", 23, 59, true),
 			Entry("has hour out of range (upper)", "24:00", 0, 0, false),
 			Entry("has minute in range (lower)", "00:00", 0, 0, true),
 			Entry("has minute in range (upper)", "23:59", 23, 59, true),
 			Entry("has minute out of range (upper)", "23:60", 0, 0, false),
+
+			Entry("is 12hr format with AM postfix", "8:00 Am", 8, 0, true),
+			Entry("is 12hr format with AM postfix", "08:00 aM", 8, 0, true),
+			Entry("is 12hr format with PM postfix", "9:00 Pm", 21, 0, true),
+			Entry("is 12hr format with PM postfix and extra padding", "09:00   pm", 21, 0, true),
+			Entry("is 12hr format with minutes", "11:59   pM", 23, 59, true),
 		)
 	})
 
@@ -252,7 +258,7 @@ var _ = Describe("Alert", func() {
 			},
 			Entry("is an empty string", "", structureValidator.ErrorValueEmpty()),
 			Entry("contains non-numbers", "a$: b", dexcom.ErrorValueStringAsAlertScheduleSettingsTimeNotValid("a$: b")),
-			Entry("does not exactly match format", "1:23", dexcom.ErrorValueStringAsAlertScheduleSettingsTimeNotValid("1:23")),
+			Entry("does not exactly match format", "1;23", dexcom.ErrorValueStringAsAlertScheduleSettingsTimeNotValid("1;23")),
 			Entry("has hour in range (lower)", "00:00"),
 			Entry("has hour in range (upper)", "23:59"),
 			Entry("has hour out of range (upper)", "24:00", dexcom.ErrorValueStringAsAlertScheduleSettingsTimeNotValid("24:00")),


### PR DESCRIPTION
validation was failing with times such as `8:00 AM` and `9:00 PM` being sent

- allow for existing 24hr format
- including 12hr format (am or pm)
    - ignore case and allow `am` or `AM` or `aM`
    - allow extra spacing between time and postfix  `8:00 AM` or `8:00   AM`