### PR TITLE
adds activity tracking to alert configurations

### DIFF
--- a/alerts/config.go
+++ b/alerts/config.go
@@ -72,10 +72,30 @@ func (a Alerts) Validate(validator structure.Validator) {
 type Base struct {
 	// Enabled controls whether notifications should be sent for this alert.
 	Enabled bool `json:"enabled" bson:"enabled"`
+
+	// Activity tracks when events related to the alert occurred.
+	Activity `json:"-" bson:"activity,omitempty"`
 }
 
 func (b Base) Validate(validator structure.Validator) {
 	validator.Bool("enabled", &b.Enabled)
+}
+
+type Activity struct {
+	// Triggered records the last time this alert was triggered.
+	Triggered time.Time `json:"triggered" bson:"triggered"`
+	// Sent records the last time this alert was sent.
+	Sent time.Time `json:"sent" bson:"sent"`
+	// Resolved records the last time this alert was resolved.
+	Resolved time.Time `json:"resolved" bson:"resolved"`
+}
+
+func (a Activity) IsActive() bool {
+	return a.Triggered.After(a.Resolved)
+}
+
+func (a Activity) IsSent() bool {
+	return a.Sent.After(a.Triggered)
 }
 
 const (

--- a/alerts/config_test.go
+++ b/alerts/config_test.go
@@ -125,6 +125,54 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Context("Base", func() {
+		Context("Activity", func() {
+			Context("IsActive()", func() {
+				It("is true", func() {
+					triggered := time.Now()
+					resolved := triggered.Add(-time.Nanosecond)
+					a := Activity{
+						Triggered: triggered,
+						Resolved:  resolved,
+					}
+					Expect(a.IsActive()).To(BeTrue())
+				})
+
+				It("is false", func() {
+					triggered := time.Now()
+					resolved := triggered.Add(time.Nanosecond)
+					a := Activity{
+						Triggered: triggered,
+						Resolved:  resolved,
+					}
+					Expect(a.IsActive()).To(BeFalse())
+				})
+			})
+
+			Context("IsNotified()", func() {
+				It("is true", func() {
+					triggered := time.Now()
+					sent := triggered.Add(time.Nanosecond)
+					a := Activity{
+						Triggered: triggered,
+						Sent:      sent,
+					}
+					Expect(a.IsSent()).To(BeTrue())
+				})
+
+				It("is false", func() {
+					triggered := time.Now()
+					notified := triggered.Add(-time.Nanosecond)
+					a := Activity{
+						Triggered: triggered,
+						Sent:      notified,
+					}
+					Expect(a.IsSent()).To(BeFalse())
+				})
+			})
+		})
+	})
+
 	Context("UrgentLowAlert", func() {
 		Context("Threshold", func() {
 			It("accepts values between 0 and 1000 mg/dL", func() {


### PR DESCRIPTION
These activity properties will track the times at which alerts were sent, resolved, or acknowledged.

BACK-2554