### PR TITLE
adds new API endpoints to the auth service for device tokens

### DIFF
--- a/auth/service/service/client.go
+++ b/auth/service/service/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tidepool-org/platform/auth"
 	"github.com/tidepool-org/platform/auth/client"
 	authStore "github.com/tidepool-org/platform/auth/store"
+	"github.com/tidepool-org/platform/devicetokens"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
@@ -114,6 +115,19 @@ func (c *Client) deleteProviderSession(ctx context.Context, repository authStore
 			logger.WithError(err).Warn("Unable to delete provider session from provider")
 		}
 	}
+}
+
+func (c *Client) GetDeviceTokens(ctx context.Context, userID string) ([]*devicetokens.DeviceToken, error) {
+	repo := c.authStore.NewDeviceTokenRepository()
+	docs, err := repo.GetAllByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	tokens := make([]*devicetokens.DeviceToken, 0, len(docs))
+	for _, doc := range docs {
+		tokens = append(tokens, &doc.DeviceToken)
+	}
+	return tokens, nil
 }
 
 func (c *Client) GetProviderSession(ctx context.Context, id string) (*auth.ProviderSession, error) {

--- a/auth/service/service/client_test.go
+++ b/auth/service/service/client_test.go
@@ -1,8 +1,151 @@
 package service_test
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/onsi/gomega/ghttp"
+
+	"github.com/tidepool-org/platform/auth/client"
+	"github.com/tidepool-org/platform/auth/service/service"
+	"github.com/tidepool-org/platform/auth/store"
+	platformclient "github.com/tidepool-org/platform/client"
+	"github.com/tidepool-org/platform/devicetokens"
+	logtest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/platform"
+	"github.com/tidepool-org/platform/provider"
 )
 
 var _ = Describe("Client", func() {
+	var testUserID = "test-user-id"
+	var testDeviceToken1 = &devicetokens.DeviceToken{
+		Apple: &devicetokens.AppleDeviceToken{
+			Token:       []byte("test"),
+			Environment: "sandbox",
+		},
+	}
+
+	newTestServiceClient := func(url string, authStore store.Store) *service.Client {
+		var err error
+		extCfg := &client.ExternalConfig{
+			Config: &platform.Config{
+				Config: &platformclient.Config{
+					Address:   url,
+					UserAgent: "test",
+				},
+				ServiceSecret: "",
+			},
+			ServerSessionTokenSecret:  "test token",
+			ServerSessionTokenTimeout: time.Minute,
+		}
+		authAs := platform.AuthorizeAsService
+		name := "test auth client"
+		logger := logtest.NewLogger()
+		if authStore == nil {
+			authStore = &mockAuthStore{
+				DeviceTokenRepository: &mockDeviceTokenRepository{
+					Tokens: map[string][]*devicetokens.DeviceToken{
+						testUserID: {
+							testDeviceToken1,
+						},
+					},
+				},
+			}
+		}
+		providerFactory := &mockProviderFactory{}
+		serviceClient, err := service.NewClient(extCfg, authAs, name, logger, authStore, providerFactory)
+		Expect(err).To(Succeed())
+		return serviceClient
+	}
+
+	Describe("GetDeviceTokens", func() {
+		It("returns a slice of tokens", func() {
+			ctx := context.Background()
+			server := NewServer()
+			defer server.Close()
+			serviceClient := newTestServiceClient(server.URL(), nil)
+
+			tokens, err := serviceClient.GetDeviceTokens(ctx, testUserID)
+
+			Expect(err).To(Succeed())
+			Expect(tokens).To(HaveLen(1))
+			Expect(tokens[0]).To(Equal(testDeviceToken1))
+		})
+
+		It("handles errors from the underlying repo", func() {
+			ctx := context.Background()
+			server := NewServer()
+			defer server.Close()
+			authStore := &mockAuthStore{
+				DeviceTokenRepository: &mockDeviceTokenRepository{
+					Error: fmt.Errorf("test error"),
+				},
+			}
+			serviceClient := newTestServiceClient(server.URL(), authStore)
+
+			_, err := serviceClient.GetDeviceTokens(ctx, testUserID)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
+
+type mockAuthStore struct {
+	store.DeviceTokenRepository
+}
+
+func (s *mockAuthStore) NewProviderSessionRepository() store.ProviderSessionRepository {
+	return nil
+}
+
+func (s *mockAuthStore) NewRestrictedTokenRepository() store.RestrictedTokenRepository {
+	return nil
+}
+
+func (s *mockAuthStore) NewDeviceTokenRepository() store.DeviceTokenRepository {
+	return s.DeviceTokenRepository
+}
+
+type mockProviderFactory struct{}
+
+func (f *mockProviderFactory) Get(typ string, name string) (provider.Provider, error) {
+	return nil, nil
+}
+
+type mockDeviceTokenRepository struct {
+	Error  error
+	Tokens map[string][]*devicetokens.DeviceToken
+}
+
+func (r *mockDeviceTokenRepository) GetAllByUserID(ctx context.Context, userID string) ([]*devicetokens.Document, error) {
+	if r.Error != nil {
+		return nil, r.Error
+	}
+
+	if tokens, ok := r.Tokens[userID]; ok {
+		docs := make([]*devicetokens.Document, 0, len(tokens))
+		for _, token := range tokens {
+			docs = append(docs, &devicetokens.Document{DeviceToken: *token})
+		}
+		return docs, nil
+	}
+	return nil, nil
+}
+
+func (r *mockDeviceTokenRepository) Upsert(ctx context.Context, doc *devicetokens.Document) error {
+	if r.Error != nil {
+		return r.Error
+	}
+	return nil
+}
+
+func (r *mockDeviceTokenRepository) EnsureIndexes() error {
+	if r.Error != nil {
+		return r.Error
+	}
+	return nil
+}

--- a/auth/store/mongo/device_tokens_repository.go
+++ b/auth/store/mongo/device_tokens_repository.go
@@ -16,6 +16,20 @@ import (
 // MongoDB collection.
 type deviceTokenRepo structuredmongo.Repository
 
+func (r *deviceTokenRepo) GetAllByUserID(ctx context.Context, userID string) ([]*devicetokens.Document, error) {
+	f := bson.M{"userId": userID}
+	cursor, err := r.Find(ctx, f, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	docs := make([]*devicetokens.Document, 0, cursor.RemainingBatchLength())
+	if err := cursor.All(ctx, &docs); err != nil {
+		return nil, err
+	}
+	return docs, nil
+}
+
 // Upsert will create or update the given Config.
 func (r *deviceTokenRepo) Upsert(ctx context.Context, doc *devicetokens.Document) error {
 	// The presence of UserID and TokenID should be enforced with a mongodb

--- a/auth/store/test/device_token_repository.go
+++ b/auth/store/test/device_token_repository.go
@@ -9,6 +9,8 @@ import (
 
 type DeviceTokenRepository struct {
 	*authTest.DeviceTokenAccessor
+	Documents []*devicetokens.Document
+	Error     error
 }
 
 func NewDeviceTokenRepository() *DeviceTokenRepository {
@@ -19,6 +21,16 @@ func NewDeviceTokenRepository() *DeviceTokenRepository {
 
 func (r *DeviceTokenRepository) Expectations() {
 	r.DeviceTokenAccessor.Expectations()
+}
+
+func (r *DeviceTokenRepository) GetAllByUserID(ctx context.Context, userID string) ([]*devicetokens.Document, error) {
+	if r.Error != nil {
+		return nil, r.Error
+	}
+	if len(r.Documents) > 0 {
+		return r.Documents, nil
+	}
+	return nil, nil
 }
 
 func (r *DeviceTokenRepository) Upsert(ctx context.Context, doc *devicetokens.Document) error {

--- a/devicetokens/devicetokens.go
+++ b/devicetokens/devicetokens.go
@@ -100,6 +100,7 @@ type AppleBlob []byte
 
 // Repository abstracts persistent storage for Token data.
 type Repository interface {
+	GetAllByUserID(ctx context.Context, userID string) ([]*Document, error)
 	Upsert(ctx context.Context, doc *Document) error
 
 	EnsureIndexes() error


### PR DESCRIPTION
These endpoints will be used by the data service when it determines that a push notification should be sent to a care partner follower.

BACK-2554