### PR TITLE
add basic Dexcom API metrics

### DIFF
--- a/blob/client/client.go
+++ b/blob/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/blob"
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/platform"
 	"github.com/tidepool-org/platform/request"
@@ -175,7 +176,7 @@ func (c *Client) GetContent(ctx context.Context, id string) (*blob.Content, erro
 	}
 
 	url := c.client.ConstructURL("v1", "blobs", id, "content")
-	headersInspector := request.NewHeadersInspector()
+	headersInspector := request.NewHeadersInspector(log.LoggerFromContext(ctx))
 	body, err := c.client.RequestStream(ctx, http.MethodGet, url, nil, nil, headersInspector)
 	if err != nil {
 		if request.IsErrorResourceNotFound(err) {

--- a/client/client.go
+++ b/client/client.go
@@ -80,8 +80,8 @@ func (c *Client) RequestStreamWithHTTPClient(ctx context.Context, method string,
 
 	for _, inspector := range inspectors {
 		if err = inspector.InspectResponse(res); err != nil {
-			drainAndClose(res.Body)
-			return nil, err
+			log.LoggerFromContext(ctx).WithError(err).Warn("inspecting response")
+			continue
 		}
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -79,17 +79,14 @@ func (c *Client) RequestStreamWithHTTPClient(ctx context.Context, method string,
 	}
 
 	for _, inspector := range inspectors {
-		if err = inspector.InspectResponse(res); err != nil {
-			log.LoggerFromContext(ctx).WithError(err).Warn("inspecting response")
-			continue
-		}
+		inspector.InspectResponse(res)
 	}
 
 	return c.handleResponse(ctx, res, req)
 }
 
 func (c *Client) RequestDataWithHTTPClient(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}, responseBody interface{}, inspectors []request.ResponseInspector, httpClient *http.Client) error {
-	headerInspector := request.NewHeadersInspector()
+	headerInspector := request.NewHeadersInspector(log.LoggerFromContext(ctx))
 	body, err := c.RequestStreamWithHTTPClient(ctx, method, url, mutators, requestBody, append(inspectors, headerInspector), httpClient)
 	if err != nil {
 		return err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -336,10 +336,10 @@ var _ = Describe("Client", func() {
 					errorInspector.AssertOutputsEmpty()
 				})
 
-				It("returns error if inspector returns an error", func() {
+				It("doesn't return an error if inspector returns an error", func() {
 					reader, err = clnt.RequestStreamWithHTTPClient(ctx, method, url, mutators, nil, append(inspectors, errorInspector), httpClient)
-					Expect(err).To(MatchError(responseErr))
-					Expect(reader).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(io.ReadAll(reader)).To(Equal([]byte(responseString)))
 					Expect(server.ReceivedRequests()).To(HaveLen(1))
 				})
 			})
@@ -738,11 +738,11 @@ var _ = Describe("Client", func() {
 					errorInspector.AssertOutputsEmpty()
 				})
 
-				It("returns error if inspector returns an error", func() {
-					Expect(clnt.RequestDataWithHTTPClient(ctx, method, url, mutators, nil, responseBody, append(inspectors, errorInspector), httpClient)).To(MatchError(responseErr))
+				It("doesn't return an error if inspector returns an error", func() {
+					Expect(clnt.RequestDataWithHTTPClient(ctx, method, url, mutators, nil, responseBody, append(inspectors, errorInspector), httpClient)).ToNot(HaveOccurred())
 					Expect(server.ReceivedRequests()).To(HaveLen(1))
 					Expect(responseBody).ToNot(BeNil())
-					Expect(responseBody.Response).To(BeEmpty())
+					Expect(responseBody.Response).To(Equal(responseString))
 				})
 			})
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Client", func() {
 			requestString = test.RandomStringFromRangeAndCharset(0, 32, test.CharsetText)
 			requestBody = &RequestBody{Request: requestString}
 			responseString = test.RandomStringFromRangeAndCharset(0, 32, test.CharsetText)
-			inspectors = []request.ResponseInspector{request.NewHeadersInspector()}
+			inspectors = []request.ResponseInspector{request.NewHeadersInspector(log.LoggerFromContext(ctx))}
 			httpClient = http.DefaultClient
 		})
 
@@ -334,13 +334,6 @@ var _ = Describe("Client", func() {
 
 				AfterEach(func() {
 					errorInspector.AssertOutputsEmpty()
-				})
-
-				It("doesn't return an error if inspector returns an error", func() {
-					reader, err = clnt.RequestStreamWithHTTPClient(ctx, method, url, mutators, nil, append(inspectors, errorInspector), httpClient)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(io.ReadAll(reader)).To(Equal([]byte(responseString)))
-					Expect(server.ReceivedRequests()).To(HaveLen(1))
 				})
 			})
 
@@ -736,13 +729,6 @@ var _ = Describe("Client", func() {
 
 				AfterEach(func() {
 					errorInspector.AssertOutputsEmpty()
-				})
-
-				It("doesn't return an error if inspector returns an error", func() {
-					Expect(clnt.RequestDataWithHTTPClient(ctx, method, url, mutators, nil, responseBody, append(inspectors, errorInspector), httpClient)).ToNot(HaveOccurred())
-					Expect(server.ReceivedRequests()).To(HaveLen(1))
-					Expect(responseBody).ToNot(BeNil())
-					Expect(responseBody.Response).To(Equal(responseString))
 				})
 			})
 

--- a/dexcom/client/client.go
+++ b/dexcom/client/client.go
@@ -132,13 +132,12 @@ func (c *Client) sendRequest(ctx context.Context, method, url string, mutators [
 type promDexcomInstrumentor struct{}
 
 // InspectResponse implements request.ResponseInspector.
-func (i *promDexcomInstrumentor) InspectResponse(r *http.Response) error {
+func (i *promDexcomInstrumentor) InspectResponse(r *http.Response) {
 	labels := prometheus.Labels{
 		"code": strconv.Itoa(r.StatusCode),
 		"path": r.Request.URL.Path,
 	}
 	promDexcomCounter.With(labels).Inc()
-	return nil
 }
 
 // promDexcomCounter instruments the Dexcom API paths and status codes called.

--- a/dexcom/client/client.go
+++ b/dexcom/client/client.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 	"time"
 
-	"golang.org/x/oauth2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/tidepool-org/platform/client"
 	"github.com/tidepool-org/platform/dexcom"
@@ -25,9 +28,6 @@ func New(cfg *client.Config, tknSrcSrc oauth.TokenSourceSource) (*Client, error)
 	if err != nil {
 		return nil, err
 	}
-
-	// NOTE: Dexcom authorization server does not support HTTP Basic authentication
-	oauth2.RegisterBrokenAuthHeaderProvider(cfg.Address)
 
 	isSandboxData := false
 	if cfg != nil && cfg.Address == "https://sandbox-api.dexcom.com" {
@@ -101,10 +101,10 @@ func (c *Client) sendDexcomRequest(ctx context.Context, startTime time.Time, end
 		"endDate":   endTime.UTC().Format(dexcom.TimeFormat),
 	})
 
-	err := c.client.SendOAuthRequest(ctx, method, url, nil, nil, responseBody, tokenSource)
+	err := c.sendRequest(ctx, method, url, nil, nil, responseBody, tokenSource)
 	if oauth.IsAccessTokenError(err) {
 		tokenSource.ExpireToken()
-		err = c.client.SendOAuthRequest(ctx, method, url, nil, nil, responseBody, tokenSource)
+		err = c.sendRequest(ctx, method, url, nil, nil, responseBody, tokenSource)
 	}
 	if oauth.IsRefreshTokenError(err) {
 		err = errors.Wrap(request.ErrorUnauthenticated(), err.Error())
@@ -118,3 +118,31 @@ func (c *Client) sendDexcomRequest(ctx context.Context, startTime time.Time, end
 }
 
 const requestDurationMaximum = 15 * time.Second
+
+// sendRequest adds instrumentation before calling oauth.Client.SendOAuthRequest.
+func (c *Client) sendRequest(ctx context.Context, method, url string, mutators []request.RequestMutator,
+	requestBody any, responseBody any, httpClientSource oauth.HTTPClientSource) error {
+
+	var inspectors = []request.ResponseInspector{
+		&promDexcomInstrumentor{},
+	}
+	return c.client.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, inspectors, httpClientSource)
+}
+
+type promDexcomInstrumentor struct{}
+
+// InspectResponse implements request.ResponseInspector.
+func (i *promDexcomInstrumentor) InspectResponse(r *http.Response) error {
+	labels := prometheus.Labels{
+		"code": strconv.Itoa(r.StatusCode),
+		"path": r.Request.URL.Path,
+	}
+	promDexcomCounter.With(labels).Inc()
+	return nil
+}
+
+// promDexcomCounter instruments the Dexcom API paths and status codes called.
+var promDexcomCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "tidepool_dexcom_api_client_requests",
+	Help: "Dexcom API client requests",
+}, []string{"code", "path"})

--- a/oauth/client/client.go
+++ b/oauth/client/client.go
@@ -41,7 +41,7 @@ func (c *Client) AppendURLQuery(urlString string, query map[string]string) strin
 	return c.client.AppendURLQuery(urlString, query)
 }
 
-func (c *Client) SendOAuthRequest(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}, responseBody interface{}, httpClientSource oauth.HTTPClientSource) error {
+func (c *Client) SendOAuthRequest(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}, responseBody interface{}, inspectors []request.ResponseInspector, httpClientSource oauth.HTTPClientSource) error {
 	if httpClientSource == nil {
 		return errors.New("http client source is missing")
 	}
@@ -51,5 +51,5 @@ func (c *Client) SendOAuthRequest(ctx context.Context, method string, url string
 		return err
 	}
 
-	return c.client.RequestDataWithHTTPClient(ctx, method, url, mutators, requestBody, responseBody, nil, httpClient)
+	return c.client.RequestDataWithHTTPClient(ctx, method, url, mutators, requestBody, responseBody, inspectors, httpClient)
 }

--- a/oauth/client/client_test.go
+++ b/oauth/client/client_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Client", func() {
 			})
 
 			It("returns error when http client source is missing", func() {
-				Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil)).To(MatchError("http client source is missing"))
+				Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, nil)).To(MatchError("http client source is missing"))
 				Expect(server.ReceivedRequests()).To(BeEmpty())
 			})
 
@@ -246,7 +246,7 @@ var _ = Describe("Client", func() {
 				It("returns error when http client source returns an error", func() {
 					responseErr := errorsTest.RandomError()
 					httpClientSource.HTTPClientOutputs = []oauthTest.HTTPClientOutput{{HTTPClient: nil, Error: responseErr}}
-					Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)).To(Equal(responseErr))
+					Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)).To(Equal(responseErr))
 					Expect(server.ReceivedRequests()).To(BeEmpty())
 				})
 
@@ -260,37 +260,37 @@ var _ = Describe("Client", func() {
 
 					It("returns error when context is missing", func() {
 						ctx = nil
-						Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)).To(MatchError("context is missing"))
+						Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)).To(MatchError("context is missing"))
 						Expect(server.ReceivedRequests()).To(BeEmpty())
 					})
 
 					It("returns error when method is missing", func() {
-						Expect(clnt.SendOAuthRequest(ctx, "", url, mutators, requestBody, responseBody, httpClientSource)).To(MatchError("method is missing"))
+						Expect(clnt.SendOAuthRequest(ctx, "", url, mutators, requestBody, responseBody, nil, httpClientSource)).To(MatchError("method is missing"))
 						Expect(server.ReceivedRequests()).To(BeEmpty())
 					})
 
 					It("returns error when url is missing", func() {
-						Expect(clnt.SendOAuthRequest(ctx, method, "", mutators, requestBody, responseBody, httpClientSource)).To(MatchError("url is missing"))
+						Expect(clnt.SendOAuthRequest(ctx, method, "", mutators, requestBody, responseBody, nil, httpClientSource)).To(MatchError("url is missing"))
 						Expect(server.ReceivedRequests()).To(BeEmpty())
 					})
 
 					It("returns error when the request object cannot be encoded", func() {
 						invalidRequestBody := struct{ Func interface{} }{func() {}}
-						Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, invalidRequestBody, responseBody, httpClientSource).Error()).To(MatchRegexp("unable to serialize request to .*; json: unsupported type: func()"))
+						Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, invalidRequestBody, responseBody, nil, httpClientSource).Error()).To(MatchRegexp("unable to serialize request to .*; json: unsupported type: func()"))
 						Expect(server.ReceivedRequests()).To(BeEmpty())
 					})
 
 					It("returns error when mutator returns an error", func() {
 						errorMutator := request.NewHeaderMutator("", "")
 						invalidMutators := []request.RequestMutator{headerMutator, errorMutator, parameterMutator}
-						Expect(clnt.SendOAuthRequest(ctx, method, url, invalidMutators, requestBody, responseBody, httpClientSource).Error()).To(MatchRegexp("unable to mutate request to .*; key is missing"))
+						Expect(clnt.SendOAuthRequest(ctx, method, url, invalidMutators, requestBody, responseBody, nil, httpClientSource).Error()).To(MatchRegexp("unable to mutate request to .*; key is missing"))
 						Expect(server.ReceivedRequests()).To(BeEmpty())
 					})
 
 					It("returns error when the server is not reachable", func() {
 						server.Close()
 						server = nil
-						Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource).Error()).To(MatchRegexp("unable to perform request to .*: connect: connection refused"))
+						Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource).Error()).To(MatchRegexp("unable to perform request to .*: connect: connection refused"))
 					})
 
 					Context("with a successful response and no request body", func() {
@@ -307,7 +307,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, nil, responseBody, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, nil, responseBody, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 							Expect(responseBody).ToNot(BeNil())
 							Expect(responseBody.Response).To(Equal(responseString))
@@ -329,7 +329,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, request.ErrorBadRequest())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -353,7 +353,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, responseErr)
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -374,7 +374,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, request.ErrorUnauthenticated())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -395,7 +395,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, request.ErrorUnauthorized())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -416,7 +416,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, request.ErrorResourceNotFound())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -440,7 +440,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, responseErr)
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -461,7 +461,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, request.ErrorTooManyRequests())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -482,7 +482,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							Expect(err).To(MatchError(fmt.Sprintf(`unexpected response status code 500 from %s "%s?%s=%s"`, method, url, parameterMutator.Key, parameterMutator.Value)))
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -506,7 +506,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, responseErr)
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -527,7 +527,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns an error", func() {
-							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)
+							err := clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)
 							errorsTest.ExpectEqual(err, request.ErrorJSONMalformed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -548,7 +548,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 							Expect(responseBody).ToNot(BeNil())
 							Expect(responseBody.Response).To(BeEmpty())
@@ -570,7 +570,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 							Expect(responseBody).ToNot(BeNil())
 							Expect(responseBody.Response).To(BeEmpty())
@@ -591,7 +591,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, nil, responseBody, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, nil, responseBody, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 							Expect(responseBody).ToNot(BeNil())
 							Expect(responseBody.Response).To(Equal(responseString))
@@ -612,7 +612,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, strings.NewReader(requestString), responseBody, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, strings.NewReader(requestString), responseBody, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 							Expect(responseBody).ToNot(BeNil())
 							Expect(responseBody.Response).To(Equal(responseString))
@@ -634,7 +634,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, responseBody, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 							Expect(responseBody).ToNot(BeNil())
 							Expect(responseBody.Response).To(Equal(responseString))
@@ -656,7 +656,7 @@ var _ = Describe("Client", func() {
 						})
 
 						It("returns success without parsing response body", func() {
-							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, nil, httpClientSource)).To(Succeed())
+							Expect(clnt.SendOAuthRequest(ctx, method, url, mutators, requestBody, nil, nil, httpClientSource)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
 					})

--- a/platform/client_test.go
+++ b/platform/client_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							inspector := request.NewHeadersInspector()
+							inspector := request.NewHeadersInspector(log.LoggerFromContext(ctx))
 							reader, err = clnt.RequestStream(ctx, method, url, mutators, nil, inspector)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(reader).ToNot(BeNil())
@@ -305,7 +305,7 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							inspector := request.NewHeadersInspector()
+							inspector := request.NewHeadersInspector(log.LoggerFromContext(ctx))
 							Expect(clnt.RequestData(ctx, method, url, mutators, nil, nil, inspector)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})
@@ -457,7 +457,7 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							inspector := request.NewHeadersInspector()
+							inspector := request.NewHeadersInspector(log.LoggerFromContext(ctx))
 							reader, err = clnt.RequestStream(ctx, method, url, mutators, nil, inspector)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(reader).ToNot(BeNil())
@@ -520,7 +520,7 @@ var _ = Describe("Client", func() {
 
 						It("returns success", func() {
 							mutators := []request.RequestMutator{request.NewHeaderMutator(headerKey, headerValue)}
-							inspector := request.NewHeadersInspector()
+							inspector := request.NewHeadersInspector(log.LoggerFromContext(ctx))
 							Expect(clnt.RequestData(ctx, method, url, mutators, nil, nil, inspector)).To(Succeed())
 							Expect(server.ReceivedRequests()).To(HaveLen(1))
 						})

--- a/request/inspector.go
+++ b/request/inspector.go
@@ -7,6 +7,17 @@ import (
 )
 
 type ResponseInspector interface {
+	// InspectResponse is passed a response to inspect.
+	//
+	// An inspector must not modify the response. Doing so could impact later
+	// inspectors.
+	//
+	// The state of the response's body is undefined. There could be multiple
+	// inspectors before or after any given inspector, so when reading the
+	// body, it's probably a good idea to restore it when done.
+	//
+	// Any error returned will simply be logged. This might be removed in the
+	// future, so implementors are encouraged to use their own logging method.
 	InspectResponse(res *http.Response) error
 }
 

--- a/request/inspector.go
+++ b/request/inspector.go
@@ -3,11 +3,11 @@ package request
 import (
 	"net/http"
 
-	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 )
 
 type ResponseInspector interface {
-	// InspectResponse is passed a response to inspect.
+	// InspectResponse is passed a http.Response to inspect.
 	//
 	// An inspector must not modify the response. Doing so could impact later
 	// inspectors.
@@ -15,25 +15,25 @@ type ResponseInspector interface {
 	// The state of the response's body is undefined. There could be multiple
 	// inspectors before or after any given inspector, so when reading the
 	// body, it's probably a good idea to restore it when done.
-	//
-	// Any error returned will simply be logged. This might be removed in the
-	// future, so implementors are encouraged to use their own logging method.
-	InspectResponse(res *http.Response) error
+	InspectResponse(res *http.Response)
 }
 
 type HeadersInspector struct {
 	Headers http.Header
+	logger  log.Logger
 }
 
-func NewHeadersInspector() *HeadersInspector {
-	return &HeadersInspector{}
+func NewHeadersInspector(logger log.Logger) *HeadersInspector {
+	return &HeadersInspector{logger: logger}
 }
 
-func (h *HeadersInspector) InspectResponse(res *http.Response) error {
+func (h *HeadersInspector) InspectResponse(res *http.Response) {
 	if res == nil {
-		return errors.New("response is missing")
+		if h.logger != nil {
+			h.logger.Warnf("response is missing")
+		}
+		return
 	}
 
 	h.Headers = res.Header
-	return nil
 }


### PR DESCRIPTION
The oauth.Client.SendOauthRequest method is modified to accept a
[]request.ResponseInspect. One of these inspectors generates prometheus
metrics calls to track Dexcom API usage by number of calls, path, and status
code.

This is done in response to use seeing some 429 (too many requests) errors in our logs. With the visibility these metrics provide, we hope to better understand our usage of the Dexcom API, so that we can take steps to reduce our usage if necessary, or at least have a meaningful discussion with Dexcom about how much we'd like to use their API.

BACK-2820