### PR TITLE
lower limit to one decimal place for range validation

### DIFF
--- a/migrations/20231128_jellyfish_migration/utils/test/data.go
+++ b/migrations/20231128_jellyfish_migration/utils/test/data.go
@@ -177,14 +177,6 @@ func tandemPumpSettingsWithSleepScheduleDatum(datum map[string]interface{}) map[
 	return datum
 }
 
-func automatedBolusRange(datum map[string]interface{}) map[string]interface{} {
-	datum["type"] = "bolus"
-	datum["subType"] = "automated"
-	datum["normal"] = 2.51753
-	datum["expectedNormal"] = 2.51752
-	return datum
-}
-
 func carelinkPumpSettings(datum map[string]interface{}) map[string]interface{} {
 	datum["type"] = "pumpSettings"
 	datum["activeSchedule"] = "standard"
@@ -405,13 +397,13 @@ var PumpSettingsCarelink = carelinkPumpSettings(base("MiniMed 530G - 751-=-11111
 var PumpSettingsOmnipod = omnipodPumpSettingsDatum(base("InsOmn-837268"))
 var PumpSettingsOmnipodBGTargetCorrect = omnipodPumpSettingsDatumTargetSet(base("InsOmn-837268"))
 var AutomatedBasalTandem = tandemAutomatedBasalDatum(base("tandemCIQ1111111111111"))
-var AutomatedBolus = automatedBolusRange(base("tandemCIQ1111111111111"))
 var WizardTandem = tandemWizardDatum(base("tandemCIQ1111111111111"))
 var ReservoirChangeWithStatus = reservoirChangeDeviceEventDatum(base("InsOmn-1111111111111"))
 var AlarmDeviceEventDatum = alarmDeviceEventDatum(base("tandemCIQ100000000000"))
 var CGMSetting = cgmSettingsDatum(base("DexG5MobRec-1111111111111"))
 var EmptyPayloadDatum = emptyPayload(base("Dex-device"))
 var PumpSettingsWithBolusDatum = pumpSettingsWithBolus(base("tandem99999999"))
+var DatumBaseFunc = base
 
 func BulkJellyfishData(deviceID string, groupID string, userID string, requiredRecords int) []map[string]interface{} {
 	data := []map[string]interface{}{}

--- a/migrations/20231128_jellyfish_migration/utils/test/data.go
+++ b/migrations/20231128_jellyfish_migration/utils/test/data.go
@@ -177,6 +177,14 @@ func tandemPumpSettingsWithSleepScheduleDatum(datum map[string]interface{}) map[
 	return datum
 }
 
+func automatedBolusRange(datum map[string]interface{}) map[string]interface{} {
+	datum["type"] = "bolus"
+	datum["subType"] = "automated"
+	datum["normal"] = 2.51753
+	datum["expectedNormal"] = 2.51752
+	return datum
+}
+
 func carelinkPumpSettings(datum map[string]interface{}) map[string]interface{} {
 	datum["type"] = "pumpSettings"
 	datum["activeSchedule"] = "standard"
@@ -397,6 +405,7 @@ var PumpSettingsCarelink = carelinkPumpSettings(base("MiniMed 530G - 751-=-11111
 var PumpSettingsOmnipod = omnipodPumpSettingsDatum(base("InsOmn-837268"))
 var PumpSettingsOmnipodBGTargetCorrect = omnipodPumpSettingsDatumTargetSet(base("InsOmn-837268"))
 var AutomatedBasalTandem = tandemAutomatedBasalDatum(base("tandemCIQ1111111111111"))
+var AutomatedBolus = automatedBolusRange(base("tandemCIQ1111111111111"))
 var WizardTandem = tandemWizardDatum(base("tandemCIQ1111111111111"))
 var ReservoirChangeWithStatus = reservoirChangeDeviceEventDatum(base("InsOmn-1111111111111"))
 var AlarmDeviceEventDatum = alarmDeviceEventDatum(base("tandemCIQ100000000000"))

--- a/migrations/20231128_jellyfish_migration/utils/utils_test.go
+++ b/migrations/20231128_jellyfish_migration/utils/utils_test.go
@@ -49,12 +49,20 @@ var _ = Describe("back-37", func() {
 				Expect(revertSet).Should(HaveKeyWithValue("percent", float64(0.47857142857142865)))
 			})
 
-			It("bolus out of range expection", func() {
-				bsonObj := getBSONData(test.AutomatedBolus)
+			It("bolus range validation ralxed for very precise values", func() {
+				datum := test.DatumBaseFunc("my-test-device-id")
+				datum["type"] = "bolus"
+				datum["subType"] = "automated"
+				datum["normal"] = 2.51753
+				datum["expectedNormal"] = 2.51752
+
+				bsonObj := getBSONData(datum)
 				datumType := fmt.Sprintf("%v", bsonObj["type"])
 				datumID := fmt.Sprintf("%v", bsonObj["_id"])
-				_, _, err := utils.ProcessDatum(datumID, datumType, bsonObj)
+				apply, revert, err := utils.ProcessDatum(datumID, datumType, bsonObj)
 				Expect(err).To(BeNil())
+				Expect(apply).ToNot(BeNil())
+				Expect(revert).ToNot(BeNil())
 			})
 
 			It("cgm settings with blood glucose precsion updates", func() {

--- a/migrations/20231128_jellyfish_migration/utils/utils_test.go
+++ b/migrations/20231128_jellyfish_migration/utils/utils_test.go
@@ -39,7 +39,7 @@ var _ = Describe("back-37", func() {
 
 		var _ = Describe("ProcessDatum", func() {
 
-			It("basal with unwanted percent feild", func() {
+			It("basal with unwanted percent field", func() {
 
 				applySet, applyUnset, revertUnset, revertSet := setup(getBSONData(test.AutomatedBasalTandem))
 
@@ -47,6 +47,14 @@ var _ = Describe("back-37", func() {
 				Expect(applyUnset).Should(HaveKeyWithValue("percent", ""))
 				Expect(revertUnset).Should(HaveKeyWithValue("_deduplicator", ""))
 				Expect(revertSet).Should(HaveKeyWithValue("percent", float64(0.47857142857142865)))
+			})
+
+			It("bolus out of range expection", func() {
+				bsonObj := getBSONData(test.AutomatedBolus)
+				datumType := fmt.Sprintf("%v", bsonObj["type"])
+				datumID := fmt.Sprintf("%v", bsonObj["_id"])
+				_, _, err := utils.ProcessDatum(datumID, datumType, bsonObj)
+				Expect(err).To(BeNil())
 			})
 
 			It("cgm settings with blood glucose precsion updates", func() {

--- a/structure/validator/float64.go
+++ b/structure/validator/float64.go
@@ -1,6 +1,8 @@
 package validator
 
 import (
+	"math"
+
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 )
@@ -85,9 +87,17 @@ func (f *Float64) GreaterThanOrEqualTo(limit float64) structure.Float64 {
 	return f
 }
 
+func toFixed(num float64, precision int) float64 {
+	var round = func(num float64) int {
+		return int(num + math.Copysign(0.5, num))
+	}
+	output := math.Pow(10, float64(precision))
+	return float64(round(num*output)) / output
+}
+
 func (f *Float64) InRange(lowerLimit float64, upperLimit float64) structure.Float64 {
 	if f.value != nil {
-		if *f.value < lowerLimit || *f.value > upperLimit {
+		if *f.value < toFixed(lowerLimit, 1) || *f.value > upperLimit {
 			f.base.ReportError(ErrorValueNotInRange(*f.value, lowerLimit, upperLimit))
 		}
 	}


### PR DESCRIPTION
e.g
``` 
{"id":"9clip43gqkvib5hiptne7ki718t4ql3t","error":"value-out-of-range","detail":"value 2.51752 is not between 2.51753 and 100","source":{"pointer":"/expectedNormal"}}
```

see https://github.com/tidepool-org/platform/blob/2d52339c4886f746f98fa7f0342d7d14a08d1c12/data/types/bolus/combination/combination.go#L94-L101
