### PR TITLE
Move logger implementation into separate package to prevent import cycle

### DIFF
--- a/log/json/logger.go
+++ b/log/json/logger.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/log/logger"
 )
 
 // CONCURRENCY: SAFE IFF writer is safe
@@ -14,5 +15,5 @@ func NewLogger(writer io.Writer, levelRanks log.LevelRanks, level log.Level) (lo
 		return nil, err
 	}
 
-	return log.NewLogger(serializer, levelRanks, level)
+	return logger.New(serializer, levelRanks, level)
 }

--- a/log/json/serializer_test.go
+++ b/log/json/serializer_test.go
@@ -1,11 +1,10 @@
 package json_test
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	logJson "github.com/tidepool-org/platform/log/json"
 )

--- a/log/logger/log_suite_test.go
+++ b/log/logger/log_suite_test.go
@@ -1,0 +1,11 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/tidepool-org/platform/test"
+)
+
+func TestSuite(t *testing.T) {
+	test.Test(t)
+}

--- a/log/logger/logger.go
+++ b/log/logger/logger.go
@@ -1,4 +1,4 @@
-package log
+package logger
 
 import (
 	"fmt"
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 )
 
 // CONCURRENCY: SAFE IFF serializer is safe
 
-func NewLogger(serializer Serializer, levelRanks LevelRanks, level Level) (Logger, error) {
+func New(serializer log.Serializer, levelRanks log.LevelRanks, level log.Level) (log.Logger, error) {
 	if serializer == nil {
 		return nil, errors.New("serializer is missing")
 	}
@@ -18,7 +19,7 @@ func NewLogger(serializer Serializer, levelRanks LevelRanks, level Level) (Logge
 		return nil, errors.New("level ranks is missing")
 	}
 
-	fields := Fields{}
+	fields := log.Fields{}
 
 	rank, found := levelRanks[level]
 	if !found {
@@ -35,50 +36,50 @@ func NewLogger(serializer Serializer, levelRanks LevelRanks, level Level) (Logge
 }
 
 type logger struct {
-	serializer Serializer
-	fields     Fields
-	levelRanks LevelRanks
-	level      Level
-	rank       Rank
+	serializer log.Serializer
+	fields     log.Fields
+	levelRanks log.LevelRanks
+	level      log.Level
+	rank       log.Rank
 }
 
-func (l *logger) Log(level Level, message string) {
+func (l *logger) Log(level log.Level, message string) {
 	l.log(level, message)
 }
 
 func (l *logger) Debug(message string) {
-	l.log(DebugLevel, message)
+	l.log(log.DebugLevel, message)
 }
 
 func (l *logger) Info(message string) {
-	l.log(InfoLevel, message)
+	l.log(log.InfoLevel, message)
 }
 
 func (l *logger) Warn(message string) {
-	l.log(WarnLevel, message)
+	l.log(log.WarnLevel, message)
 }
 
 func (l *logger) Error(message string) {
-	l.log(ErrorLevel, message)
+	l.log(log.ErrorLevel, message)
 }
 
 func (l *logger) Debugf(message string, args ...interface{}) {
-	l.log(DebugLevel, fmt.Sprintf(message, args...))
+	l.log(log.DebugLevel, fmt.Sprintf(message, args...))
 }
 
 func (l *logger) Infof(message string, args ...interface{}) {
-	l.log(InfoLevel, fmt.Sprintf(message, args...))
+	l.log(log.InfoLevel, fmt.Sprintf(message, args...))
 }
 
 func (l *logger) Warnf(message string, args ...interface{}) {
-	l.log(WarnLevel, fmt.Sprintf(message, args...))
+	l.log(log.WarnLevel, fmt.Sprintf(message, args...))
 }
 
 func (l *logger) Errorf(message string, args ...interface{}) {
-	l.log(ErrorLevel, fmt.Sprintf(message, args...))
+	l.log(log.ErrorLevel, fmt.Sprintf(message, args...))
 }
 
-func (l *logger) WithError(err error) Logger {
+func (l *logger) WithError(err error) log.Logger {
 	var value interface{}
 	if err != nil {
 		value = errors.NewSerializable(err)
@@ -86,11 +87,11 @@ func (l *logger) WithError(err error) Logger {
 	return l.WithField("error", value)
 }
 
-func (l *logger) WithField(key string, value interface{}) Logger {
-	return l.WithFields(Fields{key: value})
+func (l *logger) WithField(key string, value interface{}) log.Logger {
+	return l.WithFields(log.Fields{key: value})
 }
 
-func (l *logger) WithFields(fields Fields) Logger {
+func (l *logger) WithFields(fields log.Fields) log.Logger {
 	return &logger{
 		serializer: l.serializer,
 		fields:     joinFields(l.fields, fields),
@@ -100,11 +101,11 @@ func (l *logger) WithFields(fields Fields) Logger {
 	}
 }
 
-func (l *logger) WithLevelRank(level Level, rank Rank) Logger {
-	return l.WithLevelRanks(LevelRanks{level: rank})
+func (l *logger) WithLevelRank(level log.Level, rank log.Rank) log.Logger {
+	return l.WithLevelRanks(log.LevelRanks{level: rank})
 }
 
-func (l *logger) WithLevelRanks(levelRanks LevelRanks) Logger {
+func (l *logger) WithLevelRanks(levelRanks log.LevelRanks) log.Logger {
 	return &logger{
 		serializer: l.serializer,
 		fields:     l.fields,
@@ -114,7 +115,7 @@ func (l *logger) WithLevelRanks(levelRanks LevelRanks) Logger {
 	}
 }
 
-func (l *logger) WithLevel(level Level) Logger {
+func (l *logger) WithLevel(level log.Level) log.Logger {
 	rank, ok := l.levelRanks[level]
 	if !ok {
 		level = l.level
@@ -130,11 +131,11 @@ func (l *logger) WithLevel(level Level) Logger {
 	}
 }
 
-func (l *logger) Level() Level {
+func (l *logger) Level() log.Level {
 	return l.level
 }
 
-func (l *logger) log(level Level, message string) {
+func (l *logger) log(level log.Level, message string) {
 	rank, found := l.levelRanks[level]
 	if !found {
 		return
@@ -144,7 +145,7 @@ func (l *logger) log(level Level, message string) {
 		return
 	}
 
-	fields := Fields{
+	fields := log.Fields{
 		"caller": errors.GetCaller(2),
 		"level":  level,
 		"time":   time.Now().Truncate(time.Microsecond).Format(time.RFC3339Nano),
@@ -159,8 +160,8 @@ func (l *logger) log(level Level, message string) {
 	}
 }
 
-func joinLevelRanks(levelRanks ...LevelRanks) LevelRanks {
-	joined := LevelRanks{}
+func joinLevelRanks(levelRanks ...log.LevelRanks) log.LevelRanks {
+	joined := log.LevelRanks{}
 	for _, inner := range levelRanks {
 		for level, rank := range inner {
 			joined[level] = rank
@@ -169,8 +170,8 @@ func joinLevelRanks(levelRanks ...LevelRanks) LevelRanks {
 	return joined
 }
 
-func joinFields(fields ...Fields) Fields {
-	joined := Fields{}
+func joinFields(fields ...log.Fields) log.Fields {
+	joined := log.Fields{}
 	for _, inner := range fields {
 		for key, value := range inner {
 			if key != "" {

--- a/log/null/logger.go
+++ b/log/null/logger.go
@@ -1,10 +1,13 @@
 package null
 
-import "github.com/tidepool-org/platform/log"
+import (
+	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/log/logger"
+)
 
 // CONCURRENCY: SAFE
 
 func NewLogger() log.Logger {
-	logger, _ := log.NewLogger(NewSerializer(), log.DefaultLevelRanks(), log.DefaultLevel()) // Safely ignore error; cannot fail
-	return logger
+	lgr, _ := logger.New(NewSerializer(), log.DefaultLevelRanks(), log.DefaultLevel()) // Safely ignore error; cannot fail
+	return lgr
 }

--- a/log/test/logger.go
+++ b/log/test/logger.go
@@ -1,6 +1,9 @@
 package test
 
-import "github.com/tidepool-org/platform/log"
+import (
+	"github.com/tidepool-org/platform/log"
+	"github.com/tidepool-org/platform/log/logger"
+)
 
 type Logger struct {
 	*Serializer
@@ -9,9 +12,9 @@ type Logger struct {
 
 func NewLogger() *Logger {
 	serializer := NewSerializer()
-	logger, _ := log.NewLogger(serializer, log.DefaultLevelRanks(), log.DebugLevel)
+	lgr, _ := logger.New(serializer, log.DefaultLevelRanks(), log.DebugLevel)
 	return &Logger{
 		Serializer: serializer,
-		Logger:     logger,
+		Logger:     lgr,
 	}
 }


### PR DESCRIPTION
The change was made to prevent an import cycle in a following PR. It simply moves the logger implementation from the `log` package into the `log/logger` package.

NOTE: This is a part of the overall Dexcom work which will be collected into a final PR for final approval. However, since the work covers a number of different issues, I broke up the development into multiple smaller and more focused PRs. Once all of the smaller PRs are approved, I'll create a final overall PR for approval that will eventually be tested and deployed. (The smaller PRs will not be tested nor deployed.)