### PR TITLE
SNYK ignore known issue for 6 months

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,3 +9,5 @@ jobs:
       uses: snyk/actions/golang@master
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        args: snyk ignore --id=SNYK-GOLANG-GITHUBCOMDISINTEGRATIONIMAGING-5880692 --expiry=2024-03-12 --policy-path=.snyk


### PR DESCRIPTION
see https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDISINTEGRATIONIMAGING-5880692

in an effort to keep the build clean (or before we potential remove the imaging service) this ignores the above issue for now ... well for the next 6 mths anyway 