### PR TITLE
adds a plain-text logger for development or testing

### DIFF
--- a/log/devlog/devlog.go
+++ b/log/devlog/devlog.go
@@ -1,0 +1,118 @@
+// Package devlog provides a plain-text logger suitable for reading from the
+// console.
+//
+// For production, the team prefers JSON logging, but plain-text can be useful
+// for local development and tests.
+//
+// So while this package shouldn't be used for production, it can be enabled
+// for your development use by setting TIDEPOOL_LOGGER_PACKGE=devlog as an
+// environment variable. If you're using the development repo's helm chart,
+// there's a global.loggerPackage override available to do the same.
+
+package devlog
+
+import (
+	"fmt"
+	"io"
+	stdlog "log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
+)
+
+// New provides a plain-text log.Logger suitable for development or testing.
+func New(writer io.Writer, levelRanks log.LevelRanks, level log.Level) (log.Logger, error) {
+	if writer == nil {
+		return nil, errors.New("writer is missing")
+	}
+	logLogger := stdlog.New(writer, "", 0)
+	return log.NewLogger(&serializer{logLogger}, levelRanks, level)
+}
+
+func NewWithDefaults(writer io.Writer) (log.Logger, error) {
+	return New(writer, log.DefaultLevelRanks(), log.DebugLevel)
+}
+
+type serializer struct {
+	*stdlog.Logger
+}
+
+func (s *serializer) Serialize(fields log.Fields) error {
+	var pairs = make([]string, 0, len(fields))
+	var msg, msgTime, msgLevel, msgCaller string
+	var showCaller = false
+
+	msgLevel = abbreviateLevel("")
+	msgTime = time.Now().Format(time.Stamp)
+
+	for key, value := range fields {
+		switch key {
+		case "caller":
+			msgCaller = formatCaller(value)
+		case "level":
+			level := sOrPlusV(value)
+			msgLevel = abbreviateLevel(level)
+			if level == string(log.ErrorLevel) {
+				showCaller = true
+			}
+		case "message":
+			msg = sOrPlusV(value)
+		case "process":
+			// process isn't useful outside of sumo
+		case "time":
+			// time is terser and constant width for console logging
+			tv, err := time.Parse(time.RFC3339Nano, sOrPlusV(value))
+			if err != nil {
+				msgTime = sOrPlusV(value)
+				continue
+			}
+			msgTime = tv.Format(time.Stamp)
+		default:
+			pairs = append(pairs, key+"="+sOrPlusV(value))
+		}
+	}
+	if showCaller {
+		pairs = append(pairs, msgCaller)
+	}
+	sort.Strings(pairs)
+	rest := ""
+	if len(pairs) > 0 {
+		rest = ": " + strings.Join(pairs, " ")
+	}
+	s.Logger.Printf(msgTime + " " + msgLevel + " " + msg + rest)
+	return nil
+}
+
+func formatCaller(value any) string {
+	cc, ok := value.(*errors.Caller)
+	if !ok {
+		return "caller=" + sOrPlusV(value)
+	}
+	return fmt.Sprintf("caller=%s:%d", cc.File, cc.Line)
+}
+
+func sOrPlusV(thing any) (s string) {
+	if stringer, ok := thing.(fmt.Stringer); ok {
+		return stringer.String()
+	} else if s, ok := thing.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%+v", thing)
+}
+
+var abbr map[string]string = map[string]string{
+	string(log.DebugLevel): "DD",
+	string(log.ErrorLevel): "EE",
+	string(log.InfoLevel):  "II",
+	string(log.WarnLevel):  "WW",
+}
+
+func abbreviateLevel(fullLevel string) string {
+	if a, ok := abbr[fullLevel]; ok {
+		return a
+	}
+	return "??"
+}

--- a/log/devlog/devlog_suite_test.go
+++ b/log/devlog/devlog_suite_test.go
@@ -1,0 +1,11 @@
+package devlog
+
+import (
+	"testing"
+
+	"github.com/tidepool-org/platform/test"
+)
+
+func TestSuite(t *testing.T) {
+	test.Test(t)
+}

--- a/log/devlog/devlog_test.go
+++ b/log/devlog/devlog_test.go
@@ -1,0 +1,131 @@
+package devlog
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/errors"
+	plog "github.com/tidepool-org/platform/log"
+)
+
+var _ = Describe("devlog", func() {
+	Context("Serialize", func() {
+		It("pulls out the time field", func() {
+			stamp := time.Now().Truncate(time.Microsecond).Format(time.RFC3339Nano)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).ToNot(ContainSubstring("time=" + stamp))
+		})
+
+		It("displays caller info on error level logs", func() {
+			stamp := time.Now().Format(time.Stamp)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			fields["caller"] = &errors.Caller{File: "foo.go", Line: 42}
+			fields["level"] = string(plog.ErrorLevel)
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring("caller=foo.go:42"))
+		})
+
+		It("pulls out the message field", func() {
+			stamp := time.Now().Format(time.Stamp)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			fields["extra"] = "field"
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring(stamp + " ?? " + message + ":"))
+		})
+
+		It("falls back to ?? in the level isn't recognized", func() {
+			stamp := time.Now().Format(time.Stamp)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			fields["level"] = "some"
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring(stamp + " ?? " + message))
+		})
+
+		It("abbreviates the debug level", func() {
+			stamp := time.Now().Format(time.Stamp)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			fields["level"] = "debug"
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring(stamp + " DD " + message))
+		})
+
+		It("handles structs", func() {
+			stamp := time.Now().Truncate(time.Microsecond).Format(time.RFC3339Nano)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			datum := struct{ foo string }{foo: "bar"}
+			fields["datum"] = datum
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring(fmt.Sprintf("datum=%+v", datum)))
+		})
+
+		It("handles ints", func() {
+			stamp := time.Now().Truncate(time.Microsecond).Format(time.RFC3339Nano)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+			value := 42
+
+			fields["int"] = value
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring("int=42"))
+		})
+
+		It("handles bools", func() {
+			stamp := time.Now().Truncate(time.Microsecond).Format(time.RFC3339Nano)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			value := true
+			fields["bool"] = value
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring("bool=true"))
+		})
+
+		It("handles floats", func() {
+			stamp := time.Now().Truncate(time.Microsecond).Format(time.RFC3339Nano)
+			buf := &bytes.Buffer{}
+			s := &serializer{Logger: log.New(buf, "", 0)}
+			message := "this is a test"
+			fields := plog.Fields{"message": message, "time": stamp}
+
+			value := 24.2
+			fields["float"] = value
+			Expect(s.Serialize(fields)).To(Succeed())
+			Expect(buf.String()).To(ContainSubstring("float=24.2"))
+		})
+	})
+})


### PR DESCRIPTION
JSON logging is great for production, but when running things locally, it's very helpful to have something more readable.

This devlog injects itself when the POD_NAMESPACE env var is "default" (used by the development repo's local k8s cluster) or when the TIDEPOOL_USE_DEVLOG env var is set (to any non-blank value).

It has a few features:

  1. shortens timestamp
  2. leaves out process information
  3. shows basic caller information only for error messages (filename:line)
  4. abbreviates log level output ("error" => "EE", "debug" => "DD", etc)
  5. handles other fields by appending them to the main log message