### PR TITLE
adds ability to send push notifications to Apple devices

### DIFF
--- a/alerts/send.go
+++ b/alerts/send.go
@@ -1,0 +1,94 @@
+package alerts
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sideshow/apns2"
+	"github.com/sideshow/apns2/payload"
+	"github.com/sideshow/apns2/token"
+
+	"github.com/tidepool-org/platform/devicetokens"
+	"github.com/tidepool-org/platform/errors"
+)
+
+// Pusher abstracts the underlying push notification mechanism.
+type Pusher interface {
+	// Push a notification to a device.
+	//
+	// deviceToken should uniquely identify a device, while Notification
+	// abstracts the provider-specific notification payload.
+	Push(ctx context.Context, deviceToken devicetokens.DeviceToken, notification *Notification) error
+}
+
+// Notification models a provider-independent push notification.
+type Notification struct {
+	Title   string
+	Message string
+}
+
+// APNSPusher implements push notifications via Apple APNs.
+type APNSPusher struct {
+	serviceToken *token.Token
+	bundleID     string
+}
+
+// NewAPNSPusher creates a Pusher for sending device notifications via Apple's
+// APNs.
+//
+// The signingKey is the raw token signing key received from Apple (.p8 file
+// containing PEM-encoded private key), along with its respective team id, key
+// id, and application bundle id.
+//
+// https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns
+func NewAPNSPusher(signingKey []byte, keyID, teamID, bundleID string) (*APNSPusher, error) {
+	authKey, err := token.AuthKeyFromBytes(signingKey)
+	if err != nil {
+		return nil, err
+	}
+	token := &token.Token{
+		AuthKey: authKey,
+		KeyID:   keyID,
+		TeamID:  teamID,
+	}
+	return &APNSPusher{
+		bundleID:     bundleID,
+		serviceToken: token,
+	}, nil
+}
+
+func (p *APNSPusher) Push(ctx context.Context, deviceToken devicetokens.DeviceToken, note *Notification) error {
+	if deviceToken.Apple == nil {
+		return errors.New("Unable to push notification: APNSPusher can only use Apple device tokens but the Apple token is nil")
+	}
+
+	// TODO: look at the clientmanager package in apns2
+	client := apns2.NewTokenClient(p.serviceToken)
+	if deviceToken.Apple.Environment == "production" {
+		client = client.Production()
+	} else {
+		client = client.Development()
+	}
+
+	appleNote := p.buildAppleNotification(deviceToken.Apple, note)
+	resp, err := client.PushWithContext(ctx, appleNote)
+	if err != nil {
+		return errors.Wrap(err, "Unable to push notification")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.Newf("Unable to push notification: APNs returned non-200 status: %d, %s", resp.StatusCode, resp.Reason)
+	}
+
+	return nil
+}
+
+func (p *APNSPusher) buildAppleNotification(deviceToken *devicetokens.AppleDeviceToken, note *Notification) *apns2.Notification {
+	payload := payload.NewPayload().
+		Alert(note.Message).
+		AlertBody(note.Message)
+	return &apns2.Notification{
+		DeviceToken: string(deviceToken.Token),
+		Payload:     payload,
+		Topic:       p.bundleID,
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/rinchsan/device-check-go v1.3.0
+	github.com/sideshow/apns2 v0.23.0
 	github.com/tidepool-org/clinic/client v0.0.0-20240125151732-338a1e40e083
 	github.com/tidepool-org/devices/api v0.0.0-20220914225528-c7373eb1babc
 	github.com/tidepool-org/go-common v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT
 github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/ant0ine/go-json-rest v3.3.2+incompatible h1:nBixrkLFiDNAW0hauKDLc8yJI6XfrQumWvytE1Hk14E=
@@ -108,6 +110,7 @@ github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
@@ -278,6 +281,8 @@ github.com/schollz/closestmatch v2.1.0+incompatible h1:Uel2GXEpJqOWBrlyI+oY9LTiy
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sideshow/apns2 v0.23.0 h1:lpkikaZ995GIcKk6AFsYzHyezCrsrfEDvUWcWkEGErY=
+github.com/sideshow/apns2 v0.23.0/go.mod h1:7Fceu+sL0XscxrfLSkAoH6UtvKefq3Kq1n4W3ayQZqE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
@@ -371,6 +376,7 @@ go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.7.0 h1:pskyeJh/3AmoQ8CPE95vxHLqp1G1GfGNXTmcl9NEKTc=
 golang.org/x/arch v0.7.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
+golang.org/x/crypto v0.0.0-20170512130425-ab89591268e0/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -397,6 +403,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220403103023-749bd193bc2b/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
@@ -420,6 +427,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -469,6 +477,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/vendor/github.com/sideshow/apns2/.gitignore
+++ b/vendor/github.com/sideshow/apns2/.gitignore
@@ -1,0 +1,31 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+/*.p12
+/*.pem
+/*.cer
+/*.p8
+
+.DS_Store

--- a/vendor/github.com/sideshow/apns2/LICENSE
+++ b/vendor/github.com/sideshow/apns2/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Adam Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/sideshow/apns2/README.md
+++ b/vendor/github.com/sideshow/apns2/README.md
@@ -1,0 +1,216 @@
+# APNS/2
+
+APNS/2 is a go package designed for simple, flexible and fast Apple Push Notifications on iOS, OSX and Safari using the new HTTP/2 Push provider API.
+
+[![Build Status](https://github.com/sideshow/apns2/actions/workflows/tests.yml/badge.svg)](https://github.com/sideshow/apns2/actions/workflows/tests.yml) [![Coverage Status](https://coveralls.io/repos/sideshow/apns2/badge.svg?branch=master&service=github)](https://coveralls.io/github/sideshow/apns2?branch=master) [![GoDoc](https://godoc.org/github.com/sideshow/apns2?status.svg)](https://godoc.org/github.com/sideshow/apns2)
+
+## Features
+
+- Uses new Apple APNs HTTP/2 connection
+- Fast - See [notes on speed](https://github.com/sideshow/apns2/wiki/APNS-HTTP-2-Push-Speed)
+- Works with go 1.7 and later
+- Supports new Apple Token Based Authentication (JWT)
+- Supports new iOS 10 features such as Collapse IDs, Subtitles and Mutable Notifications
+- Supports new iOS 15 features interruptionLevel and relevanceScore
+- Supports persistent connections to APNs
+- Supports VoIP/PushKit notifications (iOS 8 and later)
+- Modular & easy to use
+- Tested and working in APNs production environment
+
+## Install
+
+- Make sure you have [Go](https://golang.org/doc/install) installed and have set your [GOPATH](https://golang.org/doc/code.html#GOPATH).
+- Install apns2:
+
+```sh
+go get -u github.com/sideshow/apns2
+```
+
+If you are running the test suite you will also need to install testify:
+
+```sh
+go get -u github.com/stretchr/testify
+```
+
+## Example
+
+```go
+package main
+
+import (
+  "log"
+  "fmt"
+
+  "github.com/sideshow/apns2"
+  "github.com/sideshow/apns2/certificate"
+)
+
+func main() {
+
+  cert, err := certificate.FromP12File("../cert.p12", "")
+  if err != nil {
+    log.Fatal("Cert Error:", err)
+  }
+
+  notification := &apns2.Notification{}
+  notification.DeviceToken = "11aa01229f15f0f0c52029d8cf8cd0aeaf2365fe4cebc4af26cd6d76b7919ef7"
+  notification.Topic = "com.sideshow.Apns2"
+  notification.Payload = []byte(`{"aps":{"alert":"Hello!"}}`) // See Payload section below
+
+  // If you want to test push notifications for builds running directly from XCode (Development), use
+  // client := apns2.NewClient(cert).Development()
+  // For apps published to the app store or installed as an ad-hoc distribution use Production()
+
+  client := apns2.NewClient(cert).Production()
+  res, err := client.Push(notification)
+
+  if err != nil {
+    log.Fatal("Error:", err)
+  }
+
+  fmt.Printf("%v %v %v\n", res.StatusCode, res.ApnsID, res.Reason)
+}
+```
+
+## JWT Token Example
+
+Instead of using a `.p12` or `.pem` certificate as above, you can optionally use
+APNs JWT _Provider Authentication Tokens_. First you will need a signing key (`.p8` file), Key ID and Team ID [from Apple](http://help.apple.com/xcode/mac/current/#/dev54d690a66). Once you have these details, you can create a new client:
+
+```go
+authKey, err := token.AuthKeyFromFile("../AuthKey_XXX.p8")
+if err != nil {
+  log.Fatal("token error:", err)
+}
+
+token := &token.Token{
+  AuthKey: authKey,
+  // KeyID from developer account (Certificates, Identifiers & Profiles -> Keys)
+  KeyID:   "ABC123DEFG",
+  // TeamID from developer account (View Account -> Membership)
+  TeamID:  "DEF123GHIJ",
+}
+...
+
+client := apns2.NewTokenClient(token)
+res, err := client.Push(notification)
+```
+
+- You can use one APNs signing key to authenticate tokens for multiple apps.
+- A signing key works for both the development and production environments.
+- A signing key doesn’t expire but can be revoked.
+
+## Notification
+
+At a minimum, a _Notification_ needs a _DeviceToken_, a _Topic_ and a _Payload_.
+
+```go
+notification := &apns2.Notification{
+  DeviceToken: "11aa01229f15f0f0c52029d8cf8cd0aeaf2365fe4cebc4af26cd6d76b7919ef7",
+  Topic: "com.sideshow.Apns2",
+  Payload: []byte(`{"aps":{"alert":"Hello!"}}`),
+}
+```
+
+You can also set an optional _ApnsID_, _Expiration_ or _Priority_.
+
+```go
+notification.ApnsID =  "40636A2C-C093-493E-936A-2A4333C06DEA"
+notification.Expiration = time.Now()
+notification.Priority = apns2.PriorityLow
+```
+
+## Payload
+
+You can use raw bytes for the `notification.Payload` as above, or you can use the payload builder package which makes it easy to construct APNs payloads.
+
+```go
+// {"aps":{"alert":"hello","badge":1},"key":"val"}
+
+payload := payload.NewPayload().Alert("hello").Badge(1).Custom("key", "val")
+
+notification.Payload = payload
+client.Push(notification)
+```
+
+Refer to the [payload](https://godoc.org/github.com/sideshow/apns2/payload) docs for more info.
+
+## Response, Error handling
+
+APNS/2 draws the distinction between a valid response from Apple indicating whether or not the _Notification_ was sent or not, and an unrecoverable or unexpected _Error_;
+
+- An `Error` is returned if a non-recoverable error occurs, i.e. if there is a problem with the underlying _http.Client_ connection or _Certificate_, the payload was not sent, or a valid _Response_ was not received.
+- A `Response` is returned if the payload was successfully sent to Apple and a documented response was received. This struct will contain more information about whether or not the push notification succeeded, its _apns-id_ and if applicable, more information around why it did not succeed.
+
+To check if a `Notification` was successfully sent;
+
+```go
+res, err := client.Push(notification)
+if err != nil {
+  log.Println("There was an error", err)
+  return
+}
+
+if res.Sent() {
+  log.Println("Sent:", res.ApnsID)
+} else {
+  fmt.Printf("Not Sent: %v %v %v\n", res.StatusCode, res.ApnsID, res.Reason)
+}
+```
+
+## Context & Timeouts
+
+For better control over request cancellations and timeouts APNS/2 supports
+contexts. Using a context can be helpful if you want to cancel all pushes when
+the parent process is cancelled, or need finer grained control over individual
+push timeouts. See the [Google post](https://blog.golang.org/context) for more
+information on contexts.
+
+```go
+ctx, cancel = context.WithTimeout(context.Background(), 10 * time.Second)
+res, err := client.PushWithContext(ctx, notification)
+defer cancel()
+```
+
+## Speed & Performance
+
+Also see the wiki page on [APNS HTTP 2 Push Speed](https://github.com/sideshow/apns2/wiki/APNS-HTTP-2-Push-Speed).
+
+For best performance, you should hold on to an `apns2.Client` instance and not re-create it every push. The underlying TLS connection itself can take a few seconds to connect and negotiate, so if you are setting up an `apns2.Client` and tearing it down every push, then this will greatly affect performance. (Apple suggest keeping the connection open all the time).
+
+You should also limit the amount of `apns2.Client` instances. The underlying transport has a http connection pool itself, so a single client instance will be enough for most users (One instance can potentially do 4,000+ pushes per second). If you need more than this then one instance per CPU core is a good starting point.
+
+Speed is greatly affected by the location of your server and the quality of your network connection. If you're just testing locally, behind a proxy or if your server is outside USA then you're not going to get great performance. With a good server located in AWS, you should be able to get [decent throughput](https://github.com/sideshow/apns2/wiki/APNS-HTTP-2-Push-Speed).
+
+## Command line tool
+
+APNS/2 has a command line tool that can be installed with `go get github.com/sideshow/apns2/apns2`. Usage:
+
+```
+apns2 --help
+usage: apns2 --certificate-path=CERTIFICATE-PATH --topic=TOPIC [<flags>]
+
+Listens to STDIN to send notifications and writes APNS response code and reason to STDOUT.
+
+The expected format is: <DeviceToken> <APNS Payload>
+Example: aff0c63d9eaa63ad161bafee732d5bc2c31f66d552054718ff19ce314371e5d0 {"aps": {"alert": "hi"}}
+Flags:
+      --help               Show context-sensitive help (also try --help-long and --help-man).
+  -c, --certificate-path=CERTIFICATE-PATH
+                           Path to certificate file.
+  -t, --topic=TOPIC        The topic of the remote notification, which is typically the bundle ID for your app
+  -m, --mode="production"  APNS server to send notifications to. `production` or `development`. Defaults to `production`
+      --version            Show application version.
+```
+
+## License
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Adam Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/sideshow/apns2/client.go
+++ b/vendor/github.com/sideshow/apns2/client.go
@@ -1,0 +1,238 @@
+// Package apns2 is a go Apple Push Notification Service (APNs) provider that
+// allows you to send remote notifications to your iOS, tvOS, and OS X
+// apps, using the new APNs HTTP/2 network protocol.
+package apns2
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/sideshow/apns2/token"
+	"golang.org/x/net/http2"
+)
+
+// Apple HTTP/2 Development & Production urls
+const (
+	HostDevelopment = "https://api.sandbox.push.apple.com"
+	HostProduction  = "https://api.push.apple.com"
+)
+
+// DefaultHost is a mutable var for testing purposes
+var DefaultHost = HostDevelopment
+
+var (
+	// HTTPClientTimeout specifies a time limit for requests made by the
+	// HTTPClient. The timeout includes connection time, any redirects,
+	// and reading the response body.
+	HTTPClientTimeout = 60 * time.Second
+
+	// ReadIdleTimeout is the timeout after which a health check using a ping
+	// frame will be carried out if no frame is received on the connection. If
+	// zero, no health check is performed.
+	ReadIdleTimeout = 15 * time.Second
+
+	// TCPKeepAlive specifies the keep-alive period for an active network
+	// connection. If zero, keep-alive probes are sent with a default value
+	// (currently 15 seconds)
+	TCPKeepAlive = 15 * time.Second
+
+	// TLSDialTimeout is the maximum amount of time a dial will wait for a connect
+	// to complete.
+	TLSDialTimeout = 20 * time.Second
+)
+
+// DialTLS is the default dial function for creating TLS connections for
+// non-proxied HTTPS requests.
+var DialTLS = func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout:   TLSDialTimeout,
+		KeepAlive: TCPKeepAlive,
+	}
+	return tls.DialWithDialer(dialer, network, addr, cfg)
+}
+
+// Client represents a connection with the APNs
+type Client struct {
+	Host        string
+	Certificate tls.Certificate
+	Token       *token.Token
+	HTTPClient  *http.Client
+}
+
+// A Context carries a deadline, a cancellation signal, and other values across
+// API boundaries. Context's methods may be called by multiple goroutines
+// simultaneously.
+type Context interface {
+	context.Context
+}
+
+type connectionCloser interface {
+	CloseIdleConnections()
+}
+
+// NewClient returns a new Client with an underlying http.Client configured with
+// the correct APNs HTTP/2 transport settings. It does not connect to the APNs
+// until the first Notification is sent via the Push method.
+//
+// As per the Apple APNs Provider API, you should keep a handle on this client
+// so that you can keep your connections with APNs open across multiple
+// notifications; don’t repeatedly open and close connections. APNs treats rapid
+// connection and disconnection as a denial-of-service attack.
+//
+// If your use case involves multiple long-lived connections, consider using
+// the ClientManager, which manages clients for you.
+func NewClient(certificate tls.Certificate) *Client {
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+	}
+	if len(certificate.Certificate) > 0 {
+		tlsConfig.BuildNameToCertificate()
+	}
+	transport := &http2.Transport{
+		TLSClientConfig: tlsConfig,
+		DialTLS:         DialTLS,
+		ReadIdleTimeout: ReadIdleTimeout,
+	}
+	return &Client{
+		HTTPClient: &http.Client{
+			Transport: transport,
+			Timeout:   HTTPClientTimeout,
+		},
+		Certificate: certificate,
+		Host:        DefaultHost,
+	}
+}
+
+// NewTokenClient returns a new Client with an underlying http.Client configured
+// with the correct APNs HTTP/2 transport settings. It does not connect to the APNs
+// until the first Notification is sent via the Push method.
+//
+// As per the Apple APNs Provider API, you should keep a handle on this client
+// so that you can keep your connections with APNs open across multiple
+// notifications; don’t repeatedly open and close connections. APNs treats rapid
+// connection and disconnection as a denial-of-service attack.
+func NewTokenClient(token *token.Token) *Client {
+	transport := &http2.Transport{
+		DialTLS:         DialTLS,
+		ReadIdleTimeout: ReadIdleTimeout,
+	}
+	return &Client{
+		Token: token,
+		HTTPClient: &http.Client{
+			Transport: transport,
+			Timeout:   HTTPClientTimeout,
+		},
+		Host: DefaultHost,
+	}
+}
+
+// Development sets the Client to use the APNs development push endpoint.
+func (c *Client) Development() *Client {
+	c.Host = HostDevelopment
+	return c
+}
+
+// Production sets the Client to use the APNs production push endpoint.
+func (c *Client) Production() *Client {
+	c.Host = HostProduction
+	return c
+}
+
+// Push sends a Notification to the APNs gateway. If the underlying http.Client
+// is not currently connected, this method will attempt to reconnect
+// transparently before sending the notification. It will return a Response
+// indicating whether the notification was accepted or rejected by the APNs
+// gateway, or an error if something goes wrong.
+//
+// Use PushWithContext if you need better cancellation and timeout control.
+func (c *Client) Push(n *Notification) (*Response, error) {
+	return c.PushWithContext(context.Background(), n)
+}
+
+// PushWithContext sends a Notification to the APNs gateway. Context carries a
+// deadline and a cancellation signal and allows you to close long running
+// requests when the context timeout is exceeded. Context can be nil, for
+// backwards compatibility.
+//
+// If the underlying http.Client is not currently connected, this method will
+// attempt to reconnect transparently before sending the notification. It will
+// return a Response indicating whether the notification was accepted or
+// rejected by the APNs gateway, or an error if something goes wrong.
+func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error) {
+	payload, err := json.Marshal(n)
+	if err != nil {
+		return nil, err
+	}
+
+	url := c.Host + "/3/device/" + n.DeviceToken
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Token != nil {
+		c.setTokenHeader(request)
+	}
+
+	setHeaders(request, n)
+
+	response, err := c.HTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	r := &Response{}
+	r.StatusCode = response.StatusCode
+	r.ApnsID = response.Header.Get("apns-id")
+
+	decoder := json.NewDecoder(response.Body)
+	if err := decoder.Decode(r); err != nil && err != io.EOF {
+		return &Response{}, err
+	}
+	return r, nil
+}
+
+// CloseIdleConnections closes any underlying connections which were previously
+// connected from previous requests but are now sitting idle. It will not
+// interrupt any connections currently in use.
+func (c *Client) CloseIdleConnections() {
+	c.HTTPClient.Transport.(connectionCloser).CloseIdleConnections()
+}
+
+func (c *Client) setTokenHeader(r *http.Request) {
+	bearer := c.Token.GenerateIfExpired()
+	r.Header.Set("authorization", "bearer "+bearer)
+}
+
+func setHeaders(r *http.Request, n *Notification) {
+	r.Header.Set("Content-Type", "application/json; charset=utf-8")
+	if n.Topic != "" {
+		r.Header.Set("apns-topic", n.Topic)
+	}
+	if n.ApnsID != "" {
+		r.Header.Set("apns-id", n.ApnsID)
+	}
+	if n.CollapseID != "" {
+		r.Header.Set("apns-collapse-id", n.CollapseID)
+	}
+	if n.Priority > 0 {
+		r.Header.Set("apns-priority", strconv.Itoa(n.Priority))
+	}
+	if !n.Expiration.IsZero() {
+		r.Header.Set("apns-expiration", strconv.FormatInt(n.Expiration.Unix(), 10))
+	}
+	if n.PushType != "" {
+		r.Header.Set("apns-push-type", string(n.PushType))
+	} else {
+		r.Header.Set("apns-push-type", string(PushTypeAlert))
+	}
+
+}

--- a/vendor/github.com/sideshow/apns2/client_manager.go
+++ b/vendor/github.com/sideshow/apns2/client_manager.go
@@ -1,0 +1,162 @@
+package apns2
+
+import (
+	"container/list"
+	"crypto/sha1"
+	"crypto/tls"
+	"sync"
+	"time"
+)
+
+type managerItem struct {
+	key      [sha1.Size]byte
+	client   *Client
+	lastUsed time.Time
+}
+
+// ClientManager is a way to manage multiple connections to the APNs.
+type ClientManager struct {
+	// MaxSize is the maximum number of clients allowed in the manager. When
+	// this limit is reached, the least recently used client is evicted. Set
+	// zero for no limit.
+	MaxSize int
+
+	// MaxAge is the maximum age of clients in the manager. Upon retrieval, if
+	// a client has remained unused in the manager for this duration or longer,
+	// it is evicted and nil is returned. Set zero to disable this
+	// functionality.
+	MaxAge time.Duration
+
+	// Factory is the function which constructs clients if not found in the
+	// manager.
+	Factory func(certificate tls.Certificate) *Client
+
+	cache map[[sha1.Size]byte]*list.Element
+	ll    *list.List
+	mu    sync.Mutex
+	once  sync.Once
+}
+
+// NewClientManager returns a new ClientManager for prolonged, concurrent usage
+// of multiple APNs clients. ClientManager is flexible enough to work best for
+// your use case. When a client is not found in the manager, Get will return
+// the result of calling Factory, which can be a Client or nil.
+//
+// Having multiple clients per certificate in the manager is not allowed.
+//
+// By default, MaxSize is 64, MaxAge is 10 minutes, and Factory always returns
+// a Client with default options.
+func NewClientManager() *ClientManager {
+	manager := &ClientManager{
+		MaxSize: 64,
+		MaxAge:  10 * time.Minute,
+		Factory: NewClient,
+	}
+
+	manager.initInternals()
+
+	return manager
+}
+
+// Add adds a Client to the manager. You can use this to individually configure
+// Clients in the manager.
+func (m *ClientManager) Add(client *Client) {
+	m.initInternals()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := cacheKey(client.Certificate)
+	now := time.Now()
+	if ele, hit := m.cache[key]; hit {
+		item := ele.Value.(*managerItem)
+		item.client = client
+		item.lastUsed = now
+		m.ll.MoveToFront(ele)
+		return
+	}
+	ele := m.ll.PushFront(&managerItem{key, client, now})
+	m.cache[key] = ele
+	if m.MaxSize != 0 && m.ll.Len() > m.MaxSize {
+		m.mu.Unlock()
+		m.removeOldest()
+		m.mu.Lock()
+	}
+}
+
+// Get gets a Client from the manager. If a Client is not found in the manager
+// or if a Client has remained in the manager longer than MaxAge, Get will call
+// the ClientManager's Factory function, store the result in the manager if
+// non-nil, and return it.
+func (m *ClientManager) Get(certificate tls.Certificate) *Client {
+	m.initInternals()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := cacheKey(certificate)
+	now := time.Now()
+	if ele, hit := m.cache[key]; hit {
+		item := ele.Value.(*managerItem)
+		if m.MaxAge != 0 && item.lastUsed.Before(now.Add(-m.MaxAge)) {
+			c := m.Factory(certificate)
+			if c == nil {
+				return nil
+			}
+			item.client = c
+		}
+		item.lastUsed = now
+		m.ll.MoveToFront(ele)
+		return item.client
+	}
+
+	c := m.Factory(certificate)
+	if c == nil {
+		return nil
+	}
+	m.mu.Unlock()
+	m.Add(c)
+	m.mu.Lock()
+	return c
+}
+
+// Len returns the current size of the ClientManager.
+func (m *ClientManager) Len() int {
+	if m.cache == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ll.Len()
+}
+
+func (m *ClientManager) initInternals() {
+	m.once.Do(func() {
+		m.cache = map[[sha1.Size]byte]*list.Element{}
+		m.ll = list.New()
+	})
+}
+
+func (m *ClientManager) removeOldest() {
+	m.mu.Lock()
+	ele := m.ll.Back()
+	m.mu.Unlock()
+	if ele != nil {
+		m.removeElement(ele)
+	}
+}
+
+func (m *ClientManager) removeElement(e *list.Element) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ll.Remove(e)
+	delete(m.cache, e.Value.(*managerItem).key)
+}
+
+func cacheKey(certificate tls.Certificate) [sha1.Size]byte {
+	var data []byte
+
+	for _, cert := range certificate.Certificate {
+		data = append(data, cert...)
+	}
+
+	return sha1.Sum(data)
+}

--- a/vendor/github.com/sideshow/apns2/notification.go
+++ b/vendor/github.com/sideshow/apns2/notification.go
@@ -1,0 +1,148 @@
+package apns2
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// EPushType defines the value for the apns-push-type header
+type EPushType string
+
+const (
+	// PushTypeAlert is used for notifications that trigger a user interaction —
+	// for example, an alert, badge, or sound. If you set this push type, the
+	// topic field must use your app’s bundle ID as the topic. If the
+	// notification requires immediate action from the user, set notification
+	// priority to 10; otherwise use 5. The alert push type is required on
+	// watchOS 6 and later. It is recommended on macOS, iOS, tvOS, and iPadOS.
+	PushTypeAlert EPushType = "alert"
+
+	// PushTypeBackground is used for notifications that deliver content in the
+	// background, and don’t trigger any user interactions. If you set this push
+	// type, the topic field must use your app’s bundle ID as the topic. Always
+	// use priority 5. Using priority 10 is an error. The background push type
+	// is required on watchOS 6 and later. It is recommended on macOS, iOS,
+	// tvOS, and iPadOS.
+	PushTypeBackground EPushType = "background"
+
+	// PushTypeLocation is used for notifications that request a user’s
+	// location. If you set this push type, the topic field must use your app’s
+	// bundle ID with .location-query appended to the end. The location push
+	// type is recommended for iOS and iPadOS. It isn’t available on macOS,
+	// tvOS, and watchOS. If the location query requires an immediate response
+	// from the Location Push Service Extension, set notification apns-priority
+	// to 10; otherwise, use 5. The location push type supports only token-based
+	// authentication.
+	PushTypeLocation EPushType = "location"
+
+	// PushTypeVOIP is used for notifications that provide information about an
+	// incoming Voice-over-IP (VoIP) call. If you set this push type, the topic
+	// field must use your app’s bundle ID with .voip appended to the end. If
+	// you’re using certificate-based authentication, you must also register the
+	// certificate for VoIP services. The voip push type is not available on
+	// watchOS. It is recommended on macOS, iOS, tvOS, and iPadOS.
+	PushTypeVOIP EPushType = "voip"
+
+	// PushTypeComplication is used for notifications that contain update
+	// information for a watchOS app’s complications. If you set this push type,
+	// the topic field must use your app’s bundle ID with .complication appended
+	// to the end. If you’re using certificate-based authentication, you must
+	// also register the certificate for WatchKit services. The complication
+	// push type is recommended for watchOS and iOS. It is not available on
+	// macOS, tvOS, and iPadOS.
+	PushTypeComplication EPushType = "complication"
+
+	// PushTypeFileProvider is used to signal changes to a File Provider
+	// extension. If you set this push type, the topic field must use your app’s
+	// bundle ID with .pushkit.fileprovider appended to the end. The
+	// fileprovider push type is not available on watchOS. It is recommended on
+	// macOS, iOS, tvOS, and iPadOS.
+	PushTypeFileProvider EPushType = "fileprovider"
+
+	// PushTypeMDM is used for notifications that tell managed devices to
+	// contact the MDM server. If you set this push type, you must use the topic
+	// from the UID attribute in the subject of your MDM push certificate.
+	PushTypeMDM EPushType = "mdm"
+)
+
+const (
+	// PriorityLow will tell APNs to send the push message at a time that takes
+	// into account power considerations for the device. Notifications with this
+	// priority might be grouped and delivered in bursts. They are throttled,
+	// and in some cases are not delivered.
+	PriorityLow = 5
+
+	// PriorityHigh will tell APNs to send the push message immediately.
+	// Notifications with this priority must trigger an alert, sound, or badge
+	// on the target device. It is an error to use this priority for a push
+	// notification that contains only the content-available key.
+	PriorityHigh = 10
+)
+
+// Notification represents the the data and metadata for a APNs Remote Notification.
+type Notification struct {
+
+	// An optional canonical UUID that identifies the notification. The
+	// canonical form is 32 lowercase hexadecimal digits, displayed in five
+	// groups separated by hyphens in the form 8-4-4-4-12. An example UUID is as
+	// follows:
+	//
+	//  123e4567-e89b-12d3-a456-42665544000
+	//
+	// If you don't set this, a new UUID is created by APNs and returned in the
+	// response.
+	ApnsID string
+
+	// A string which allows multiple notifications with the same collapse
+	// identifier to be displayed to the user as a single notification. The
+	// value should not exceed 64 bytes.
+	CollapseID string
+
+	// A string containing hexadecimal bytes of the device token for the target
+	// device.
+	DeviceToken string
+
+	// The topic of the remote notification, which is typically the bundle ID
+	// for your app. The certificate you create in the Apple Developer Member
+	// Center must include the capability for this topic. If your certificate
+	// includes multiple topics, you must specify a value for this header. If
+	// you omit this header and your APNs certificate does not specify multiple
+	// topics, the APNs server uses the certificate’s Subject as the default
+	// topic.
+	Topic string
+
+	// An optional time at which the notification is no longer valid and can be
+	// discarded by APNs. If this value is in the past, APNs treats the
+	// notification as if it expires immediately and does not store the
+	// notification or attempt to redeliver it. If this value is left as the
+	// default (ie, Expiration.IsZero()) an expiration header will not added to
+	// the http request.
+	Expiration time.Time
+
+	// The priority of the notification. Specify ether apns.PriorityHigh (10) or
+	// apns.PriorityLow (5) If you don't set this, the APNs server will set the
+	// priority to 10.
+	Priority int
+
+	// A byte array containing the JSON-encoded payload of this push notification.
+	// Refer to "The Remote Notification Payload" section in the Apple Local and
+	// Remote Notification Programming Guide for more info.
+	Payload interface{}
+
+	// The pushtype of the push notification. If this values is left as the
+	// default an apns-push-type header with value 'alert' will be added to the
+	// http request.
+	PushType EPushType
+}
+
+// MarshalJSON converts the notification payload to JSON.
+func (n *Notification) MarshalJSON() ([]byte, error) {
+	switch payload := n.Payload.(type) {
+	case string:
+		return []byte(payload), nil
+	case []byte:
+		return payload, nil
+	default:
+		return json.Marshal(payload)
+	}
+}

--- a/vendor/github.com/sideshow/apns2/payload/builder.go
+++ b/vendor/github.com/sideshow/apns2/payload/builder.go
@@ -1,0 +1,402 @@
+// Package payload is a helper package which contains a payload
+// builder to make constructing notification payloads easier.
+package payload
+
+import "encoding/json"
+
+// InterruptionLevel defines the value for the payload aps interruption-level
+type EInterruptionLevel string
+
+const (
+	// InterruptionLevelPassive is used to indicate that notification be delivered in a passive manner.
+	InterruptionLevelPassive EInterruptionLevel = "passive"
+
+	// InterruptionLevelActive is used to indicate the importance and delivery timing of a notification.
+	InterruptionLevelActive EInterruptionLevel = "active"
+
+	// InterruptionLevelTimeSensitive is used to indicate the importance and delivery timing of a notification.
+	InterruptionLevelTimeSensitive EInterruptionLevel = "time-sensitive"
+
+	// InterruptionLevelCritical is used to indicate the importance and delivery timing of a notification.
+	// This interruption level requires an approved entitlement from Apple.
+	// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+	InterruptionLevelCritical EInterruptionLevel = "critical"
+)
+
+// Payload represents a notification which holds the content that will be
+// marshalled as JSON.
+type Payload struct {
+	content map[string]interface{}
+}
+
+type aps struct {
+	Alert             interface{}        `json:"alert,omitempty"`
+	Badge             interface{}        `json:"badge,omitempty"`
+	Category          string             `json:"category,omitempty"`
+	ContentAvailable  int                `json:"content-available,omitempty"`
+	InterruptionLevel EInterruptionLevel `json:"interruption-level,omitempty"`
+	MutableContent    int                `json:"mutable-content,omitempty"`
+	RelevanceScore    interface{}        `json:"relevance-score,omitempty"`
+	Sound             interface{}        `json:"sound,omitempty"`
+	ThreadID          string             `json:"thread-id,omitempty"`
+	URLArgs           []string           `json:"url-args,omitempty"`
+}
+
+type alert struct {
+	Action          string   `json:"action,omitempty"`
+	ActionLocKey    string   `json:"action-loc-key,omitempty"`
+	Body            string   `json:"body,omitempty"`
+	LaunchImage     string   `json:"launch-image,omitempty"`
+	LocArgs         []string `json:"loc-args,omitempty"`
+	LocKey          string   `json:"loc-key,omitempty"`
+	Title           string   `json:"title,omitempty"`
+	Subtitle        string   `json:"subtitle,omitempty"`
+	TitleLocArgs    []string `json:"title-loc-args,omitempty"`
+	TitleLocKey     string   `json:"title-loc-key,omitempty"`
+	SummaryArg      string   `json:"summary-arg,omitempty"`
+	SummaryArgCount int      `json:"summary-arg-count,omitempty"`
+}
+
+type sound struct {
+	Critical int     `json:"critical,omitempty"`
+	Name     string  `json:"name,omitempty"`
+	Volume   float32 `json:"volume,omitempty"`
+}
+
+// NewPayload returns a new Payload struct
+func NewPayload() *Payload {
+	return &Payload{
+		map[string]interface{}{
+			"aps": &aps{},
+		},
+	}
+}
+
+// Alert sets the aps alert on the payload.
+// This will display a notification alert message to the user.
+//
+//	{"aps":{"alert":alert}}`
+func (p *Payload) Alert(alert interface{}) *Payload {
+	p.aps().Alert = alert
+	return p
+}
+
+// Badge sets the aps badge on the payload.
+// This will display a numeric badge on the app icon.
+//
+//	{"aps":{"badge":b}}
+func (p *Payload) Badge(b int) *Payload {
+	p.aps().Badge = b
+	return p
+}
+
+// ZeroBadge sets the aps badge on the payload to 0.
+// This will clear the badge on the app icon.
+//
+//	{"aps":{"badge":0}}
+func (p *Payload) ZeroBadge() *Payload {
+	p.aps().Badge = 0
+	return p
+}
+
+// UnsetBadge removes the badge attribute from the payload.
+// This will leave the badge on the app icon unchanged.
+// If you wish to clear the app icon badge, use ZeroBadge() instead.
+//
+//	{"aps":{}}
+func (p *Payload) UnsetBadge() *Payload {
+	p.aps().Badge = nil
+	return p
+}
+
+// Sound sets the aps sound on the payload.
+// This will play a sound from the app bundle, or the default sound otherwise.
+//
+//	{"aps":{"sound":sound}}
+func (p *Payload) Sound(sound interface{}) *Payload {
+	p.aps().Sound = sound
+	return p
+}
+
+// ContentAvailable sets the aps content-available on the payload to 1.
+// This will indicate to the app that there is new content available to download
+// and launch the app in the background.
+//
+//	{"aps":{"content-available":1}}
+func (p *Payload) ContentAvailable() *Payload {
+	p.aps().ContentAvailable = 1
+	return p
+}
+
+// MutableContent sets the aps mutable-content on the payload to 1.
+// This will indicate to the to the system to call your Notification Service
+// extension to mutate or replace the notification's content.
+//
+//	{"aps":{"mutable-content":1}}
+func (p *Payload) MutableContent() *Payload {
+	p.aps().MutableContent = 1
+	return p
+}
+
+// Custom payload
+
+// Custom sets a custom key and value on the payload.
+// This will add custom key/value data to the notification payload at root level.
+//
+//	{"aps":{}, key:value}
+func (p *Payload) Custom(key string, val interface{}) *Payload {
+	p.content[key] = val
+	return p
+}
+
+// Alert dictionary
+
+// AlertTitle sets the aps alert title on the payload.
+// This will display a short string describing the purpose of the notification.
+// Apple Watch & Safari display this string as part of the notification interface.
+//
+//	{"aps":{"alert":{"title":title}}}
+func (p *Payload) AlertTitle(title string) *Payload {
+	p.aps().alert().Title = title
+	return p
+}
+
+// AlertTitleLocKey sets the aps alert title localization key on the payload.
+// This is the key to a title string in the Localizable.strings file for the
+// current localization. See Localized Formatted Strings in Apple documentation
+// for more information.
+//
+//	{"aps":{"alert":{"title-loc-key":key}}}
+func (p *Payload) AlertTitleLocKey(key string) *Payload {
+	p.aps().alert().TitleLocKey = key
+	return p
+}
+
+// AlertTitleLocArgs sets the aps alert title localization args on the payload.
+// These are the variable string values to appear in place of the format
+// specifiers in title-loc-key. See Localized Formatted Strings in Apple
+// documentation for more information.
+//
+//	{"aps":{"alert":{"title-loc-args":args}}}
+func (p *Payload) AlertTitleLocArgs(args []string) *Payload {
+	p.aps().alert().TitleLocArgs = args
+	return p
+}
+
+// AlertSubtitle sets the aps alert subtitle on the payload.
+// This will display a short string describing the purpose of the notification.
+// Apple Watch & Safari display this string as part of the notification interface.
+//
+//	{"aps":{"alert":{"subtitle":"subtitle"}}}
+func (p *Payload) AlertSubtitle(subtitle string) *Payload {
+	p.aps().alert().Subtitle = subtitle
+	return p
+}
+
+// AlertBody sets the aps alert body on the payload.
+// This is the text of the alert message.
+//
+//	{"aps":{"alert":{"body":body}}}
+func (p *Payload) AlertBody(body string) *Payload {
+	p.aps().alert().Body = body
+	return p
+}
+
+// AlertLaunchImage sets the aps launch image on the payload.
+// This is the filename of an image file in the app bundle. The image is used
+// as the launch image when users tap the action button or move the action
+// slider.
+//
+//	{"aps":{"alert":{"launch-image":image}}}
+func (p *Payload) AlertLaunchImage(image string) *Payload {
+	p.aps().alert().LaunchImage = image
+	return p
+}
+
+// AlertLocArgs sets the aps alert localization args on the payload.
+// These are the variable string values to appear in place of the format
+// specifiers in loc-key. See Localized Formatted Strings in Apple
+// documentation for more information.
+//
+//  {"aps":{"alert":{"loc-args":args}}}
+func (p *Payload) AlertLocArgs(args []string) *Payload {
+	p.aps().alert().LocArgs = args
+	return p
+}
+
+// AlertLocKey sets the aps alert localization key on the payload.
+// This is the key to an alert-message string in the Localizable.strings file
+// for the current localization. See Localized Formatted Strings in Apple
+// documentation for more information.
+//
+//	{"aps":{"alert":{"loc-key":key}}}
+func (p *Payload) AlertLocKey(key string) *Payload {
+	p.aps().alert().LocKey = key
+	return p
+}
+
+// AlertAction sets the aps alert action on the payload.
+// This is the label of the action button, if the user sets the notifications
+// to appear as alerts. This label should be succinct, such as “Details” or
+// “Read more”. If omitted, the default value is “Show”.
+//
+//	{"aps":{"alert":{"action":action}}}
+func (p *Payload) AlertAction(action string) *Payload {
+	p.aps().alert().Action = action
+	return p
+}
+
+// AlertActionLocKey sets the aps alert action localization key on the payload.
+// This is the the string used as a key to get a localized string in the current
+// localization to use for the notfication right button’s title instead of
+// “View”. See Localized Formatted Strings in Apple documentation for more
+// information.
+//
+//	{"aps":{"alert":{"action-loc-key":key}}}
+func (p *Payload) AlertActionLocKey(key string) *Payload {
+	p.aps().alert().ActionLocKey = key
+	return p
+}
+
+// AlertSummaryArg sets the aps alert summary arg key on the payload.
+// This is the string that is used as a key to fill in an argument
+// at the bottom of a notification to provide more context, such as
+// a name associated with the sender of the notification.
+//
+//	{"aps":{"alert":{"summary-arg":key}}}
+func (p *Payload) AlertSummaryArg(key string) *Payload {
+	p.aps().alert().SummaryArg = key
+	return p
+}
+
+// AlertSummaryArgCount sets the aps alert summary arg count key on the payload.
+// This integer sets a custom "weight" on the notification, effectively
+// allowing a notification to be viewed internally as two. For example if
+// a notification encompasses 3 messages, you can set it to 3.
+//
+//	{"aps":{"alert":{"summary-arg-count":key}}}
+func (p *Payload) AlertSummaryArgCount(key int) *Payload {
+	p.aps().alert().SummaryArgCount = key
+	return p
+}
+
+// General
+
+// Category sets the aps category on the payload.
+// This is a string value that represents the identifier property of the
+// UIMutableUserNotificationCategory object you created to define custom actions.
+//
+//	{"aps":{"category":category}}
+func (p *Payload) Category(category string) *Payload {
+	p.aps().Category = category
+	return p
+}
+
+// Mdm sets the mdm on the payload.
+// This is for Apple Mobile Device Management (mdm) payloads.
+//
+//	{"aps":{}:"mdm":mdm}
+func (p *Payload) Mdm(mdm string) *Payload {
+	p.content["mdm"] = mdm
+	return p
+}
+
+// ThreadID sets the aps thread id on the payload.
+// This is for the purpose of updating the contents of a View Controller in a
+// Notification Content app extension when a new notification arrives. If a
+// new notification arrives whose thread-id value matches the thread-id of the
+// notification already being displayed, the didReceiveNotification method
+// is called.
+//
+//	{"aps":{"thread-id":id}}
+func (p *Payload) ThreadID(threadID string) *Payload {
+	p.aps().ThreadID = threadID
+	return p
+}
+
+// URLArgs sets the aps category on the payload.
+// This specifies an array of values that are paired with the placeholders
+// inside the urlFormatString value of your website.json file.
+// See Apple Notification Programming Guide for Websites.
+//
+//	{"aps":{"url-args":urlArgs}}
+func (p *Payload) URLArgs(urlArgs []string) *Payload {
+	p.aps().URLArgs = urlArgs
+	return p
+}
+
+// SoundName sets the name value on the aps sound dictionary.
+// This function makes the notification a critical alert, which should be pre-approved by Apple.
+// See: https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/
+//
+// {"aps":{"sound":{"critical":1,"name":name,"volume":1.0}}}
+func (p *Payload) SoundName(name string) *Payload {
+	p.aps().sound().Name = name
+	return p
+}
+
+// SoundVolume sets the volume value on the aps sound dictionary.
+// This function makes the notification a critical alert, which should be pre-approved by Apple.
+// See: https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/
+//
+// {"aps":{"sound":{"critical":1,"name":"default","volume":volume}}}
+func (p *Payload) SoundVolume(volume float32) *Payload {
+	p.aps().sound().Volume = volume
+	return p
+}
+
+// InterruptionLevel defines the value for the payload aps interruption-level
+// This is to indicate the importance and delivery timing of a notification.
+// (Using InterruptionLevelCritical requires an approved entitlement from Apple.)
+// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
+// {"aps":{"interruption-level":passive}}
+func (p *Payload) InterruptionLevel(interruptionLevel EInterruptionLevel) *Payload {
+	p.aps().InterruptionLevel = interruptionLevel
+	return p
+}
+
+// The relevance score, a number between 0 and 1,
+// that the system uses to sort the notifications from your app.
+// The highest score gets featured in the notification summary.
+// See https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore.
+//
+//	{"aps":{"relevance-score":0.1}}
+func (p *Payload) RelevanceScore(b float32) *Payload {
+	p.aps().RelevanceScore = b
+	return p
+}
+
+// Unsets the relevance score
+// that the system uses to sort the notifications from your app.
+// The highest score gets featured in the notification summary.
+// See https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore.
+//
+//	{"aps":{"relevance-score":0.1}}
+func (p *Payload) UnsetRelevanceScore() *Payload {
+	p.aps().RelevanceScore = nil
+	return p
+}
+
+// MarshalJSON returns the JSON encoded version of the Payload
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.content)
+}
+
+func (p *Payload) aps() *aps {
+	return p.content["aps"].(*aps)
+}
+
+func (a *aps) alert() *alert {
+	if _, ok := a.Alert.(*alert); !ok {
+		a.Alert = &alert{}
+	}
+	return a.Alert.(*alert)
+}
+
+func (a *aps) sound() *sound {
+	if _, ok := a.Sound.(*sound); !ok {
+		a.Sound = &sound{Critical: 1, Name: "default", Volume: 1.0}
+	}
+	return a.Sound.(*sound)
+}

--- a/vendor/github.com/sideshow/apns2/response.go
+++ b/vendor/github.com/sideshow/apns2/response.go
@@ -1,0 +1,156 @@
+package apns2
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// StatusSent is a 200 response.
+const StatusSent = http.StatusOK
+
+// The possible Reason error codes returned from APNs. From table 4 in the
+// Handling Notification Responses from APNs article
+const (
+	// 400 The collapse identifier exceeds the maximum allowed size
+	ReasonBadCollapseID = "BadCollapseId"
+
+	// 400 The specified device token was bad. Verify that the request contains a
+	// valid token and that the token matches the environment.
+	ReasonBadDeviceToken = "BadDeviceToken"
+
+	// 400 The apns-expiration value is bad.
+	ReasonBadExpirationDate = "BadExpirationDate"
+
+	// 400 The apns-id value is bad.
+	ReasonBadMessageID = "BadMessageId"
+
+	// 400 The apns-priority value is bad.
+	ReasonBadPriority = "BadPriority"
+
+	// 400 The apns-topic was invalid.
+	ReasonBadTopic = "BadTopic"
+
+	// 400 The device token does not match the specified topic.
+	ReasonDeviceTokenNotForTopic = "DeviceTokenNotForTopic"
+
+	// 400 One or more headers were repeated.
+	ReasonDuplicateHeaders = "DuplicateHeaders"
+
+	// 400 Idle time out.
+	ReasonIdleTimeout = "IdleTimeout"
+
+	// 400 The apns-push-type value is invalid.
+	ReasonInvalidPushType = "InvalidPushType"
+
+	// 400 The device token is not specified in the request :path. Verify that the
+	// :path header contains the device token.
+	ReasonMissingDeviceToken = "MissingDeviceToken"
+
+	// 400 The apns-topic header of the request was not specified and was
+	// required. The apns-topic header is mandatory when the client is connected
+	// using a certificate that supports multiple topics.
+	ReasonMissingTopic = "MissingTopic"
+
+	// 400 The message payload was empty.
+	ReasonPayloadEmpty = "PayloadEmpty"
+
+	// 400 Pushing to this topic is not allowed.
+	ReasonTopicDisallowed = "TopicDisallowed"
+
+	// 403 The certificate was bad.
+	ReasonBadCertificate = "BadCertificate"
+
+	// 403 The client certificate was for the wrong environment.
+	ReasonBadCertificateEnvironment = "BadCertificateEnvironment"
+
+	// 403 The provider token is stale and a new token should be generated.
+	ReasonExpiredProviderToken = "ExpiredProviderToken"
+
+	// 403 The specified action is not allowed.
+	ReasonForbidden = "Forbidden"
+
+	// 403 The provider token is not valid or the token signature could not be
+	// verified.
+	ReasonInvalidProviderToken = "InvalidProviderToken"
+
+	// 403 No provider certificate was used to connect to APNs and Authorization
+	// header was missing or no provider token was specified.
+	ReasonMissingProviderToken = "MissingProviderToken"
+
+	// 404 The request contained a bad :path value.
+	ReasonBadPath = "BadPath"
+
+	// 405 The specified :method was not POST.
+	ReasonMethodNotAllowed = "MethodNotAllowed"
+
+	// 410 The device token is inactive for the specified topic.
+	ReasonUnregistered = "Unregistered"
+
+	// 413 The message payload was too large. See Creating the Remote Notification
+	// Payload in the Apple Local and Remote Notification Programming Guide for
+	// details on maximum payload size.
+	ReasonPayloadTooLarge = "PayloadTooLarge"
+
+	// 429 The provider token is being updated too often.
+	ReasonTooManyProviderTokenUpdates = "TooManyProviderTokenUpdates"
+
+	// 429 Too many requests were made consecutively to the same device token.
+	ReasonTooManyRequests = "TooManyRequests"
+
+	// 500 An internal server error occurred.
+	ReasonInternalServerError = "InternalServerError"
+
+	// 503 The service is unavailable.
+	ReasonServiceUnavailable = "ServiceUnavailable"
+
+	// 503 The server is shutting down.
+	ReasonShutdown = "Shutdown"
+)
+
+// Response represents a result from the APNs gateway indicating whether a
+// notification was accepted or rejected and (if applicable) the metadata
+// surrounding the rejection.
+type Response struct {
+
+	// The HTTP status code returned by APNs.
+	// A 200 value indicates that the notification was successfully sent.
+	// For a list of other possible status codes, see table 6-4 in the Apple Local
+	// and Remote Notification Programming Guide.
+	StatusCode int
+
+	// The APNs error string indicating the reason for the notification failure (if
+	// any). The error code is specified as a string. For a list of possible
+	// values, see the Reason constants above.
+	// If the notification was accepted, this value will be "".
+	Reason string
+
+	// The APNs ApnsID value from the Notification. If you didn't set an ApnsID on the
+	// Notification, this will be a new unique UUID which has been created by APNs.
+	ApnsID string
+
+	// If the value of StatusCode is 410, this is the last time at which APNs
+	// confirmed that the device token was no longer valid for the topic.
+	Timestamp Time
+}
+
+// Sent returns whether or not the notification was successfully sent.
+// This is the same as checking if the StatusCode == 200.
+func (c *Response) Sent() bool {
+	return c.StatusCode == StatusSent
+}
+
+// Time represents a device uninstall time
+type Time struct {
+	time.Time
+}
+
+// UnmarshalJSON converts an epoch date into a Time struct.
+func (t *Time) UnmarshalJSON(b []byte) error {
+	ts, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return err
+	}
+	t.Time = time.Unix(ts/1000, 0)
+	return nil
+}

--- a/vendor/github.com/sideshow/apns2/token/token.go
+++ b/vendor/github.com/sideshow/apns2/token/token.go
@@ -1,0 +1,107 @@
+package token
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const (
+	// TokenTimeout is the period of time in seconds that a token is valid for.
+	// If the timestamp for token issue is not within the last hour, APNs
+	// rejects subsequent push messages. This is set to under an hour so that
+	// we generate a new token before the existing one expires.
+	TokenTimeout = 3000
+)
+
+// Possible errors when parsing a .p8 file.
+var (
+	ErrAuthKeyNotPem   = errors.New("token: AuthKey must be a valid .p8 PEM file")
+	ErrAuthKeyNotECDSA = errors.New("token: AuthKey must be of type ecdsa.PrivateKey")
+	ErrAuthKeyNil      = errors.New("token: AuthKey was nil")
+)
+
+// Token represents an Apple Provider Authentication Token (JSON Web Token).
+type Token struct {
+	sync.Mutex
+	AuthKey  *ecdsa.PrivateKey
+	KeyID    string
+	TeamID   string
+	IssuedAt int64
+	Bearer   string
+}
+
+// AuthKeyFromFile loads a .p8 certificate from a local file and returns a
+// *ecdsa.PrivateKey.
+func AuthKeyFromFile(filename string) (*ecdsa.PrivateKey, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return AuthKeyFromBytes(bytes)
+}
+
+// AuthKeyFromBytes loads a .p8 certificate from an in memory byte array and
+// returns an *ecdsa.PrivateKey.
+func AuthKeyFromBytes(bytes []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(bytes)
+	if block == nil {
+		return nil, ErrAuthKeyNotPem
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	if pk, ok := key.(*ecdsa.PrivateKey); ok {
+		return pk, nil
+	}
+	return nil, ErrAuthKeyNotECDSA
+}
+
+// GenerateIfExpired checks to see if the token is about to expire and
+// generates a new token.
+func (t *Token) GenerateIfExpired() (bearer string) {
+	t.Lock()
+	defer t.Unlock()
+	if t.Expired() {
+		t.Generate()
+	}
+	return t.Bearer
+}
+
+// Expired checks to see if the token has expired.
+func (t *Token) Expired() bool {
+	return time.Now().Unix() >= (t.IssuedAt + TokenTimeout)
+}
+
+// Generate creates a new token.
+func (t *Token) Generate() (bool, error) {
+	if t.AuthKey == nil {
+		return false, ErrAuthKeyNil
+	}
+	issuedAt := time.Now().Unix()
+	jwtToken := &jwt.Token{
+		Header: map[string]interface{}{
+			"alg": "ES256",
+			"kid": t.KeyID,
+		},
+		Claims: jwt.MapClaims{
+			"iss": t.TeamID,
+			"iat": issuedAt,
+		},
+		Method: jwt.SigningMethodES256,
+	}
+	bearer, err := jwtToken.SignedString(t.AuthKey)
+	if err != nil {
+		return false, err
+	}
+	t.IssuedAt = issuedAt
+	t.Bearer = bearer
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -569,6 +569,11 @@ github.com/russross/blackfriday/v2
 # github.com/schollz/closestmatch v2.1.0+incompatible
 ## explicit
 github.com/schollz/closestmatch
+# github.com/sideshow/apns2 v0.23.0
+## explicit; go 1.15
+github.com/sideshow/apns2
+github.com/sideshow/apns2/payload
+github.com/sideshow/apns2/token
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus


### PR DESCRIPTION
This is just a start, there's nothing using this yet, but it felt like a complete change, and one worth pushing on its own.

The intent is to allow sending push notifications, while providing minimal
friction to switching push notification providers. A future requirement to
send notifications to Android is expected, but in the meantime, the front-end
team has settled on APNs for their notifications. It's simple enough to
support multiple notification providers, and this interface can easily be
removed in the future if we decide on a single provider and don't feel that
the abstraction brings further value.
    
The change brings in a new dependency, github.com/sideshow/apns2, however it's
a small library, with very few dependencies of its own[1], primarily
those packages I would likely use in implementing the functionality myself.
    
[1]: Aside from the kingpin library, whose functionality we aren't using
anyway, as it's only used for a standalone binary that's part of the package,
it's not used by the library itself.
    
BACK-2507