### PR TITLE
Tide-v1 release bugfixes

### DIFF
--- a/data/store/mongo/mongo_summary.go
+++ b/data/store/mongo/mongo_summary.go
@@ -29,9 +29,18 @@ func (d *SummaryRepository) EnsureIndexes() error {
 		{
 			Keys: bson.D{
 				{Key: "dates.outdatedSince", Value: 1},
+				{Key: "type", Value: 1},
 			},
 			Options: options.Index().
-				SetName("DatesOutdatedSince"),
+				SetName("OutdatedSince"),
+		},
+		{
+			Keys: bson.D{
+				{Key: "config.schemaVersion", Value: 1},
+				{Key: "type", Value: 1},
+			},
+			Options: options.Index().
+				SetName("SchemaVersion"),
 		},
 	})
 }

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -587,9 +587,14 @@ var _ = Describe("Mongo", func() {
 						"Name":       Equal("UserIDTypeUnique"),
 					}),
 					MatchFields(IgnoreExtras, Fields{
-						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("dates.outdatedSince")),
+						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("dates.outdatedSince", "type")),
 						"Background": Equal(false),
-						"Name":       Equal("DatesOutdatedSince"),
+						"Name":       Equal("OutdatedSince"),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("config.schemaVersion", "type")),
+						"Background": Equal(false),
+						"Name":       Equal("SchemaVersion"),
 					}),
 				))
 			})

--- a/task/summary/migrationrunner.go
+++ b/task/summary/migrationrunner.go
@@ -173,29 +173,29 @@ func (t *MigrationTaskRunner) Run(ctx context.Context, batch int) error {
 	pagination := page.NewPagination()
 	pagination.Size = batch
 
-	t.logger.Info("Searching for User CGM Summaries requiring Update")
+	t.logger.Info("Searching for User CGM Summaries requiring Migration")
 	outdatedCGMSummaryUserIDs, err := t.dataClient.GetMigratableUserIDs(t.context, "cgm", pagination)
 	if err != nil {
 		return err
 	}
 
-	t.logger.Info("Searching for User BGM Summaries requiring Update")
+	t.logger.Info("Searching for User BGM Summaries requiring Migration")
 	outdatedBGMSummaryUserIDs, err := t.dataClient.GetMigratableUserIDs(t.context, "bgm", pagination)
 	if err != nil {
 		return err
 	}
 
-	t.logger.Debug("Starting User CGM Summary Update")
+	t.logger.Debug("Starting User CGM Summary Migration")
 	if err := t.UpdateCGMSummaries(outdatedCGMSummaryUserIDs); err != nil {
 		return err
 	}
-	t.logger.Debug("Finished User CGM Summary Update")
+	t.logger.Debug("Finished User CGM Summary Migration")
 
-	t.logger.Debug("Starting User BGM Summary Update")
+	t.logger.Debug("Starting User BGM Summary Migration")
 	if err := t.UpdateBGMSummaries(outdatedBGMSummaryUserIDs); err != nil {
 		return err
 	}
-	t.logger.Debug("Finished User BGM Summary Update")
+	t.logger.Debug("Finished User BGM Summary Migration")
 
 	return nil
 }


### PR DESCRIPTION
Adjusts indexes to better match summary queries
Also fixes the processing loop that occurs when a summary is being migrated, but user has no active data within the last 2 years.