### PR TITLE
stopgap for when no units sent

### DIFF
--- a/dexcom/egv.go
+++ b/dexcom/egv.go
@@ -5,6 +5,7 @@ import (
 
 	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/data/types/settings/cgm"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -185,7 +186,13 @@ func (e *EGV) Parse(parser structure.ObjectParser) {
 	e.ID = parser.String("recordId")
 	e.SystemTime = TimeFromString(parser.String("systemTime"))
 	e.DisplayTime = TimeFromString(parser.String("displayTime"))
-	e.Unit = parser.String("unit")
+	// NOTE: currently we are finding that g7 data occasionally doesn't have the required units
+	// data. This is a workaround until that issue is resolved
+	unitVal := parser.String("unit")
+	if unitVal == nil {
+		unitVal = pointer.FromString(EGVUnitMgdL)
+	}
+	e.Unit = unitVal
 	e.RateUnit = parser.String("rateUnit")
 	e.Value = parser.Float64("value")
 	e.Status = parser.String("status")


### PR DESCRIPTION
From support 

> OK, looks like there are 17 users who are impacted by this. They are all showing the same error: records of type bloodGlucose are coming in without a unit 