### PR TITLE
don't look for device data provenance without a JWT (part 2)

### DIFF
--- a/data/service/api/v1/datasets_data_create.go
+++ b/data/service/api/v1/datasets_data_create.go
@@ -144,7 +144,7 @@ func CollectProvenanceInfo(ctx context.Context, req *rest.Request, authDetails r
 		token = token[len("bearer "):]
 	}
 
-	if token != "" {
+	if token != "" && shouldHaveJWT(authDetails) {
 		claims := &TokenClaims{}
 		if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
 			lgr.WithError(err).Warn("Unable to parse access token for provenance")
@@ -172,6 +172,20 @@ func CollectProvenanceInfo(ctx context.Context, req *rest.Request, authDetails r
 	}
 
 	return provenance
+}
+
+// shouldHaveJWT indicates if it is expected that this token is a JWT.
+//
+// Of the current authentication methods, three of the four provide token
+// information, but only two of those three, use a JSON Web Token (JWT).
+func shouldHaveJWT(authDetails request.AuthDetails) bool {
+	switch authDetails.Method() {
+	case request.MethodAccessToken:
+		return true
+	case request.MethodSessionToken:
+		return true
+	}
+	return false
 }
 
 // SelectXFF is the first public IP from the X-Forwarded-For request header.

--- a/data/service/api/v1/datasets_data_create_provenance_test.go
+++ b/data/service/api/v1/datasets_data_create_provenance_test.go
@@ -106,11 +106,7 @@ func newTestReqAndDetails(clientID, userID, sourceIP string) (*rest.Request, req
 			Header:     headers,
 		},
 	}
-	method := request.MethodSessionToken
-	if userID == "" {
-		method = request.MethodServiceSecret
-	}
-	details := request.NewAuthDetails(method, userID, token)
+	details := request.NewAuthDetails(request.MethodSessionToken, userID, token)
 	return req, details
 }
 


### PR DESCRIPTION
In a previous commit (see BACK-2995), empty tokens were excluded, but there can be tokens that aren't JWTs, which would still trigger a spurious log message. This change removes more cases where a token exists, but isn't a JWT. The goal is to log a warning when we expect a JWT, but don't get one.

BACK-3027