### PR TITLE
Don't assume that 127.0.0.[2-255] aren't in use.

### DIFF
--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -20,6 +20,13 @@ var _ = Describe("Mongo", func() {
 		var config *storeStructuredMongo.Config
 		var store *storeStructuredMongo.Store
 		var repository *storeStructuredMongo.Repository
+		// unusedIPs for testing error paths. These IPs are defined in
+		// TEST-NET-3, for documentation and examples, so in theory they
+		// should be unused. Details at:
+		// https://datatracker.ietf.org/doc/html/rfc5737
+		unusedIPs := []string{
+			"203.0.113.2", "203.0.113.3",
+		}
 
 		BeforeEach(func() {
 			config = storeStructuredMongoTest.NewConfig()
@@ -49,7 +56,7 @@ var _ = Describe("Mongo", func() {
 			})
 
 			It("returns an error if the addresses are not reachable", func() {
-				config.Addresses = []string{"127.0.0.2", "127.0.0.3"}
+				config.Addresses = unusedIPs
 				var err error
 				store, err = storeStructuredMongo.NewStore(config)
 				Expect(store).ToNot(BeNil())
@@ -60,7 +67,7 @@ var _ = Describe("Mongo", func() {
 			})
 
 			It("returns the correct status if the addresses are not reachable", func() {
-				config.Addresses = []string{"127.0.0.2", "127.0.0.3"}
+				config.Addresses = unusedIPs
 				var err error
 				store, err = storeStructuredMongo.NewStore(config)
 				Expect(store).ToNot(BeNil())


### PR DESCRIPTION
A pair of tests were testing error paths for non-responsive hosts. To do so, they were attempting to connect to 127.0.0.2 and 127.0.0.3. However, some hosts are configured to respond to 127.0.0.0/8 as localhost, and with such a configuration, these tests could fail.

One alternative is to configure mongodb to bind specifically to 127.0.0.1. Another would be a test helper that tests the expected IP to make sure nothing responds before running the test, possibly skipping it if something responds (or trying another address?) But this solution seems like the simplest, easiest change to make, that covers the most possible configurations.