### PR TITLE
remove unused device tokens repo from data

### DIFF
--- a/data/service/api/v1/mocks/context.go
+++ b/data/service/api/v1/mocks/context.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/tidepool-org/platform/alerts"
 	"github.com/tidepool-org/platform/data/service/context"
-	"github.com/tidepool-org/platform/devicetokens"
 	"github.com/tidepool-org/platform/permission"
 	"github.com/tidepool-org/platform/request"
 	servicecontext "github.com/tidepool-org/platform/service/context"
@@ -23,13 +22,12 @@ type Context struct {
 
 	T likeT
 	// authDetails should be updated via the WithAuthDetails method.
-	authDetails                *test.MockAuthDetails
-	RESTRequest                *rest.Request
-	ResponseWriter             rest.ResponseWriter
-	recorder                   *httptest.ResponseRecorder
-	MockAlertsRepository       alerts.Repository
-	MockDeviceTokensRepository devicetokens.Repository
-	MockPermissionClient       permission.Client
+	authDetails          *test.MockAuthDetails
+	RESTRequest          *rest.Request
+	ResponseWriter       rest.ResponseWriter
+	recorder             *httptest.ResponseRecorder
+	MockAlertsRepository alerts.Repository
+	MockPermissionClient permission.Client
 }
 
 func NewContext(t likeT, method, url string, body io.Reader) *Context {
@@ -96,10 +94,6 @@ func (c *Context) Recorder() *httptest.ResponseRecorder {
 
 func (c *Context) AlertsRepository() alerts.Repository {
 	return c.MockAlertsRepository
-}
-
-func (c *Context) DeviceTokensRepository() devicetokens.Repository {
-	return c.MockDeviceTokensRepository
 }
 
 func (c *Context) PermissionClient() permission.Client {


### PR DESCRIPTION
This was missed when moving device tokens from the data service to the auth service in commit a0f5a84.

BACK-2554