### PR TITLE
adds a mongodb query for alertable data

### DIFF
--- a/data/service/api/v1/users_datasets_create_test.go
+++ b/data/service/api/v1/users_datasets_create_test.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ant0ine/go-json-rest/rest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/ant0ine/go-json-rest/rest"
 
 	"github.com/tidepool-org/platform/alerts"
 	"github.com/tidepool-org/platform/auth"

--- a/data/store/mongo/mongo_datum.go
+++ b/data/store/mongo/mongo_datum.go
@@ -12,9 +12,14 @@ import (
 	"errors"
 
 	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/data/summary/types"
 	baseDatum "github.com/tidepool-org/platform/data/types"
+	"github.com/tidepool-org/platform/data/types/blood/glucose"
+	"github.com/tidepool-org/platform/data/types/blood/glucose/continuous"
+	"github.com/tidepool-org/platform/data/types/dosingdecision"
 	"github.com/tidepool-org/platform/data/types/upload"
+	platerrors "github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -627,6 +632,56 @@ func (d *DatumRepository) GetDataRange(ctx context.Context, userId string, typ s
 		return nil, fmt.Errorf("unable to get %s data in date range for user: %w", typ, err)
 	}
 
+	return cursor, nil
+}
+
+func (d *DatumRepository) GetAlertableData(ctx context.Context,
+	params store.AlertableParams) (*store.AlertableResponse, error) {
+
+	if params.End.IsZero() {
+		params.End = time.Now()
+	}
+
+	cursor, err := d.getAlertableData(ctx, params, dosingdecision.Type)
+	if err != nil {
+		return nil, err
+	}
+	dosingDecisions := []*dosingdecision.DosingDecision{}
+	if err := cursor.All(ctx, &dosingDecisions); err != nil {
+		return nil, platerrors.Wrap(err, "Unable to load alertable dosing documents")
+	}
+	cursor, err = d.getAlertableData(ctx, params, continuous.Type)
+	if err != nil {
+		return nil, err
+	}
+	glucoseData := []*glucose.Glucose{}
+	if err := cursor.All(ctx, &glucoseData); err != nil {
+		return nil, platerrors.Wrap(err, "Unable to load alertable glucose documents")
+	}
+	response := &store.AlertableResponse{
+		DosingDecisions: dosingDecisions,
+		Glucose:         glucoseData,
+	}
+
+	return response, nil
+}
+
+func (d *DatumRepository) getAlertableData(ctx context.Context,
+	params store.AlertableParams, typ string) (*mongo.Cursor, error) {
+
+	selector := bson.M{
+		"_active":  true,
+		"uploadId": params.UploadID,
+		"type":     typ,
+		"_userId":  params.UserID,
+		"time":     bson.M{"$gte": params.Start, "$lte": params.End},
+	}
+	findOptions := options.Find().SetSort(bson.D{{Key: "time", Value: -1}})
+	cursor, err := d.Find(ctx, selector, findOptions)
+	if err != nil {
+		format := "Unable to find alertable %s data in dataset %s"
+		return nil, platerrors.Wrapf(err, format, typ, params.UploadID)
+	}
 	return cursor, nil
 }
 

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -2598,6 +2598,75 @@ var _ = Describe("Mongo", func() {
 			})
 		})
 
+		Context("GetAlertableData", func() {
+			testDataSet := func(userID, deviceID string) *upload.Upload {
+				GinkgoHelper()
+				collection = store.GetCollection("deviceData")
+				dataSetCollection = store.GetCollection("deviceDataSets")
+				upload := NewDataSet(userID, deviceID)
+				creationTime := time.Now().Add(-24 * time.Hour)
+				upload.Active = true
+				upload.CreatedTime = pointer.FromTime(creationTime)
+				upload.ModifiedTime = pointer.FromTime(creationTime)
+				return upload
+			}
+
+			testDataSetData := func(upload *upload.Upload) []data.Datum {
+				requiredRecords := test.RandomIntFromRange(6, 8)
+				recordInterval := 5 * time.Minute
+				t := time.Now().UTC().Add(-time.Duration(requiredRecords) * recordInterval)
+				var dataSetData = make([]data.Datum, 0, 2*requiredRecords)
+				for count := 0; count < requiredRecords; count++ {
+					datum := dataTypesTest.RandomBase()
+					datum.Type = "cbg"
+					datumTime := t.Add(time.Duration(count) * recordInterval)
+					datum.Time = pointer.FromAny(datumTime)
+					datum.Active = true
+					datum.DeviceID = pointer.FromAny(*upload.DeviceID)
+					datum.UploadID = pointer.FromAny(*upload.UploadID)
+					dataSetData = append(dataSetData, datum)
+
+					datum = dataTypesTest.RandomBase()
+					datum.Type = "dosingDecision"
+					datum.Time = pointer.FromAny(datumTime)
+					datum.Active = true
+					datum.DeviceID = pointer.FromAny(*upload.DeviceID)
+					datum.UploadID = pointer.FromAny(*upload.UploadID)
+					dataSetData = append(dataSetData, datum)
+				}
+				return dataSetData
+			}
+
+			It("retrieves both cbg and dosing data", func() {
+				var err error
+				ctx := context.Background()
+				ctx = log.NewContextWithLogger(ctx, logTest.NewLogger())
+				repository = store.NewDataRepository()
+				Expect(repository).ToNot(BeNil())
+				testUserID := userTest.RandomID()
+				testDeviceID := dataTest.NewDeviceID()
+				testSet := testDataSet(testUserID, testDeviceID)
+				Expect(repository.CreateDataSet(ctx, testSet)).To(Succeed())
+				testSetData := testDataSetData(testSet)
+				Expect(repository.CreateDataSetData(ctx, testSet, testSetData)).To(Succeed())
+				store, err = dataStoreMongo.NewStore(config)
+				Expect(err).To(Succeed())
+
+				params := dataStore.AlertableParams{
+					Start:    time.Now().Add(-time.Hour),
+					UserID:   testUserID,
+					UploadID: *testSet.UploadID,
+				}
+				resp, err := store.NewDataRepository().GetAlertableData(ctx, params)
+
+				Expect(err).To(Succeed())
+				Expect(resp).ToNot(BeNil())
+				Expect(resp.Glucose).ToNot(BeEmpty())
+				Expect(resp.DosingDecisions).ToNot(BeEmpty())
+			})
+
+		})
+
 		Context("alerts", func() {
 			BeforeEach(func() {
 				var err error

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/tidepool-org/platform/alerts"
 	"github.com/tidepool-org/platform/data/summary/types"
+	"github.com/tidepool-org/platform/data/types/blood/glucose"
+	"github.com/tidepool-org/platform/data/types/dosingdecision"
 
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/data/types/upload"
@@ -67,6 +69,9 @@ type DatumRepository interface {
 	DistinctUserIDs(ctx context.Context, typ string) ([]string, error)
 
 	CheckDataSetContainsTypeInRange(ctx context.Context, dataSetId string, typ string, startTime time.Time, endTime time.Time) (bool, error)
+
+	// GetAlertableData queries for the data used to evaluate alerts configurations.
+	GetAlertableData(ctx context.Context, params AlertableParams) (*AlertableResponse, error)
 }
 
 // DataRepository is the combined interface of DataSetRepository and
@@ -96,4 +101,20 @@ type SummaryRepository interface {
 	EnsureIndexes() error
 
 	GetStore() *storeStructuredMongo.Repository
+}
+
+type AlertableParams struct {
+	// UserID of the user that owns the data.
+	UserID string
+	// UploadID of the device data set to query.
+	UploadID string
+	// Start limits the data to those recorded after this time.
+	Start time.Time
+	// End limits the data to those recorded before this time.
+	End time.Time
+}
+
+type AlertableResponse struct {
+	Glucose         []*glucose.Glucose
+	DosingDecisions []*dosingdecision.DosingDecision
 }

--- a/data/store/test/data_repository.go
+++ b/data/store/test/data_repository.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"time"
 
-	"go.mongodb.org/mongo-driver/mongo"
-
-	"github.com/tidepool-org/platform/data/summary/types"
-
 	"github.com/onsi/gomega"
+	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/tidepool-org/platform/data"
 	dataStore "github.com/tidepool-org/platform/data/store"
+	"github.com/tidepool-org/platform/data/summary/types"
 	"github.com/tidepool-org/platform/data/types/upload"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/test"
@@ -195,6 +193,16 @@ type CheckDataSetContainsTypeInRangeOutput struct {
 	Error  error
 }
 
+type GetAlertableDataInput struct {
+	Context context.Context
+	Params  dataStore.AlertableParams
+}
+
+type GetAlertableDataOutput struct {
+	Response *dataStore.AlertableResponse
+	Error    error
+}
+
 type DataRepository struct {
 	*test.Closer
 	GetDataSetsForUserByIDInvocations                    int
@@ -268,6 +276,10 @@ type DataRepository struct {
 	CheckDataSetContainsTypeInRangeInvocations int
 	CheckDataSetContainsTypeInRangeInputs      []CheckDataSetContainsTypeInRangeInput
 	CheckDataSetContainsTypeInRangeOutputs     []CheckDataSetContainsTypeInRangeOutput
+
+	GetAlertableDataInvocations int
+	GetAlertableDataInputs      []GetAlertableDataInput
+	GetAlertableDataOutputs     []GetAlertableDataOutput
 }
 
 func NewDataRepository() *DataRepository {
@@ -543,6 +555,18 @@ func (d *DataRepository) CheckDataSetContainsTypeInRange(ctx context.Context, da
 	output := d.CheckDataSetContainsTypeInRangeOutputs[0]
 	d.CheckDataSetContainsTypeInRangeOutputs = d.CheckDataSetContainsTypeInRangeOutputs[1:]
 	return output.Status, output.Error
+}
+
+func (d *DataRepository) GetAlertableData(ctx context.Context, params dataStore.AlertableParams) (*dataStore.AlertableResponse, error) {
+	d.GetAlertableDataInvocations++
+
+	d.GetAlertableDataInputs = append(d.GetAlertableDataInputs, GetAlertableDataInput{Context: ctx, Params: params})
+
+	gomega.Expect(d.GetAlertableDataOutputs).ToNot(gomega.BeEmpty())
+
+	output := d.GetAlertableDataOutputs[0]
+	d.GetAlertableDataOutputs = d.GetAlertableDataOutputs[1:]
+	return output.Response, output.Error
 }
 
 func (d *DataRepository) Expectations() {

--- a/tools/benchmark_data_store/benchmark_data_store.go
+++ b/tools/benchmark_data_store/benchmark_data_store.go
@@ -5,8 +5,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strconv"
 	"time"
 
@@ -209,7 +209,7 @@ func (t *Tool) loadBenchmarks() error {
 func (t *Tool) loadBenchmarksFile(benchmarksFile string) (Benchmarks, error) {
 	t.Logger().Debugf("Loading benchmarks file %q", benchmarksFile)
 
-	content, err := ioutil.ReadFile(benchmarksFile)
+	content, err := os.ReadFile(benchmarksFile)
 	if err != nil {
 		return nil, errors.Newf("unable to read content from benchmarks file %q", benchmarksFile)
 	}


### PR DESCRIPTION
Where alertable data means those data used when evaluating whether a defined alert configuration is triggered, and a notification needs to be sent.

BACK-2554