### PR TITLE
[BACK-1758] Single separate writes to deviceData and deviceDataSets collections.

### DIFF
--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -546,12 +546,6 @@ var _ = Describe("Mongo", func() {
 						"Name":       Equal("OriginId"),
 					}),
 					MatchFields(IgnoreExtras, Fields{
-						"Key":                     Equal(storeStructuredMongoTest.MakeKeySlice("uploadId")),
-						"Unique":                  Equal(true),
-						"Name":                    Equal("UniqueUploadId"),
-						"PartialFilterExpression": Equal(bson.D{{Key: "type", Value: "upload"}}),
-					}),
-					MatchFields(IgnoreExtras, Fields{
 						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("uploadId", "type", "-deletedTime", "_active")),
 						"Background": Equal(true),
 						"Name":       Equal("UploadId"),
@@ -926,7 +920,7 @@ var _ = Describe("Mongo", func() {
 						})
 
 						AfterEach(func() {
-							logger.AssertDebug("DatumRepository.UpdateDataSet", log.Fields{"id": id, "update": update})
+							logger.AssertDebug("DataSetRepository.UpdateDataSet", log.Fields{"id": id, "update": update})
 						})
 
 						Context("with updates", func() {
@@ -945,7 +939,7 @@ var _ = Describe("Mongo", func() {
 								update.Time = pointer.FromTime(newTime)
 								_, err = repository.UpdateDataSet(ctx, id, update)
 								Expect(err).ToNot(HaveOccurred())
-								ValidateDataSetWithModifiedThreshold(collection, bson.M{"uploadId": dataSet.UploadID}, bson.M{}, time.Second, dataSet)
+								ValidateDataSetWithModifiedThreshold(dataSetCollection, bson.M{"uploadId": dataSet.UploadID}, bson.M{}, time.Second, dataSet)
 							})
 						})
 
@@ -976,12 +970,7 @@ var _ = Describe("Mongo", func() {
 							ValidateDataSet(dataSetCollection, bson.M{}, bson.M{}, dataSetExistingOther, dataSetExistingOne, dataSetExistingTwo, result)
 							ValidateDataSet(dataSetCollection, bson.M{"modifiedTime": bson.M{"$exists": true}}, bson.M{}, dataSetExistingOther, dataSetExistingOne, dataSetExistingTwo, result)
 
-							// Updating an existing dataset that lives in the
-							// previous deviceData collection via
-							// DatumRepository should also call
-							// DataSetRepository.upsertDataSet to upsert the
-							// data set into the new deviceDataSets repo
-							logger.AssertDebug("DataSetRepository.upsertDataSet", log.Fields{"id": id, "update": update})
+							logger.AssertDebug("DataSetRepository.UpdateDataSet", log.Fields{"id": id, "update": update})
 						})
 					})
 				})
@@ -1374,7 +1363,7 @@ var _ = Describe("Mongo", func() {
 										selectedDataSetData.SetActive(false)
 										selectedDataSetData.SetModifiedTime(pointer.FromTime(time.Now().UTC().Truncate(time.Millisecond)))
 										ValidateDataSetDataWithModifiedThreshold(collection, bson.M{"_active": false, "uploadId": dataSet.UploadID}, bson.M{"archivedTime": 0}, time.Second, selectedDataSetData)
-										ValidateDataSet(collection, bson.M{"uploadId": dataSet.UploadID}, bson.M{}, dataSet)
+										ValidateDataSet(dataSetCollection, bson.M{"uploadId": dataSet.UploadID}, bson.M{}, dataSet)
 									})
 
 									It("succeeds with no changes when the data set user id is different", func() {


### PR DESCRIPTION
This commit removes dual reading and writing from the deviceDataSets and deviceData collection and instead does a single collection read and write for datum (colleciton deviceData) and uploads (collection deviceDataSets). This is intended to be done AFTER migration of all type="upload" from the deviceData to the deviceDataSets collection.