### PR TITLE
Update tools container to fix build failures

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -16,7 +16,8 @@ CMD ["make", "service-start"]
 
 # Production
 FROM mongo:6.0.5 AS production
-ENV ENV="/home/tidepool/.bashrc" DEBIAN_FRONTEND="noninteractive"
+# this statically set $HOME is non-ideal, but is to combat it being hardcoded to /data/db upstream
+ENV HOME="/home/tidepool/" DEBIAN_FRONTEND="noninteractive"
 RUN apt -y update && \
     apt -y install ca-certificates tzdata && \
     adduser --disabled-password tidepool

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -15,7 +15,7 @@ RUN ["make", "service-build"]
 CMD ["make", "service-start"]
 
 # Production
-FROM mongo:4.2.14 AS production
+FROM mongo:6.0.5 AS production
 ENV ENV="/home/tidepool/.bashrc" DEBIAN_FRONTEND="noninteractive"
 RUN apt -y update && \
     apt -y install ca-certificates tzdata && \

--- a/tools/ashrc
+++ b/tools/ashrc
@@ -1,7 +1,7 @@
 # NOTE: admin and readonly usernames are assembled by attaching mongo-*-readonly and mongo-*-admin around the last dashed term in the service TIDEPOOL_STORE_USERNAME
 
-alias mongo=$'/usr/bin/mongo "${TIDEPOOL_STORE_SCHEME}://${TIDEPOOL_STORE_ADDRESSES}/${TIDEPOOL_STORE_DATABASE}?${TIDEPOOL_STORE_OPT_PARAMS}" $( [ "$TIDEPOOL_STORE_TLS" == "true" ] && echo "--tls" ) --username "mongo-${TIDEPOOL_STORE_USERNAME##*-}-readonly" ${TIDEPOOL_STORE_PASSWORD:+-p "$TIDEPOOL_STORE_PASSWORD"}'
+alias mongo=$'/usr/bin/mongosh "${TIDEPOOL_STORE_SCHEME}://${TIDEPOOL_STORE_ADDRESSES}/${TIDEPOOL_STORE_DATABASE}?${TIDEPOOL_STORE_OPT_PARAMS}" $( [ "$TIDEPOOL_STORE_TLS" == "true" ] && echo "--tls" ) --username "mongo-${TIDEPOOL_STORE_USERNAME##*-}-readonly" ${TIDEPOOL_STORE_PASSWORD:+-p "$TIDEPOOL_STORE_PASSWORD"}'
 
-alias mongow=$'/usr/bin/mongo "${TIDEPOOL_STORE_SCHEME}://${TIDEPOOL_STORE_ADDRESSES}/${TIDEPOOL_STORE_DATABASE}?${TIDEPOOL_STORE_OPT_PARAMS}" $( [ "$TIDEPOOL_STORE_TLS" == "true" ] && echo "--tls" ) --username "$TIDEPOOL_STORE_USERNAME -p'
+alias mongow=$'/usr/bin/mongosh "${TIDEPOOL_STORE_SCHEME}://${TIDEPOOL_STORE_ADDRESSES}/${TIDEPOOL_STORE_DATABASE}?${TIDEPOOL_STORE_OPT_PARAMS}" $( [ "$TIDEPOOL_STORE_TLS" == "true" ] && echo "--tls" ) --username "$TIDEPOOL_STORE_USERNAME -p'
 
-alias mongoa=$'/usr/bin/mongo "${TIDEPOOL_STORE_SCHEME}://${TIDEPOOL_STORE_ADDRESSES}/${TIDEPOOL_STORE_DATABASE}?${TIDEPOOL_STORE_OPT_PARAMS}" $( [ "$TIDEPOOL_STORE_TLS" == "true" ] && echo "--tls" ) --username "mongo-${TIDEPOOL_STORE_USERNAME##*-}-admin" -p'
+alias mongoa=$'/usr/bin/mongosh "${TIDEPOOL_STORE_SCHEME}://${TIDEPOOL_STORE_ADDRESSES}/${TIDEPOOL_STORE_DATABASE}?${TIDEPOOL_STORE_OPT_PARAMS}" $( [ "$TIDEPOOL_STORE_TLS" == "true" ] && echo "--tls" ) --username "mongo-${TIDEPOOL_STORE_USERNAME##*-}-admin" -p'


### PR DESCRIPTION
Since we also need to move to mongodb 6.x, and the clientside mongosh tools will work fine against older versions, this commit moves us to 6.x, instead of just the latest 4.x.