### PR TITLE
adds the ability to retrieve device tokens to the auth client

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 
+	"github.com/tidepool-org/platform/devicetokens"
 	"github.com/tidepool-org/platform/request"
 )
 
@@ -18,6 +19,7 @@ type Client interface {
 	ProviderSessionAccessor
 	RestrictedTokenAccessor
 	ExternalAccessor
+	DeviceTokensClient
 }
 
 type ExternalAccessor interface {
@@ -46,4 +48,10 @@ func ServerSessionTokenFromContext(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+// DeviceTokensClient provides access to the tokens used to authenticate
+// mobile device push notifications.
+type DeviceTokensClient interface {
+	GetDeviceTokens(ctx context.Context, userID string) ([]*devicetokens.DeviceToken, error)
 }

--- a/auth/client/client.go
+++ b/auth/client/client.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/tidepool-org/platform/auth"
+	"github.com/tidepool-org/platform/devicetokens"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
@@ -306,6 +307,25 @@ func (c *Client) DeleteRestrictedToken(ctx context.Context, id string) error {
 
 	url := c.client.ConstructURL("v1", "restricted_tokens", id)
 	return c.client.RequestData(ctx, http.MethodDelete, url, nil, nil, nil)
+}
+
+// GetDeviceTokens belonging to a given user.
+func (c *Client) GetDeviceTokens(ctx context.Context, userID string) ([]*devicetokens.DeviceToken, error) {
+	ctx = log.NewContextWithLogger(ctx, c.logger)
+	if c.client.IsAuthorizeAsService() {
+		serverSessionToken, err := c.ServerSessionToken()
+		if err != nil {
+			return nil, err
+		}
+		ctx = auth.NewContextWithServerSessionToken(ctx, serverSessionToken)
+	}
+	url := c.client.ConstructURL("v1", "users", userID, "device_tokens")
+	tokens := []*devicetokens.DeviceToken{}
+	err := c.client.RequestData(ctx, http.MethodGet, url, nil, nil, &tokens)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to request device token data")
+	}
+	return tokens, nil
 }
 
 type ConfigLoader interface {

--- a/auth/client/client_test.go
+++ b/auth/client/client_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/tidepool-org/platform/auth"
 	authClient "github.com/tidepool-org/platform/auth/client"
 	authTest "github.com/tidepool-org/platform/auth/test"
+	"github.com/tidepool-org/platform/devicetokens"
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/log"
@@ -459,6 +461,64 @@ var _ = Describe("Client", func() {
 						Expect(details.IsService()).To(BeTrue())
 						Expect(details.UserID()).To(BeEmpty())
 					})
+				})
+			})
+
+			Describe("GetDeviceTokens", func() {
+				var testUserID = "test-user-id"
+				var testUserIDBadResponse = "test-user-id-bad-response"
+				var testTokens = map[string]any{
+					testUserID: []*devicetokens.DeviceToken{{
+						Apple: &devicetokens.AppleDeviceToken{
+							Token:       []byte("blah"),
+							Environment: "sandbox",
+						},
+					}},
+					testUserIDBadResponse: []map[string]any{
+						{
+							"Apple": "",
+						},
+					},
+				}
+
+				It("returns a token", func() {
+					body, err := json.Marshal(testTokens[testUserID])
+					Expect(err).To(Succeed())
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest("GET", "/v1/users/"+testUserID+"/device_tokens"),
+							RespondWith(http.StatusOK, body)),
+					)
+
+					tokens, err := client.GetDeviceTokens(ctx, testUserID)
+					Expect(err).To(Succeed())
+					Expect(tokens).To(HaveLen(1))
+					Expect([]byte(tokens[0].Apple.Token)).To(Equal([]byte("blah")))
+					Expect(tokens[0].Apple.Environment).To(Equal("sandbox"))
+				})
+
+				It("returns an error when receiving malformed responses", func() {
+					body, err := json.Marshal(testTokens[testUserIDBadResponse])
+					Expect(err).To(Succeed())
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest("GET", "/v1/users/"+testUserIDBadResponse+"/device_tokens"),
+							RespondWith(http.StatusOK, body)),
+					)
+
+					_, err = client.GetDeviceTokens(ctx, testUserIDBadResponse)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("returns an error on non-200 responses", func() {
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest("GET", "/v1/users/"+testUserID+"/device_tokens"),
+							RespondWith(http.StatusBadRequest, nil)),
+					)
+					_, err := client.GetDeviceTokens(ctx, testUserID)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(ContainSubstring("Unable to request device token data")))
 				})
 			})
 		})

--- a/auth/test/client.go
+++ b/auth/test/client.go
@@ -4,6 +4,7 @@ type Client struct {
 	*ProviderSessionAccessor
 	*RestrictedTokenAccessor
 	*ExternalAccessor
+	*DeviceTokensClient
 }
 
 func NewClient() *Client {
@@ -11,6 +12,7 @@ func NewClient() *Client {
 		ProviderSessionAccessor: NewProviderSessionAccessor(),
 		RestrictedTokenAccessor: NewRestrictedTokenAccessor(),
 		ExternalAccessor:        NewExternalAccessor(),
+		DeviceTokensClient:      NewDeviceTokensClient(),
 	}
 }
 

--- a/auth/test/external_accessor.go
+++ b/auth/test/external_accessor.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 
+	"github.com/tidepool-org/platform/devicetokens"
 	"github.com/tidepool-org/platform/request"
 )
 
@@ -153,4 +154,12 @@ func (e *ExternalAccessor) AssertOutputsEmpty() {
 	if len(e.EnsureAuthorizedUserOutputs) > 0 {
 		panic("EnsureAuthorizedUserOutputs is not empty")
 	}
+}
+
+func NewDeviceTokensClient() *DeviceTokensClient { return &DeviceTokensClient{} }
+
+type DeviceTokensClient struct{}
+
+func (c *DeviceTokensClient) GetDeviceTokens(ctx context.Context, userID string) ([]*devicetokens.DeviceToken, error) {
+	return nil, nil
 }

--- a/auth/test/mock.go
+++ b/auth/test/mock.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 
 	auth "github.com/tidepool-org/platform/auth"
+	devicetokens "github.com/tidepool-org/platform/devicetokens"
 	page "github.com/tidepool-org/platform/page"
 	request "github.com/tidepool-org/platform/request"
 )
@@ -165,6 +166,21 @@ func (m *MockClient) EnsureAuthorizedUser(ctx context.Context, targetUserID, per
 func (mr *MockClientMockRecorder) EnsureAuthorizedUser(ctx, targetUserID, permission interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAuthorizedUser", reflect.TypeOf((*MockClient)(nil).EnsureAuthorizedUser), ctx, targetUserID, permission)
+}
+
+// GetDeviceTokens mocks base method.
+func (m *MockClient) GetDeviceTokens(ctx context.Context, userID string) ([]*devicetokens.DeviceToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceTokens", ctx, userID)
+	ret0, _ := ret[0].([]*devicetokens.DeviceToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceTokens indicates an expected call of GetDeviceTokens.
+func (mr *MockClientMockRecorder) GetDeviceTokens(ctx, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceTokens", reflect.TypeOf((*MockClient)(nil).GetDeviceTokens), ctx, userID)
 }
 
 // GetProviderSession mocks base method.
@@ -381,4 +397,42 @@ func (m *MockExternalAccessor) ValidateSessionToken(ctx context.Context, token s
 func (mr *MockExternalAccessorMockRecorder) ValidateSessionToken(ctx, token interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateSessionToken", reflect.TypeOf((*MockExternalAccessor)(nil).ValidateSessionToken), ctx, token)
+}
+
+// MockDeviceTokensClient is a mock of DeviceTokensClient interface.
+type MockDeviceTokensClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeviceTokensClientMockRecorder
+}
+
+// MockDeviceTokensClientMockRecorder is the mock recorder for MockDeviceTokensClient.
+type MockDeviceTokensClientMockRecorder struct {
+	mock *MockDeviceTokensClient
+}
+
+// NewMockDeviceTokensClient creates a new mock instance.
+func NewMockDeviceTokensClient(ctrl *gomock.Controller) *MockDeviceTokensClient {
+	mock := &MockDeviceTokensClient{ctrl: ctrl}
+	mock.recorder = &MockDeviceTokensClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDeviceTokensClient) EXPECT() *MockDeviceTokensClientMockRecorder {
+	return m.recorder
+}
+
+// GetDeviceTokens mocks base method.
+func (m *MockDeviceTokensClient) GetDeviceTokens(ctx context.Context, userID string) ([]*devicetokens.DeviceToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceTokens", ctx, userID)
+	ret0, _ := ret[0].([]*devicetokens.DeviceToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceTokens indicates an expected call of GetDeviceTokens.
+func (mr *MockDeviceTokensClientMockRecorder) GetDeviceTokens(ctx, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceTokens", reflect.TypeOf((*MockDeviceTokensClient)(nil).GetDeviceTokens), ctx, userID)
 }


### PR DESCRIPTION
This functionality will be used by care partner processes to retrieve device tokens in order to send mobile device push notifications in response to care partner alerts being triggered.

BACK-2554