### PR TITLE
[BACK-2866] Fix Dexcom task failing for newly created Dexcom connections

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *.coverprofile
 _bin/
 _tmp/
+coverprofile.out
 debug
 deploy/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.coverprofile
+*.env
 *.test
 /_bin
 /_data
@@ -7,3 +8,5 @@
 /deploy
 /.idea
 .DS_Store
+.envrc
+coverprofile.out

--- a/data/service/api/v1/users_datasets_create.go
+++ b/data/service/api/v1/users_datasets_create.go
@@ -69,7 +69,9 @@ func UsersDataSetsCreate(dataServiceContext dataService.Context) {
 	}
 
 	dataSet.SetUserID(&targetUserID)
-	dataSet.SetCreatedUserID(pointer.FromString(details.UserID()))
+	if details.IsUser() {
+		dataSet.SetCreatedUserID(pointer.FromString(details.UserID()))
+	}
 
 	dataSet.Normalize(normalizer)
 

--- a/dexcom/fetch/task.go
+++ b/dexcom/fetch/task.go
@@ -35,9 +35,9 @@ func NewTaskCreate(providerSessionID string, dataSourceID string) (*task.TaskCre
 }
 
 func ErrorOrRetryTask(t *task.Task, err error) {
+	t.AppendError(err)
 	if t.IsFailed() {
-		if shouldTaskError(t) {
-			t.AppendError(err)
+		if shouldTaskFail(t) {
 			return
 		}
 		incrementTaskRetryCount(t)
@@ -51,7 +51,7 @@ func FailTask(l log.Logger, t *task.Task, err error) error {
 	return err
 }
 
-func shouldTaskError(t *task.Task) bool {
+func shouldTaskFail(t *task.Task) bool {
 	if t.Data[dexcomTaskRetryField] != nil {
 		count, ok := t.Data[dexcomTaskRetryField].(int)
 		if ok {


### PR DESCRIPTION
- Fix Dexcom task failing for newly created Dexcom connections
- Only set CreatedUserID in UsersDataSetsCreate if user AuthDetails
- Always add error to Dexcom tasks whether or not task should fail
- Update tests
- Update .gitignore and .dockerignore
- https://tidepool.atlassian.net/browse/BACK-2866