### PR TITLE
Include logger in structure validator, parser, and normalizer

### DIFF
--- a/alerts/config_test.go
+++ b/alerts/config_test.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/tidepool-org/platform/data/blood/glucose"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/request"
 	"github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -68,7 +70,7 @@ var _ = Describe("Config", func() {
   }
 }`, mockUserID1, mockUserID2)
 		conf := &Config{}
-		err := request.DecodeObject(nil, buf, conf)
+		err := request.DecodeObject(context.Background(), nil, buf, conf)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UserID).To(Equal(mockUserID1))
 		Expect(conf.FollowedUserID).To(Equal(mockUserID2))
@@ -97,22 +99,22 @@ var _ = Describe("Config", func() {
 	Context("UrgentLowAlert", func() {
 		Context("Threshold", func() {
 			It("accepts values between 0 and 1000 mg/dL", func() {
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := UrgentLowAlert{Threshold: Threshold{Value: 0, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = UrgentLowAlert{Threshold: Threshold{Value: 1000, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = UrgentLowAlert{Threshold: Threshold{Value: 1001, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 1001 is not between 0 and 1000"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = UrgentLowAlert{Threshold: Threshold{Value: -1, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1 is not between 0 and 1000"))
@@ -123,29 +125,29 @@ var _ = Describe("Config", func() {
 	Context("LowAlert", func() {
 		Context("Threshold", func() {
 			It("accepts values in mmol/L", func() {
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := LowAlert{Threshold: Threshold{Value: 4.2735, Units: "mmol/L"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 			})
 
 			It("accepts values between 0 and 1000 mg/dL", func() {
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := LowAlert{Threshold: Threshold{Value: 0, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = LowAlert{Threshold: Threshold{Value: 1000, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = LowAlert{Threshold: Threshold{Value: 1001, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 1001 is not between 0 and 1000"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = LowAlert{Threshold: Threshold{Value: -1, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1 is not between 0 and 1000"))
@@ -156,22 +158,22 @@ var _ = Describe("Config", func() {
 			It("accepts values between 0 and 6 hours (inclusive)", func() {
 				okThresh := Threshold{Units: "mg/dL", Value: 123}
 
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := HighAlert{Delay: 0, Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Delay: DurationMinutes(time.Hour * 6 / time.Minute), Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Delay: -1, Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1ns is not between 0s and 6h0m0s"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Delay: DurationMinutes(time.Hour*6 + time.Minute), Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 6h1m0s is not between 0s and 6h0m0s"))
@@ -182,22 +184,22 @@ var _ = Describe("Config", func() {
 	Context("HighAlert", func() {
 		Context("Threshold", func() {
 			It("accepts values between 0 and 1000 mg/dL", func() {
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := HighAlert{Threshold: Threshold{Value: 0, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Threshold: Threshold{Value: 1000, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Threshold: Threshold{Value: 1001, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 1001 is not between 0 and 1000"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Threshold: Threshold{Value: -1, Units: "mg/dL"}}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1 is not between 0 and 1000"))
@@ -208,22 +210,22 @@ var _ = Describe("Config", func() {
 			It("accepts values between 0 and 6 hours (inclusive)", func() {
 				okThresh := Threshold{Units: "mg/dL", Value: 123}
 
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := HighAlert{Delay: 0, Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Delay: DurationMinutes(time.Hour * 6 / time.Minute), Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Delay: -1, Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1ns is not between 0s and 6h0m0s"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = HighAlert{Delay: DurationMinutes(time.Hour*6 + time.Minute), Threshold: okThresh}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 6h1m0s is not between 0s and 6h0m0s"))
@@ -234,22 +236,22 @@ var _ = Describe("Config", func() {
 	Context("NoCommunicationAlert", func() {
 		Context("Delay", func() {
 			It("accepts values between 0 and 6 hours (inclusive)", func() {
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := NoCommunicationAlert{Delay: 0}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = NoCommunicationAlert{Delay: DurationMinutes(time.Hour * 6)}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = NoCommunicationAlert{Delay: -1}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1ns is not between 0s and 6h0m0s"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = NoCommunicationAlert{Delay: DurationMinutes(time.Hour*6 + time.Second)}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 6h0m1s is not between 0s and 6h0m0s"))
@@ -260,22 +262,22 @@ var _ = Describe("Config", func() {
 	Context("NotLoopingAlert", func() {
 		Context("Delay", func() {
 			It("accepts values between 0 and 2 hours (inclusive)", func() {
-				val := validator.New()
+				val := validator.New(logTest.NewLogger())
 				b := NotLoopingAlert{Delay: 0}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = NotLoopingAlert{Delay: DurationMinutes(2 * time.Hour)}
 				b.Validate(val)
 				Expect(val.Error()).To(Succeed())
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = NotLoopingAlert{Delay: -1}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value -1ns is not between 0s and 2h0m0s"))
 
-				val = validator.New()
+				val = validator.New(logTest.NewLogger())
 				b = NotLoopingAlert{Delay: DurationMinutes(2*time.Hour + time.Second)}
 				b.Validate(val)
 				Expect(val.Error()).To(MatchError("value 2h0m1s is not between 0s and 2h0m0s"))
@@ -286,29 +288,29 @@ var _ = Describe("Config", func() {
 
 	Context("repeat", func() {
 		It("accepts values of 0 (indicating disabled)", func() {
-			val := validator.New()
+			val := validator.New(logTest.NewLogger())
 			b := Base{Repeat: 0}
 			b.Validate(val)
 			Expect(val.Error()).To(Succeed())
 		})
 
 		It("accepts values of 15 minutes to 4 hours (inclusive)", func() {
-			val := validator.New()
+			val := validator.New(logTest.NewLogger())
 			b := Base{Repeat: DurationMinutes(15 * time.Minute)}
 			b.Validate(val)
 			Expect(val.Error()).To(Succeed())
 
-			val = validator.New()
+			val = validator.New(logTest.NewLogger())
 			b = Base{Repeat: DurationMinutes(4 * time.Hour)}
 			b.Validate(val)
 			Expect(val.Error()).To(Succeed())
 
-			val = validator.New()
+			val = validator.New(logTest.NewLogger())
 			b = Base{Repeat: DurationMinutes(4*time.Hour + 1)}
 			b.Validate(val)
 			Expect(val.Error()).NotTo(Succeed())
 
-			val = validator.New()
+			val = validator.New(logTest.NewLogger())
 			b = Base{Repeat: DurationMinutes(15*time.Minute - 1)}
 			b.Validate(val)
 			Expect(val.Error()).NotTo(Succeed())
@@ -319,7 +321,7 @@ var _ = Describe("Config", func() {
 		It("validates threshold units", func() {
 			buf := buff(`{"urgentLow": {"threshold": {"units":"%s","value":42}}`, "garbage")
 			threshold := &Threshold{}
-			err := request.DecodeObject(nil, buf, threshold)
+			err := request.DecodeObject(context.Background(), nil, buf, threshold)
 			Expect(err).To(MatchError("json is malformed"))
 		})
 		It("validates repeat minutes (negative)", func() {
@@ -336,7 +338,7 @@ var _ = Describe("Config", func() {
   }
 }`, mockUserID1, mockUserID2, glucose.MgdL)
 			cfg := &Config{}
-			err := request.DecodeObject(nil, buf, cfg)
+			err := request.DecodeObject(context.Background(), nil, buf, cfg)
 			Expect(err).To(MatchError("value -11m0s is not greater than or equal to 15m0s"))
 		})
 		It("validates repeat minutes (string)", func() {
@@ -353,7 +355,7 @@ var _ = Describe("Config", func() {
   }
 }`, mockUserID1, mockUserID2, glucose.MgdL)
 			cfg := &Config{}
-			err := request.DecodeObject(nil, buf, cfg)
+			err := request.DecodeObject(context.Background(), nil, buf, cfg)
 			Expect(err).To(MatchError("json is malformed"))
 		})
 	})
@@ -373,7 +375,7 @@ var _ = Describe("Config", func() {
   }
 }`, mockUserID1, mockUserID2)
 			conf := &Config{}
-			err := request.DecodeObject(nil, buf, conf)
+			err := request.DecodeObject(context.Background(), nil, buf, conf)
 			Expect(err).To(Succeed())
 			Expect(conf.Low.Repeat).To(Equal(DurationMinutes(0)))
 		})
@@ -417,7 +419,7 @@ var _ = Describe("Threshold", func() {
 	It("accepts mg/dL", func() {
 		buf := buff(`{"units":"%s","value":42}`, glucose.MgdL)
 		threshold := &Threshold{}
-		err := request.DecodeObject(nil, buf, threshold)
+		err := request.DecodeObject(context.Background(), nil, buf, threshold)
 		Expect(err).To(BeNil())
 		Expect(threshold.Value).To(Equal(42.0))
 		Expect(threshold.Units).To(Equal(glucose.MgdL))
@@ -425,25 +427,25 @@ var _ = Describe("Threshold", func() {
 	It("accepts mmol/L", func() {
 		buf := buff(`{"units":"%s","value":42}`, glucose.MmolL)
 		threshold := &Threshold{}
-		err := request.DecodeObject(nil, buf, threshold)
+		err := request.DecodeObject(context.Background(), nil, buf, threshold)
 		Expect(err).To(BeNil())
 		Expect(threshold.Value).To(Equal(42.0))
 		Expect(threshold.Units).To(Equal(glucose.MmolL))
 	})
 	It("rejects lb/gal", func() {
 		buf := buff(`{"units":"%s","value":42}`, "lb/gal")
-		err := request.DecodeObject(nil, buf, &Threshold{})
+		err := request.DecodeObject(context.Background(), nil, buf, &Threshold{})
 		Expect(err).Should(HaveOccurred())
 	})
 	It("rejects blank units", func() {
 		buf := buff(`{"units":"","value":42}`)
-		err := request.DecodeObject(nil, buf, &Threshold{})
+		err := request.DecodeObject(context.Background(), nil, buf, &Threshold{})
 		Expect(err).Should(HaveOccurred())
 	})
 	It("is case-sensitive with respect to Units", func() {
 		badUnits := strings.ToUpper(glucose.MmolL)
 		buf := buff(`{"units":"%s","value":42}`, badUnits)
-		err := request.DecodeObject(nil, buf, &Threshold{})
+		err := request.DecodeObject(context.Background(), nil, buf, &Threshold{})
 		Expect(err).Should(HaveOccurred())
 	})
 

--- a/association/association_test.go
+++ b/association/association_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidepool-org/platform/data"
 	dataTest "github.com/tidepool-org/platform/data/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/net"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -76,13 +77,13 @@ var _ = Describe("Association", func() {
 
 		Context("ParseAssociation", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(association.ParseAssociation(structureParser.NewObject(nil))).To(BeNil())
+				Expect(association.ParseAssociation(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := associationTest.RandomAssociation()
 				object := associationTest.NewObjectFromAssociation(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(association.ParseAssociation(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -101,7 +102,7 @@ var _ = Describe("Association", func() {
 					object := associationTest.NewObjectFromAssociation(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &association.Association{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -131,7 +132,7 @@ var _ = Describe("Association", func() {
 				func(mutator func(datum *association.Association), expectedErrors ...error) {
 					datum := associationTest.RandomAssociation()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *association.Association) {},
@@ -527,13 +528,13 @@ var _ = Describe("Association", func() {
 	Context("AssociationArray", func() {
 		Context("ParseAssociationArray", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(association.ParseAssociationArray(structureParser.NewArray(nil))).To(BeNil())
+				Expect(association.ParseAssociationArray(structureParser.NewArray(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := associationTest.RandomAssociationArray()
 				array := associationTest.NewArrayFromAssociationArray(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				Expect(association.ParseAssociationArray(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -547,7 +548,7 @@ var _ = Describe("Association", func() {
 
 		Context("Parse", func() {
 			It("successfully parses a nil array", func() {
-				parser := structureParser.NewArray(nil)
+				parser := structureParser.NewArray(logTest.NewLogger(), nil)
 				datum := association.NewAssociationArray()
 				datum.Parse(parser)
 				Expect(datum).To(Equal(association.NewAssociationArray()))
@@ -555,7 +556,7 @@ var _ = Describe("Association", func() {
 			})
 
 			It("successfully parses an empty array", func() {
-				parser := structureParser.NewArray(&[]interface{}{})
+				parser := structureParser.NewArray(logTest.NewLogger(), &[]interface{}{})
 				datum := association.NewAssociationArray()
 				datum.Parse(parser)
 				Expect(datum).To(Equal(association.NewAssociationArray()))
@@ -565,7 +566,7 @@ var _ = Describe("Association", func() {
 			It("successfully parses a non-empty array", func() {
 				expectedDatum := associationTest.RandomAssociationArray()
 				array := associationTest.NewArrayFromAssociationArray(expectedDatum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				datum := association.NewAssociationArray()
 				datum.Parse(parser)
 				Expect(datum).To(Equal(expectedDatum))
@@ -578,7 +579,7 @@ var _ = Describe("Association", func() {
 				func(mutator func(datum *association.AssociationArray), expectedErrors ...error) {
 					datum := associationTest.RandomAssociationArray()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *association.AssociationArray) {},

--- a/auth/client/client.go
+++ b/auth/client/client.go
@@ -81,12 +81,12 @@ func (c *Client) ListUserProviderSessions(ctx context.Context, userID string, fi
 	}
 	if filter == nil {
 		filter = auth.NewProviderSessionFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -108,7 +108,7 @@ func (c *Client) CreateUserProviderSession(ctx context.Context, userID string, c
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -162,7 +162,7 @@ func (c *Client) UpdateProviderSession(ctx context.Context, id string, update *a
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 
@@ -199,12 +199,12 @@ func (c *Client) ListUserRestrictedTokens(ctx context.Context, userID string, fi
 	}
 	if filter == nil {
 		filter = auth.NewRestrictedTokenFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -238,7 +238,7 @@ func (c *Client) CreateUserRestrictedToken(ctx context.Context, userID string, c
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -280,7 +280,7 @@ func (c *Client) UpdateRestrictedToken(ctx context.Context, id string, update *a
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 

--- a/auth/provider_session.go
+++ b/auth/provider_session.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/id"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/oauth"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/request"
@@ -184,13 +185,13 @@ type ProviderSession struct {
 	ModifiedTime *time.Time   `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
 }
 
-func NewProviderSession(userID string, create *ProviderSessionCreate) (*ProviderSession, error) {
+func NewProviderSession(ctx context.Context, userID string, create *ProviderSessionCreate) (*ProviderSession, error) {
 	if userID == "" {
 		return nil, errors.New("user id is missing")
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 

--- a/auth/restricted_token.go
+++ b/auth/restricted_token.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/id"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
@@ -127,13 +128,13 @@ type RestrictedToken struct {
 	ModifiedTime   *time.Time `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
 }
 
-func NewRestrictedToken(userID string, create *RestrictedTokenCreate) (*RestrictedToken, error) {
+func NewRestrictedToken(ctx context.Context, userID string, create *RestrictedTokenCreate) (*RestrictedToken, error) {
 	if userID == "" {
 		return nil, errors.New("user id is missing")
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 

--- a/auth/store/mongo/provider_session_repository.go
+++ b/auth/store/mongo/provider_session_repository.go
@@ -51,12 +51,12 @@ func (p *ProviderSessionRepository) ListUserProviderSessions(ctx context.Context
 	}
 	if filter == nil {
 		filter = auth.NewProviderSessionFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -96,10 +96,10 @@ func (p *ProviderSessionRepository) CreateUserProviderSession(ctx context.Contex
 		return nil, errors.New("context is missing")
 	}
 
-	providerSession, err := auth.NewProviderSession(userID, create)
+	providerSession, err := auth.NewProviderSession(ctx, userID, create)
 	if err != nil {
 		return nil, err
-	} else if err = structureValidator.New().Validate(providerSession); err != nil {
+	} else if err = structureValidator.New(log.LoggerFromContext(ctx)).Validate(providerSession); err != nil {
 		return nil, errors.Wrap(err, "provider session is invalid")
 	}
 
@@ -165,7 +165,7 @@ func (p *ProviderSessionRepository) UpdateProviderSession(ctx context.Context, i
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 

--- a/auth/store/mongo/restricted_token_repository.go
+++ b/auth/store/mongo/restricted_token_repository.go
@@ -45,12 +45,12 @@ func (r *RestrictedTokenRepository) ListUserRestrictedTokens(ctx context.Context
 	}
 	if filter == nil {
 		filter = auth.NewRestrictedTokenFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -85,10 +85,10 @@ func (r *RestrictedTokenRepository) CreateUserRestrictedToken(ctx context.Contex
 		return nil, errors.New("context is missing")
 	}
 
-	restrictedToken, err := auth.NewRestrictedToken(userID, create)
+	restrictedToken, err := auth.NewRestrictedToken(ctx, userID, create)
 	if err != nil {
 		return nil, err
-	} else if err = structureValidator.New().Validate(restrictedToken); err != nil {
+	} else if err = structureValidator.New(log.LoggerFromContext(ctx)).Validate(restrictedToken); err != nil {
 		return nil, errors.Wrap(err, "restricted token is invalid")
 	}
 
@@ -167,7 +167,7 @@ func (r *RestrictedTokenRepository) UpdateRestrictedToken(ctx context.Context, i
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -16,6 +16,7 @@ import (
 	cryptoTest "github.com/tidepool-org/platform/crypto/test"
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/net"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -60,7 +61,7 @@ var _ = Describe("Blob", func() {
 					object := blobTest.NewObjectFromFilter(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &blob.Filter{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -112,7 +113,7 @@ var _ = Describe("Blob", func() {
 				func(mutator func(datum *blob.Filter), expectedErrors ...error) {
 					datum := blobTest.RandomFilter()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *blob.Filter) {},
@@ -235,7 +236,7 @@ var _ = Describe("Blob", func() {
 				func(mutator func(datum *blob.Content), expectedErrors ...error) {
 					datum := blobTest.RandomContent()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *blob.Content) {},
@@ -326,7 +327,7 @@ var _ = Describe("Blob", func() {
 					object := blobTest.NewObjectFromBlob(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &blob.Blob{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(blobTest.MatchBlob(expectedDatum))
 				},
 				Entry("succeeds",
@@ -535,7 +536,7 @@ var _ = Describe("Blob", func() {
 				func(mutator func(datum *blob.Blob), expectedErrors ...error) {
 					datum := blobTest.RandomBlob()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *blob.Blob) {},
@@ -757,7 +758,7 @@ var _ = Describe("Blob", func() {
 					object := blobTest.NewObjectFromDeviceLogsBlob(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &blob.DeviceLogsBlob{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(blobTest.MatchDeviceLogsBlob(expectedDatum))
 				},
 				Entry("succeeds",
@@ -905,7 +906,7 @@ var _ = Describe("Blob", func() {
 				func(mutator func(datum *blob.DeviceLogsBlob), expectedErrors ...error) {
 					datum := blobTest.RandomDeviceLogsBlob()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *blob.DeviceLogsBlob) {},

--- a/blob/client/client.go
+++ b/blob/client/client.go
@@ -42,12 +42,12 @@ func (c *Client) List(ctx context.Context, userID string, filter *blob.Filter, p
 	}
 	if filter == nil {
 		filter = blob.NewFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -71,7 +71,7 @@ func (c *Client) Create(ctx context.Context, userID string, content *blob.Conten
 	}
 	if content == nil {
 		return nil, errors.New("content is missing")
-	} else if err := structureValidator.New().Validate(content); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(content); err != nil {
 		return nil, errors.Wrap(err, "content is invalid")
 	}
 
@@ -103,7 +103,7 @@ func (c *Client) CreateDeviceLogs(ctx context.Context, userID string, content *b
 	}
 	if content == nil {
 		return nil, errors.New("content is missing")
-	} else if err := structureValidator.New().Validate(content); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(content); err != nil {
 		return nil, errors.Wrap(err, "content is invalid")
 	}
 
@@ -214,7 +214,7 @@ func (c *Client) Delete(ctx context.Context, id string, condition *request.Condi
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return false, errors.Wrap(err, "condition is invalid")
 	}
 

--- a/blob/service/client/client.go
+++ b/blob/service/client/client.go
@@ -49,7 +49,7 @@ func (c *Client) List(ctx context.Context, userID string, filter *blob.Filter, p
 func (c *Client) Create(ctx context.Context, userID string, content *blob.Content) (*blob.Blob, error) {
 	if content == nil {
 		return nil, errors.New("content is missing")
-	} else if err := structureValidator.New().Validate(content); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(content); err != nil {
 		return nil, errors.Wrap(err, "content is invalid")
 	}
 
@@ -108,7 +108,7 @@ func (c *Client) Create(ctx context.Context, userID string, content *blob.Conten
 func (c *Client) CreateDeviceLogs(ctx context.Context, userID string, content *blob.DeviceLogsContent) (*blob.DeviceLogsBlob, error) {
 	if content == nil {
 		return nil, errors.New("content is missing")
-	} else if err := structureValidator.New().Validate(content); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(content); err != nil {
 		return nil, errors.Wrap(err, "content is invalid")
 	}
 

--- a/blob/store/structured/mongo/blob_repository.go
+++ b/blob/store/structured/mongo/blob_repository.go
@@ -65,12 +65,12 @@ func (b *BlobRepository) List(ctx context.Context, userID string, filter *blob.F
 	}
 	if filter == nil {
 		filter = blob.NewFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -128,7 +128,7 @@ func (b *BlobRepository) Create(ctx context.Context, userID string, create *blob
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -244,7 +244,7 @@ func (b *BlobRepository) Get(ctx context.Context, id string, condition *request.
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return nil, errors.Wrap(err, "condition is invalid")
 	}
 
@@ -273,12 +273,12 @@ func (b *BlobRepository) Update(ctx context.Context, id string, condition *reque
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return nil, errors.Wrap(err, "condition is invalid")
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 
@@ -349,7 +349,7 @@ func (b *BlobRepository) Delete(ctx context.Context, id string, condition *reque
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return false, errors.Wrap(err, "condition is invalid")
 	}
 
@@ -390,7 +390,7 @@ func (b *BlobRepository) Destroy(ctx context.Context, id string, condition *requ
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return false, errors.Wrap(err, "condition is invalid")
 	}
 

--- a/blob/store/structured/mongo/devicelogs_repository.go
+++ b/blob/store/structured/mongo/devicelogs_repository.go
@@ -57,7 +57,7 @@ func (d *DeviceLogsRepository) Create(ctx context.Context, userID string, create
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -111,12 +111,12 @@ func (d *DeviceLogsRepository) Update(ctx context.Context, id string, condition 
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return nil, errors.Wrap(err, "condition is invalid")
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 
@@ -190,7 +190,7 @@ func (d *DeviceLogsRepository) Destroy(ctx context.Context, id string, condition
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return false, errors.Wrap(err, "condition is invalid")
 	}
 

--- a/blob/store/structured/structured_test.go
+++ b/blob/store/structured/structured_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/crypto"
 	cryptoTest "github.com/tidepool-org/platform/crypto/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/net"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -30,7 +31,7 @@ var _ = Describe("Structured", func() {
 				func(mutator func(datum *blobStoreStructured.Create), expectedErrors ...error) {
 					datum := blobStoreStructuredTest.RandomCreate()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *blobStoreStructured.Create) {},
@@ -67,7 +68,7 @@ var _ = Describe("Structured", func() {
 				func(mutator func(datum *blobStoreStructured.Update), expectedErrors ...error) {
 					datum := blobStoreStructuredTest.RandomUpdate()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *blobStoreStructured.Update) {},

--- a/client/client.go
+++ b/client/client.go
@@ -100,7 +100,7 @@ func (c *Client) RequestDataWithHTTPClient(ctx context.Context, method string, u
 		return nil
 	}
 
-	return request.DecodeObject(structure.NewPointerSource(), body, responseBody)
+	return request.DecodeObject(ctx, structure.NewPointerSource(), body, responseBody)
 }
 
 func (c *Client) createRequest(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}) (*http.Request, error) {

--- a/data/blood/glucose/target_test.go
+++ b/data/blood/glucose/target_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/data/blood/glucose"
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -56,7 +57,7 @@ var _ = Describe("Target", func() {
 		Context("Validate", func() {
 			DescribeTable("validates the datum",
 				func(datum *glucose.Target, sourceUnits string, expectedErrors ...error) {
-					validator := structureValidator.New()
+					validator := structureValidator.New(logTest.NewLogger())
 					Expect(validator).ToNot(BeNil())
 					datum.Validate(validator, &sourceUnits)
 					errorsTest.ExpectEqual(validator.Error(), expectedErrors...)
@@ -403,7 +404,7 @@ var _ = Describe("Target", func() {
 		Context("Normalize", func() {
 			DescribeTable("normalizes the datum",
 				func(datum *glucose.Target, sourceUnits interface{}, expectedDatum *glucose.Target) {
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer, AsStringPointer(sourceUnits))
 					Expect(normalizer.Error()).ToNot(HaveOccurred())

--- a/data/client/client.go
+++ b/data/client/client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tidepool-org/platform/data/summary/types"
+	"github.com/tidepool-org/platform/log"
 
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/errors"
@@ -66,12 +67,12 @@ func (c *ClientImpl) ListUserDataSets(ctx context.Context, userID string, filter
 	}
 	if filter == nil {
 		filter = data.NewDataSetFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -93,7 +94,7 @@ func (c *ClientImpl) CreateUserDataSet(ctx context.Context, userID string, creat
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -233,7 +234,7 @@ func (c *ClientImpl) GetOutdatedUserIDs(ctx context.Context, typ string, paginat
 
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -254,7 +255,7 @@ func (c *ClientImpl) GetMigratableUserIDs(ctx context.Context, typ string, pagin
 
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -273,7 +274,7 @@ func (c *ClientImpl) UpdateDataSet(ctx context.Context, id string, update *data.
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 

--- a/data/deduplicator/deduplicator.go
+++ b/data/deduplicator/deduplicator.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Factory interface {
-	New(dataSet *dataTypesUpload.Upload) (Deduplicator, error)
-	Get(dataSet *dataTypesUpload.Upload) (Deduplicator, error)
+	New(ctx context.Context, dataSet *dataTypesUpload.Upload) (Deduplicator, error)
+	Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (Deduplicator, error)
 }
 
 type Deduplicator interface {

--- a/data/deduplicator/deduplicator/base.go
+++ b/data/deduplicator/deduplicator/base.go
@@ -34,11 +34,11 @@ func NewBase(name string, version string) (*Base, error) {
 	}, nil
 }
 
-func (b *Base) New(dataSet *dataTypesUpload.Upload) (bool, error) {
-	return b.Get(dataSet)
+func (b *Base) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	return b.Get(ctx, dataSet)
 }
 
-func (b *Base) Get(dataSet *dataTypesUpload.Upload) (bool, error) {
+func (b *Base) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
 	if dataSet == nil {
 		return false, errors.New("data set is missing")
 	}

--- a/data/deduplicator/deduplicator/base_test.go
+++ b/data/deduplicator/deduplicator/base_test.go
@@ -77,55 +77,55 @@ var _ = Describe("Base", func() {
 
 		Context("New", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(nil)
+				found, err := deduplicator.New(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.New(dataSet)).To(BeTrue())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 
 		Context("Get", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(nil)
+				found, err := deduplicator.Get(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 

--- a/data/deduplicator/deduplicator/data_set_delete_origin.go
+++ b/data/deduplicator/deduplicator/data_set_delete_origin.go
@@ -27,12 +27,12 @@ func NewDataSetDeleteOrigin() (*DataSetDeleteOrigin, error) {
 	}, nil
 }
 
-func (d *DataSetDeleteOrigin) New(dataSet *dataTypesUpload.Upload) (bool, error) {
-	return d.Get(dataSet)
+func (d *DataSetDeleteOrigin) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	return d.Get(ctx, dataSet)
 }
 
-func (d *DataSetDeleteOrigin) Get(dataSet *dataTypesUpload.Upload) (bool, error) {
-	if found, err := d.Base.Get(dataSet); err != nil || found {
+func (d *DataSetDeleteOrigin) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	if found, err := d.Base.Get(ctx, dataSet); err != nil || found {
 		return found, err
 	}
 

--- a/data/deduplicator/deduplicator/data_set_delete_origin_test.go
+++ b/data/deduplicator/deduplicator/data_set_delete_origin_test.go
@@ -46,65 +46,65 @@ var _ = Describe("DataSetDeleteOrigin", func() {
 
 		Context("New", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(nil)
+				found, err := deduplicator.New(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.New(dataSet)).To(BeTrue())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 			})
 
 			It("returns true when the deduplicator name matches deprecated", func() {
 				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous.origin")
-				Expect(deduplicator.New(dataSet)).To(BeTrue())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 
 		Context("Get", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(nil)
+				found, err := deduplicator.Get(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 
 			It("returns true when the deduplicator name matches deprecated", func() {
 				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous.origin")
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 

--- a/data/deduplicator/deduplicator/device_deactivate_hash.go
+++ b/data/deduplicator/deduplicator/device_deactivate_hash.go
@@ -33,7 +33,7 @@ func NewDeviceDeactivateHash() (*DeviceDeactivateHash, error) {
 	}, nil
 }
 
-func (d *DeviceDeactivateHash) New(dataSet *dataTypesUpload.Upload) (bool, error) {
+func (d *DeviceDeactivateHash) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
 	if dataSet == nil {
 		return false, errors.New("data set is missing")
 	}
@@ -46,7 +46,7 @@ func (d *DeviceDeactivateHash) New(dataSet *dataTypesUpload.Upload) (bool, error
 	}
 
 	if dataSet.HasDeduplicatorName() {
-		return d.Get(dataSet)
+		return d.Get(ctx, dataSet)
 	}
 
 	if dataSet.DeviceManufacturers == nil || dataSet.DeviceModel == nil {
@@ -66,8 +66,8 @@ func (d *DeviceDeactivateHash) New(dataSet *dataTypesUpload.Upload) (bool, error
 	return false, nil
 }
 
-func (d *DeviceDeactivateHash) Get(dataSet *dataTypesUpload.Upload) (bool, error) {
-	if found, err := d.Base.Get(dataSet); err != nil || found {
+func (d *DeviceDeactivateHash) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	if found, err := d.Base.Get(ctx, dataSet); err != nil || found {
 		return found, err
 	}
 

--- a/data/deduplicator/deduplicator/device_deactivate_hash_test.go
+++ b/data/deduplicator/deduplicator/device_deactivate_hash_test.go
@@ -49,34 +49,34 @@ var _ = Describe("DeviceDeactivateHash", func() {
 
 		Context("New", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(nil)
+				found, err := deduplicator.New(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the data set type is not normal", func() {
 				dataSet.DataSetType = pointer.FromString("continuous")
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the device id is missing", func() {
 				dataSet.DeviceID = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			dataSetTypeAssertions := func() {
 				It("returns false when the deduplicator name does not match", func() {
 					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-					Expect(deduplicator.New(dataSet)).To(BeFalse())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 				})
 
 				It("returns true when the deduplicator name matches", func() {
-					Expect(deduplicator.New(dataSet)).To(BeTrue())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 				})
 
 				It("returns true when the deduplicator name matches deprecated", func() {
 					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.hash-deactivate-old")
-					Expect(deduplicator.New(dataSet)).To(BeTrue())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 				})
 
 				When("the deduplicator is missing", func() {
@@ -86,41 +86,41 @@ var _ = Describe("DeviceDeactivateHash", func() {
 
 					It("returns false when the device manufacturers is missing", func() {
 						dataSet.DeviceManufacturers = nil
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device manufacturers is empty", func() {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{})
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device manufacturers does not match", func() {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Bravo"})
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device model is missing", func() {
 						dataSet.DeviceModel = nil
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device model is empty", func() {
 						dataSet.DeviceModel = pointer.FromString("")
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device model does not match", func() {
 						dataSet.DeviceModel = pointer.FromString("Alpha")
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns true when the device manufacturers and device model matches", func() {
-						Expect(deduplicator.New(dataSet)).To(BeTrue())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
 
 					It("returns true when the device manufacturers and device model matches with multiple", func() {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Abbott", "Bravo"})
-						Expect(deduplicator.New(dataSet)).To(BeTrue())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
 				})
 
@@ -128,7 +128,7 @@ var _ = Describe("DeviceDeactivateHash", func() {
 					func(deviceManufacturer string, deviceModel string) {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{deviceManufacturer})
 						dataSet.DeviceModel = pointer.FromString(deviceModel)
-						Expect(deduplicator.New(dataSet)).To(BeTrue())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					},
 					Entry("is Abbott FreeStyle Libre", "Abbott", "FreeStyle Libre"),
 					Entry("is LifeScan OneTouch Ultra 2", "LifeScan", "OneTouch Ultra 2"),
@@ -185,33 +185,33 @@ var _ = Describe("DeviceDeactivateHash", func() {
 
 		Context("Get", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(nil)
+				found, err := deduplicator.Get(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 
 			It("returns true when the deduplicator name matches deprecated", func() {
 				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.hash-deactivate-old")
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 

--- a/data/deduplicator/deduplicator/device_truncate_data_set.go
+++ b/data/deduplicator/deduplicator/device_truncate_data_set.go
@@ -27,7 +27,7 @@ func NewDeviceTruncateDataSet() (*DeviceTruncateDataSet, error) {
 	}, nil
 }
 
-func (t *DeviceTruncateDataSet) New(dataSet *dataTypesUpload.Upload) (bool, error) {
+func (t *DeviceTruncateDataSet) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
 	if dataSet == nil {
 		return false, errors.New("data set is missing")
 	}
@@ -40,7 +40,7 @@ func (t *DeviceTruncateDataSet) New(dataSet *dataTypesUpload.Upload) (bool, erro
 	}
 
 	if dataSet.HasDeduplicatorName() {
-		return t.Get(dataSet)
+		return t.Get(ctx, dataSet)
 	}
 
 	if dataSet.DeviceManufacturers == nil {
@@ -58,8 +58,8 @@ func (t *DeviceTruncateDataSet) New(dataSet *dataTypesUpload.Upload) (bool, erro
 	return false, nil
 }
 
-func (t *DeviceTruncateDataSet) Get(dataSet *dataTypesUpload.Upload) (bool, error) {
-	if found, err := t.Base.Get(dataSet); err != nil || found {
+func (t *DeviceTruncateDataSet) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	if found, err := t.Base.Get(ctx, dataSet); err != nil || found {
 		return found, err
 	}
 

--- a/data/deduplicator/deduplicator/device_truncate_data_set_test.go
+++ b/data/deduplicator/deduplicator/device_truncate_data_set_test.go
@@ -47,34 +47,34 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 
 		Context("New", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(nil)
+				found, err := deduplicator.New(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the data set type is not normal", func() {
 				dataSet.DataSetType = pointer.FromString("continuous")
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the device id is missing", func() {
 				dataSet.DeviceID = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			dataSetTypeAssertions := func() {
 				It("returns false when the deduplicator name does not match", func() {
 					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-					Expect(deduplicator.New(dataSet)).To(BeFalse())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 				})
 
 				It("returns true when the deduplicator name matches", func() {
-					Expect(deduplicator.New(dataSet)).To(BeTrue())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 				})
 
 				It("returns true when the deduplicator name matches deprecated", func() {
 					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.truncate")
-					Expect(deduplicator.New(dataSet)).To(BeTrue())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 				})
 
 				When("the deduplicator is missing", func() {
@@ -84,26 +84,26 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 
 					It("returns false when the device manufacturers is missing", func() {
 						dataSet.DeviceManufacturers = nil
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device manufacturers is empty", func() {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{})
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns false when the device manufacturers does not match", func() {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Bravo"})
-						Expect(deduplicator.New(dataSet)).To(BeFalse())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
 					It("returns true when the device manufacturers matches", func() {
-						Expect(deduplicator.New(dataSet)).To(BeTrue())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
 
 					It("returns true when the device manufacturers matches with multiple", func() {
 						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Animas", "Bravo"})
-						Expect(deduplicator.New(dataSet)).To(BeTrue())
+						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
 				})
 			}
@@ -127,33 +127,33 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 
 		Context("Get", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(nil)
+				found, err := deduplicator.Get(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 
 			It("returns true when the deduplicator name matches deprecated", func() {
 				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.truncate")
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 

--- a/data/deduplicator/deduplicator/none.go
+++ b/data/deduplicator/deduplicator/none.go
@@ -26,12 +26,12 @@ func NewNone() (*None, error) {
 	}, nil
 }
 
-func (n *None) New(dataSet *dataTypesUpload.Upload) (bool, error) {
-	return n.Get(dataSet)
+func (n *None) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	return n.Get(ctx, dataSet)
 }
 
-func (n *None) Get(dataSet *dataTypesUpload.Upload) (bool, error) {
-	if found, err := n.Base.Get(dataSet); err != nil || found {
+func (n *None) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
+	if found, err := n.Base.Get(ctx, dataSet); err != nil || found {
 		return found, err
 	}
 

--- a/data/deduplicator/deduplicator/none_test.go
+++ b/data/deduplicator/deduplicator/none_test.go
@@ -46,65 +46,65 @@ var _ = Describe("None", func() {
 
 		Context("New", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(nil)
+				found, err := deduplicator.New(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.New(dataSet)).To(BeFalse())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.New(dataSet)).To(BeTrue())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 			})
 
 			It("returns true when the deduplicator name matches deprecated", func() {
 				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous")
-				Expect(deduplicator.New(dataSet)).To(BeTrue())
+				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 
 		Context("Get", func() {
 			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(nil)
+				found, err := deduplicator.Get(context.Background(), nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(found).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator is missing", func() {
 				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name is missing", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns false when the deduplicator name does not match", func() {
 				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(dataSet)).To(BeFalse())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
 			})
 
 			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 
 			It("returns true when the deduplicator name matches deprecated", func() {
 				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous")
-				Expect(deduplicator.Get(dataSet)).To(BeTrue())
+				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
 			})
 		})
 

--- a/data/deduplicator/factory/factory_test.go
+++ b/data/deduplicator/factory/factory_test.go
@@ -1,6 +1,8 @@
 package factory_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -10,6 +12,8 @@ import (
 	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
 	dataTypesUploadTest "github.com/tidepool-org/platform/data/types/upload/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
 )
@@ -48,6 +52,7 @@ var _ = Describe("Factory", func() {
 	Context("with a new factory", func() {
 		var factory *dataDeduplicatorFactory.Factory
 		var dataSet *dataTypesUpload.Upload
+		var ctx context.Context
 
 		BeforeEach(func() {
 			var err error
@@ -56,23 +61,25 @@ var _ = Describe("Factory", func() {
 			Expect(factory).ToNot(BeNil())
 			dataSet = dataTypesUploadTest.RandomUpload()
 			Expect(dataSet).ToNot(BeNil())
+			ctx = log.NewContextWithLogger(context.Background(), logTest.NewLogger())
 		})
 
 		Context("New", func() {
 			It("returns an error when the data set is missing", func() {
-				deduplicator, err := factory.New(nil)
+				deduplicator, err := factory.New(ctx, nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			It("returns an error when the data set is invalid", func() {
 				dataSet.DeviceModel = pointer.FromString("")
-				deduplicator, err := factory.New(dataSet)
+				deduplicator, err := factory.New(ctx, dataSet)
 				Expect(err).To(MatchError("data set is invalid; value is empty"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			When("the data set has a deduplicator name", func() {
+
 				BeforeEach(func() {
 					dataSet.Deduplicator = &data.DeduplicatorDescriptor{
 						Name: pointer.FromString(netTest.RandomReverseDomain()),
@@ -80,15 +87,15 @@ var _ = Describe("Factory", func() {
 				})
 
 				AfterEach(func() {
-					Expect(secondDeduplicator.GetInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
-					Expect(firstDeduplicator.GetInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
+					Expect(secondDeduplicator.GetInputs).To(Equal([]dataDeduplicatorFactoryTest.GetInput{{Context: ctx, DataSet: dataSet}}))
+					Expect(firstDeduplicator.GetInputs).To(Equal([]dataDeduplicatorFactoryTest.GetInput{{Context: ctx, DataSet: dataSet}}))
 				})
 
 				It("returns an error when a deduplicator returns an error", func() {
 					responseErr := errorsTest.RandomError()
 					firstDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
 					secondDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: responseErr}}
-					deduplicator, err := factory.New(dataSet)
+					deduplicator, err := factory.New(ctx, dataSet)
 					Expect(err).To(Equal(responseErr))
 					Expect(deduplicator).To(BeNil())
 				})
@@ -96,13 +103,13 @@ var _ = Describe("Factory", func() {
 				It("returns successfully when a deduplicator returns successfully", func() {
 					firstDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
 					secondDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: true, Error: nil}}
-					Expect(factory.New(dataSet)).To(Equal(secondDeduplicator))
+					Expect(factory.New(ctx, dataSet)).To(Equal(secondDeduplicator))
 				})
 
 				It("returns an error when no deduplicator returns successfully", func() {
 					firstDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
 					secondDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
-					deduplicator, err := factory.New(dataSet)
+					deduplicator, err := factory.New(ctx, dataSet)
 					Expect(err).To(MatchError("deduplicator not found"))
 					Expect(deduplicator).To(BeNil())
 				})
@@ -110,15 +117,15 @@ var _ = Describe("Factory", func() {
 
 			newAssertions := func() {
 				AfterEach(func() {
-					Expect(secondDeduplicator.NewInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
-					Expect(firstDeduplicator.NewInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
+					Expect(secondDeduplicator.NewInputs).To(Equal([]dataDeduplicatorFactoryTest.NewInput{{Context: ctx, DataSet: dataSet}}))
+					Expect(firstDeduplicator.NewInputs).To(Equal([]dataDeduplicatorFactoryTest.NewInput{{Context: ctx, DataSet: dataSet}}))
 				})
 
 				It("returns an error when a deduplicator returns an error", func() {
 					responseErr := errorsTest.RandomError()
 					firstDeduplicator.NewOutputs = []dataDeduplicatorFactoryTest.NewOutput{{Found: false, Error: nil}}
 					secondDeduplicator.NewOutputs = []dataDeduplicatorFactoryTest.NewOutput{{Found: false, Error: responseErr}}
-					deduplicator, err := factory.New(dataSet)
+					deduplicator, err := factory.New(ctx, dataSet)
 					Expect(err).To(Equal(responseErr))
 					Expect(deduplicator).To(BeNil())
 				})
@@ -126,13 +133,13 @@ var _ = Describe("Factory", func() {
 				It("returns successfully when a deduplicator returns successfully", func() {
 					firstDeduplicator.NewOutputs = []dataDeduplicatorFactoryTest.NewOutput{{Found: false, Error: nil}}
 					secondDeduplicator.NewOutputs = []dataDeduplicatorFactoryTest.NewOutput{{Found: true, Error: nil}}
-					Expect(factory.New(dataSet)).To(Equal(secondDeduplicator))
+					Expect(factory.New(ctx, dataSet)).To(Equal(secondDeduplicator))
 				})
 
 				It("returns an error when no deduplicator returns successfully", func() {
 					firstDeduplicator.NewOutputs = []dataDeduplicatorFactoryTest.NewOutput{{Found: false, Error: nil}}
 					secondDeduplicator.NewOutputs = []dataDeduplicatorFactoryTest.NewOutput{{Found: false, Error: nil}}
-					deduplicator, err := factory.New(dataSet)
+					deduplicator, err := factory.New(ctx, dataSet)
 					Expect(err).To(MatchError("deduplicator not found"))
 					Expect(deduplicator).To(BeNil())
 				})
@@ -157,29 +164,29 @@ var _ = Describe("Factory", func() {
 
 		Context("Get", func() {
 			It("returns an error when the data set is missing", func() {
-				deduplicator, err := factory.Get(nil)
+				deduplicator, err := factory.Get(ctx, nil)
 				Expect(err).To(MatchError("data set is missing"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			It("returns an error when the data set is invalid", func() {
 				dataSet.DeviceModel = pointer.FromString("")
-				deduplicator, err := factory.Get(dataSet)
+				deduplicator, err := factory.Get(ctx, dataSet)
 				Expect(err).To(MatchError("data set is invalid; value is empty"))
 				Expect(deduplicator).To(BeNil())
 			})
 
 			When("the data set has a deduplicator name", func() {
 				AfterEach(func() {
-					Expect(secondDeduplicator.GetInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
-					Expect(firstDeduplicator.GetInputs).To(Equal([]*dataTypesUpload.Upload{dataSet}))
+					Expect(secondDeduplicator.GetInputs).To(Equal([]dataDeduplicatorFactoryTest.GetInput{{Context: ctx, DataSet: dataSet}}))
+					Expect(firstDeduplicator.GetInputs).To(Equal([]dataDeduplicatorFactoryTest.GetInput{{Context: ctx, DataSet: dataSet}}))
 				})
 
 				It("returns an error when a deduplicator returns an error", func() {
 					responseErr := errorsTest.RandomError()
 					firstDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
 					secondDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: responseErr}}
-					deduplicator, err := factory.Get(dataSet)
+					deduplicator, err := factory.Get(ctx, dataSet)
 					Expect(err).To(Equal(responseErr))
 					Expect(deduplicator).To(BeNil())
 				})
@@ -187,13 +194,13 @@ var _ = Describe("Factory", func() {
 				It("returns successfully when a deduplicator returns successfully", func() {
 					firstDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
 					secondDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: true, Error: nil}}
-					Expect(factory.Get(dataSet)).To(Equal(secondDeduplicator))
+					Expect(factory.Get(ctx, dataSet)).To(Equal(secondDeduplicator))
 				})
 
 				It("returns an error when no deduplicator returns successfully", func() {
 					firstDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
 					secondDeduplicator.GetOutputs = []dataDeduplicatorFactoryTest.GetOutput{{Found: false, Error: nil}}
-					deduplicator, err := factory.Get(dataSet)
+					deduplicator, err := factory.Get(ctx, dataSet)
 					Expect(err).To(MatchError("deduplicator not found"))
 					Expect(deduplicator).To(BeNil())
 				})
@@ -201,12 +208,12 @@ var _ = Describe("Factory", func() {
 
 			It("returns successfully without a deduplicator when the data set does not have a deduplicator", func() {
 				dataSet.Deduplicator = nil
-				Expect(factory.Get(dataSet)).To(BeNil())
+				Expect(factory.Get(ctx, dataSet)).To(BeNil())
 			})
 
 			It("returns successfully without a deduplicator  when the data set does not have a deduplicator name", func() {
 				dataSet.Deduplicator.Name = nil
-				Expect(factory.Get(dataSet)).To(BeNil())
+				Expect(factory.Get(ctx, dataSet)).To(BeNil())
 			})
 		})
 	})

--- a/data/deduplicator/factory/test/deduplicator.go
+++ b/data/deduplicator/factory/test/deduplicator.go
@@ -1,13 +1,25 @@
 package test
 
 import (
+	"context"
+
 	dataDeduplicatorTest "github.com/tidepool-org/platform/data/deduplicator/test"
 	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
 )
 
+type NewInput struct {
+	Context context.Context
+	DataSet *dataTypesUpload.Upload
+}
+
 type NewOutput struct {
 	Found bool
 	Error error
+}
+
+type GetInput struct {
+	Context context.Context
+	DataSet *dataTypesUpload.Upload
 }
 
 type GetOutput struct {
@@ -18,13 +30,13 @@ type GetOutput struct {
 type Deduplicator struct {
 	*dataDeduplicatorTest.Deduplicator
 	NewInvocations int
-	NewInputs      []*dataTypesUpload.Upload
-	NewStub        func(dataSet *dataTypesUpload.Upload) (bool, error)
+	NewInputs      []NewInput
+	NewStub        func(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error)
 	NewOutputs     []NewOutput
 	NewOutput      *NewOutput
 	GetInvocations int
-	GetInputs      []*dataTypesUpload.Upload
-	GetStub        func(dataSet *dataTypesUpload.Upload) (bool, error)
+	GetInputs      []GetInput
+	GetStub        func(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error)
 	GetOutputs     []GetOutput
 	GetOutput      *GetOutput
 }
@@ -35,11 +47,11 @@ func NewDeduplicator() *Deduplicator {
 	}
 }
 
-func (d *Deduplicator) New(dataSet *dataTypesUpload.Upload) (bool, error) {
+func (d *Deduplicator) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
 	d.NewInvocations++
-	d.NewInputs = append(d.NewInputs, dataSet)
+	d.NewInputs = append(d.NewInputs, NewInput{Context: ctx, DataSet: dataSet})
 	if d.NewStub != nil {
-		return d.NewStub(dataSet)
+		return d.NewStub(ctx, dataSet)
 	}
 	if len(d.NewOutputs) > 0 {
 		output := d.NewOutputs[0]
@@ -52,11 +64,11 @@ func (d *Deduplicator) New(dataSet *dataTypesUpload.Upload) (bool, error) {
 	panic("New has no output")
 }
 
-func (d *Deduplicator) Get(dataSet *dataTypesUpload.Upload) (bool, error) {
+func (d *Deduplicator) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (bool, error) {
 	d.GetInvocations++
-	d.GetInputs = append(d.GetInputs, dataSet)
+	d.GetInputs = append(d.GetInputs, GetInput{Context: ctx, DataSet: dataSet})
 	if d.GetStub != nil {
-		return d.GetStub(dataSet)
+		return d.GetStub(ctx, dataSet)
 	}
 	if len(d.GetOutputs) > 0 {
 		output := d.GetOutputs[0]

--- a/data/deduplicator/test/factory.go
+++ b/data/deduplicator/test/factory.go
@@ -1,13 +1,25 @@
 package test
 
 import (
+	"context"
+
 	dataDeduplicator "github.com/tidepool-org/platform/data/deduplicator"
 	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
 )
 
+type NewInput struct {
+	Context context.Context
+	DataSet *dataTypesUpload.Upload
+}
+
 type NewOutput struct {
 	Deduplicator dataDeduplicator.Deduplicator
 	Error        error
+}
+
+type GetInput struct {
+	Context context.Context
+	DataSet *dataTypesUpload.Upload
 }
 
 type GetOutput struct {
@@ -17,13 +29,13 @@ type GetOutput struct {
 
 type Factory struct {
 	NewInvocations int
-	NewInputs      []*dataTypesUpload.Upload
-	NewStub        func(dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error)
+	NewInputs      []NewInput
+	NewStub        func(ctx context.Context, dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error)
 	NewOutputs     []NewOutput
 	NewOutput      *NewOutput
 	GetInvocations int
-	GetInputs      []*dataTypesUpload.Upload
-	GetStub        func(dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error)
+	GetInputs      []GetInput
+	GetStub        func(ctx context.Context, dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error)
 	GetOutputs     []GetOutput
 	GetOutput      *GetOutput
 }
@@ -32,11 +44,11 @@ func NewFactory() *Factory {
 	return &Factory{}
 }
 
-func (f *Factory) New(dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error) {
+func (f *Factory) New(ctx context.Context, dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error) {
 	f.NewInvocations++
-	f.NewInputs = append(f.NewInputs, dataSet)
+	f.NewInputs = append(f.NewInputs, NewInput{Context: ctx, DataSet: dataSet})
 	if f.NewStub != nil {
-		return f.NewStub(dataSet)
+		return f.NewStub(ctx, dataSet)
 	}
 	if len(f.NewOutputs) > 0 {
 		output := f.NewOutputs[0]
@@ -49,11 +61,11 @@ func (f *Factory) New(dataSet *dataTypesUpload.Upload) (dataDeduplicator.Dedupli
 	panic("New has no output")
 }
 
-func (f *Factory) Get(dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error) {
+func (f *Factory) Get(ctx context.Context, dataSet *dataTypesUpload.Upload) (dataDeduplicator.Deduplicator, error) {
 	f.GetInvocations++
-	f.GetInputs = append(f.GetInputs, dataSet)
+	f.GetInputs = append(f.GetInputs, GetInput{Context: ctx, DataSet: dataSet})
 	if f.GetStub != nil {
-		return f.GetStub(dataSet)
+		return f.GetStub(ctx, dataSet)
 	}
 	if len(f.GetOutputs) > 0 {
 		output := f.GetOutputs[0]

--- a/data/deduplicator_test.go
+++ b/data/deduplicator_test.go
@@ -8,6 +8,7 @@ import (
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	dataTest "github.com/tidepool-org/platform/data/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/net"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -60,7 +61,7 @@ var _ = Describe("Deduplicator", func() {
 				func(mutator func(datum *data.DeduplicatorDescriptor), expectedErrors ...error) {
 					datum := dataTest.RandomDeduplicatorDescriptor()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *data.DeduplicatorDescriptor) {},
@@ -126,7 +127,7 @@ var _ = Describe("Deduplicator", func() {
 					datum := dataTest.RandomDeduplicatorDescriptor()
 					mutator(datum)
 					expectedDatum := dataTest.CloneDeduplicatorDescriptor(datum)
-					Expect(structureNormalizer.New().Normalize(datum)).ToNot(HaveOccurred())
+					Expect(structureNormalizer.New(logTest.NewLogger()).Normalize(datum)).ToNot(HaveOccurred())
 					if expectator != nil {
 						expectator(datum, expectedDatum)
 					}
@@ -157,7 +158,7 @@ var _ = Describe("Deduplicator", func() {
 					datum := dataTest.RandomDeduplicatorDescriptor()
 					mutator(datum)
 					expectedDatum := dataTest.CloneDeduplicatorDescriptor(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.NormalizeDEPRECATED(normalizer)
 					Expect(normalizer.Error()).ToNot(HaveOccurred())

--- a/data/normalizer/normalizer.go
+++ b/data/normalizer/normalizer.go
@@ -2,6 +2,7 @@ package normalizer
 
 import (
 	"github.com/tidepool-org/platform/data"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/structure"
 	structureNormalizer "github.com/tidepool-org/platform/structure/normalizer"
 )
@@ -11,9 +12,9 @@ type Normalizer struct {
 	data       *[]data.Datum
 }
 
-func New() *Normalizer {
+func New(logger log.Logger) *Normalizer {
 	return &Normalizer{
-		normalizer: structureNormalizer.New(),
+		normalizer: structureNormalizer.New(logger),
 		data:       &[]data.Datum{},
 	}
 }

--- a/data/normalizer/normalizer_test.go
+++ b/data/normalizer/normalizer_test.go
@@ -11,6 +11,7 @@ import (
 	dataTest "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureTest "github.com/tidepool-org/platform/structure/test"
 )
@@ -18,7 +19,7 @@ import (
 var _ = Describe("Normalizer", func() {
 	Context("New", func() {
 		It("returns successfully", func() {
-			Expect(dataNormalizer.New()).ToNot(BeNil())
+			Expect(dataNormalizer.New(logTest.NewLogger())).ToNot(BeNil())
 		})
 	})
 
@@ -26,7 +27,7 @@ var _ = Describe("Normalizer", func() {
 		var normalizer *dataNormalizer.Normalizer
 
 		BeforeEach(func() {
-			normalizer = dataNormalizer.New()
+			normalizer = dataNormalizer.New(logTest.NewLogger())
 			Expect(normalizer).ToNot(BeNil())
 		})
 

--- a/data/service/api/v1/datasets_data_create.go
+++ b/data/service/api/v1/datasets_data_create.go
@@ -74,9 +74,10 @@ func DataSetsDataCreate(dataServiceContext dataService.Context) {
 		return
 	}
 
-	parser := structureParser.NewArray(&rawDatumArray)
-	validator := structureValidator.New()
-	normalizer := dataNormalizer.New()
+	logger := log.LoggerFromContext(ctx)
+	parser := structureParser.NewArray(logger, &rawDatumArray)
+	validator := structureValidator.New(logger)
+	normalizer := dataNormalizer.New(logger)
 
 	datumArray := []data.Datum{}
 	for _, reference := range parser.References() {
@@ -108,7 +109,7 @@ func DataSetsDataCreate(dataServiceContext dataService.Context) {
 		datum.SetProvenance(CollectProvenanceInfo(ctx, req, authDetails))
 	}
 
-	if deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(dataSet); getErr != nil {
+	if deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(ctx, dataSet); getErr != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to get deduplicator", getErr)
 		return
 	} else if deduplicator == nil {

--- a/data/service/api/v1/datasets_data_delete.go
+++ b/data/service/api/v1/datasets_data_delete.go
@@ -57,7 +57,7 @@ func DataSetsDataDelete(dataServiceContext dataService.Context) {
 		return
 	}
 
-	if deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(dataSet); getErr != nil {
+	if deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(ctx, dataSet); getErr != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to get deduplicator", getErr)
 		return
 	} else if deduplicator == nil {

--- a/data/service/api/v1/datasets_delete.go
+++ b/data/service/api/v1/datasets_delete.go
@@ -59,7 +59,7 @@ func DataSetsDelete(dataServiceContext dataService.Context) {
 		}
 	}
 
-	if deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(dataSet); getErr != nil {
+	if deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(ctx, dataSet); getErr != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to get deduplicator", getErr)
 		return
 	} else if deduplicator == nil {

--- a/data/service/api/v1/datasets_update.go
+++ b/data/service/api/v1/datasets_update.go
@@ -82,7 +82,7 @@ func DataSetsUpdate(dataServiceContext dataService.Context) {
 	}
 
 	if update.State != nil && *update.State == "closed" {
-		deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(dataSet)
+		deduplicator, getErr := dataServiceContext.DataDeduplicatorFactory().Get(ctx, dataSet)
 		if getErr != nil {
 			dataServiceContext.RespondWithInternalServerFailure("Unable to get deduplicator", getErr)
 			return

--- a/data/service/api/v1/users_datasets_create.go
+++ b/data/service/api/v1/users_datasets_create.go
@@ -49,9 +49,10 @@ func UsersDataSetsCreate(dataServiceContext dataService.Context) {
 		return
 	}
 
-	parser := structureParser.NewObject(&rawDatum)
-	validator := structureValidator.New()
-	normalizer := dataNormalizer.New()
+	logger := log.LoggerFromContext(ctx)
+	parser := structureParser.NewObject(logger, &rawDatum)
+	validator := structureValidator.New(logger)
+	normalizer := dataNormalizer.New(logger)
 
 	dataSet := upload.ParseUpload(parser)
 	if dataSet != nil {
@@ -90,7 +91,7 @@ func UsersDataSetsCreate(dataServiceContext dataService.Context) {
 		return
 	}
 
-	if deduplicator, err := dataServiceContext.DataDeduplicatorFactory().New(dataSet); err != nil {
+	if deduplicator, err := dataServiceContext.DataDeduplicatorFactory().New(ctx, dataSet); err != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to get deduplicator", err)
 		return
 	} else if deduplicator == nil {

--- a/data/service/api/v1/users_datasets_create_test.go
+++ b/data/service/api/v1/users_datasets_create_test.go
@@ -49,8 +49,8 @@ var _ = Describe("UsersDataSetsCreate", func() {
 
 			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs).To(HaveLen(1))
 			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs[0]).ToNot(BeNil())
-			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs[0].CreatedUserID).ToNot(BeNil())
-			Expect(*dataServiceContext.dataDeduplicatorFactory.NewInputs[0].CreatedUserID).To(Equal("test-auth-details-user-id"))
+			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs[0].DataSet.CreatedUserID).ToNot(BeNil())
+			Expect(*dataServiceContext.dataDeduplicatorFactory.NewInputs[0].DataSet.CreatedUserID).To(Equal("test-auth-details-user-id"))
 
 			dataServiceContext.dataDeduplicator.AssertOutputsEmpty()
 			dataServiceContext.dataDeduplicatorFactory.AssertOutputsEmpty()
@@ -68,7 +68,7 @@ var _ = Describe("UsersDataSetsCreate", func() {
 
 			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs).To(HaveLen(1))
 			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs[0]).ToNot(BeNil())
-			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs[0].CreatedUserID).To(BeNil())
+			Expect(dataServiceContext.dataDeduplicatorFactory.NewInputs[0].DataSet.CreatedUserID).To(BeNil())
 
 			dataServiceContext.dataDeduplicator.AssertOutputsEmpty()
 			dataServiceContext.dataDeduplicatorFactory.AssertOutputsEmpty()

--- a/data/source/client/client.go
+++ b/data/source/client/client.go
@@ -6,6 +6,7 @@ import (
 
 	dataSource "github.com/tidepool-org/platform/data/source"
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/platform"
 	"github.com/tidepool-org/platform/request"
@@ -39,12 +40,12 @@ func (c *Client) List(ctx context.Context, userID string, filter *dataSource.Fil
 	}
 	if filter == nil {
 		filter = dataSource.NewFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -68,7 +69,7 @@ func (c *Client) Create(ctx context.Context, userID string, create *dataSource.C
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -128,12 +129,12 @@ func (c *Client) Update(ctx context.Context, id string, condition *request.Condi
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return nil, errors.Wrap(err, "condition is invalid")
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 
@@ -160,7 +161,7 @@ func (c *Client) Delete(ctx context.Context, id string, condition *request.Condi
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return false, errors.Wrap(err, "condition is invalid")
 	}
 

--- a/data/source/source_test.go
+++ b/data/source/source_test.go
@@ -16,6 +16,7 @@ import (
 	dataTest "github.com/tidepool-org/platform/data/test"
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	requestTest "github.com/tidepool-org/platform/request/test"
@@ -60,7 +61,7 @@ var _ = Describe("Source", func() {
 					object := dataSourceTest.NewObjectFromFilter(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &dataSource.Filter{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -146,7 +147,7 @@ var _ = Describe("Source", func() {
 				func(mutator func(datum *dataSource.Filter), expectedErrors ...error) {
 					datum := dataSourceTest.RandomFilter()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataSource.Filter) {},
@@ -371,7 +372,7 @@ var _ = Describe("Source", func() {
 					object := dataSourceTest.NewObjectFromCreate(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &dataSource.Create{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -457,7 +458,7 @@ var _ = Describe("Source", func() {
 				func(mutator func(datum *dataSource.Create), expectedErrors ...error) {
 					datum := dataSourceTest.RandomCreate()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataSource.Create) {},
@@ -595,7 +596,7 @@ var _ = Describe("Source", func() {
 					object := dataSourceTest.NewObjectFromUpdate(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &dataSource.Update{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(dataSourceTest.MatchUpdate(expectedDatum))
 				},
 				Entry("succeeds",
@@ -753,7 +754,7 @@ var _ = Describe("Source", func() {
 				func(mutator func(datum *dataSource.Update), expectedErrors ...error) {
 					datum := dataSourceTest.RandomUpdate()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataSource.Update) {},
@@ -1058,7 +1059,7 @@ var _ = Describe("Source", func() {
 					datum := dataSourceTest.RandomUpdate()
 					mutator(datum)
 					expectedDatum := dataSourceTest.CloneUpdate(datum)
-					normalizer := structureNormalizer.New()
+					normalizer := structureNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					Expect(normalizer.Normalize(datum)).ToNot(HaveOccurred())
 					if expectator != nil {
@@ -1149,7 +1150,7 @@ var _ = Describe("Source", func() {
 					object := dataSourceTest.NewObjectFromSource(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &dataSource.Source{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(dataSourceTest.MatchSource(expectedDatum))
 				},
 				Entry("succeeds",
@@ -1440,7 +1441,7 @@ var _ = Describe("Source", func() {
 				func(mutator func(datum *dataSource.Source), expectedErrors ...error) {
 					datum := dataSourceTest.RandomSource()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataSource.Source) {},
@@ -1812,7 +1813,7 @@ var _ = Describe("Source", func() {
 					datum := dataSourceTest.RandomSource()
 					mutator(datum)
 					expectedDatum := dataSourceTest.CloneSource(datum)
-					normalizer := structureNormalizer.New()
+					normalizer := structureNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					Expect(normalizer.Normalize(datum)).ToNot(HaveOccurred())
 					if expectator != nil {

--- a/data/source/store/structured/mongo/mongo.go
+++ b/data/source/store/structured/mongo/mongo.go
@@ -81,12 +81,12 @@ func (c *DataSourcesRepository) List(ctx context.Context, userID string, filter 
 	}
 	if filter == nil {
 		filter = dataSource.NewFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -145,7 +145,7 @@ func (c *DataSourcesRepository) Create(ctx context.Context, userID string, creat
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 
@@ -248,12 +248,12 @@ func (c *DataSourcesRepository) Update(ctx context.Context, id string, condition
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return nil, errors.Wrap(err, "condition is invalid")
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 
@@ -337,7 +337,7 @@ func (c *DataSourcesRepository) Destroy(ctx context.Context, id string, conditio
 	}
 	if condition == nil {
 		condition = request.NewCondition()
-	} else if err := structureValidator.New().Validate(condition); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(condition); err != nil {
 		return false, errors.Wrap(err, "condition is invalid")
 	}
 

--- a/data/store/mongo/mongo_data_set.go
+++ b/data/store/mongo/mongo_data_set.go
@@ -160,7 +160,7 @@ func (d *DataSetRepository) updateDataSet(ctx context.Context, id string, update
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 
@@ -245,12 +245,12 @@ func (d *DataSetRepository) ListUserDataSets(ctx context.Context, userID string,
 	}
 	if filter == nil {
 		filter = data.NewDataSetFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -300,12 +300,12 @@ func (d *DataSetRepository) GetDataSetsForUserByID(ctx context.Context, userID s
 	}
 	if filter == nil {
 		filter = store.NewFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 

--- a/data/store/mongo/mongo_datum.go
+++ b/data/store/mongo/mongo_datum.go
@@ -159,7 +159,7 @@ func (d *DatumRepository) ActivateDataSetData(ctx context.Context, dataSet *uplo
 	if err := validateDataSet(dataSet); err != nil {
 		return err
 	}
-	selector, err := validateAndTranslateSelectors(selectors)
+	selector, err := validateAndTranslateSelectors(ctx, selectors)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (d *DatumRepository) ArchiveDataSetData(ctx context.Context, dataSet *uploa
 	if err := validateDataSet(dataSet); err != nil {
 		return err
 	}
-	selector, err := validateAndTranslateSelectors(selectors)
+	selector, err := validateAndTranslateSelectors(ctx, selectors)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (d *DatumRepository) DeleteDataSetData(ctx context.Context, dataSet *upload
 	if err := validateDataSet(dataSet); err != nil {
 		return err
 	}
-	selector, err := validateAndTranslateSelectors(selectors)
+	selector, err := validateAndTranslateSelectors(ctx, selectors)
 	if err != nil {
 		return err
 	}
@@ -280,7 +280,7 @@ func (d *DatumRepository) DestroyDeletedDataSetData(ctx context.Context, dataSet
 	if err := validateDataSet(dataSet); err != nil {
 		return err
 	}
-	selector, err := validateAndTranslateSelectors(selectors)
+	selector, err := validateAndTranslateSelectors(ctx, selectors)
 	if err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func (d *DatumRepository) DestroyDataSetData(ctx context.Context, dataSet *uploa
 	if err := validateDataSet(dataSet); err != nil {
 		return err
 	}
-	selector, err := validateAndTranslateSelectors(selectors)
+	selector, err := validateAndTranslateSelectors(ctx, selectors)
 	if err != nil {
 		return err
 	}
@@ -482,10 +482,10 @@ func (d *DatumRepository) UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.
 	return overallErr
 }
 
-func validateAndTranslateSelectors(selectors *data.Selectors) (bson.M, error) {
+func validateAndTranslateSelectors(ctx context.Context, selectors *data.Selectors) (bson.M, error) {
 	if selectors == nil {
 		return bson.M{}, nil
-	} else if err := structureValidator.New().Validate(selectors); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(selectors); err != nil {
 		return nil, errors.Join(ErrSelectorsInvalid, err)
 	}
 

--- a/data/store/store_test.go
+++ b/data/store/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/data/store"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -33,7 +34,7 @@ var _ = Describe("Store", func() {
 			Context("Parse", func() {
 				It("parses deleted missing", func() {
 					object := map[string]interface{}{}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					filter.Parse(parser)
 					Expect(filter.Deleted).To(BeFalse())
 					Expect(parser.Error()).ToNot(HaveOccurred())
@@ -41,7 +42,7 @@ var _ = Describe("Store", func() {
 
 				It("parses deleted false", func() {
 					object := map[string]interface{}{"deleted": false}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					filter.Parse(parser)
 					Expect(filter.Deleted).To(BeFalse())
 					Expect(parser.Error()).ToNot(HaveOccurred())
@@ -49,7 +50,7 @@ var _ = Describe("Store", func() {
 
 				It("parses deleted true", func() {
 					object := map[string]interface{}{"deleted": true}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					filter.Parse(parser)
 					Expect(filter.Deleted).To(BeTrue())
 					Expect(parser.Error()).ToNot(HaveOccurred())
@@ -57,7 +58,7 @@ var _ = Describe("Store", func() {
 
 				It("reports an error if page is not a bool", func() {
 					object := map[string]interface{}{"deleted": "invalid"}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					filter.Parse(parser)
 					Expect(filter.Deleted).To(BeFalse())
 					Expect(parser.Error()).To(HaveOccurred())
@@ -69,7 +70,7 @@ var _ = Describe("Store", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 				})
 
 				It("succeeds with deleted default", func() {

--- a/data/types/activity/physical/distance_test.go
+++ b/data/types/activity/physical/distance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -390,7 +391,7 @@ var _ = Describe("Distance", func() {
 						datum := NewDistance()
 						mutator(datum)
 						expectedDatum := CloneDistance(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/duration_test.go
+++ b/data/types/activity/physical/duration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -288,7 +289,7 @@ var _ = Describe("Duration", func() {
 						datum := NewDuration()
 						mutator(datum)
 						expectedDatum := CloneDuration(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/elevation_change_test.go
+++ b/data/types/activity/physical/elevation_change_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -247,7 +248,7 @@ var _ = Describe("ElevationChange", func() {
 						datum := NewElevationChange()
 						mutator(datum)
 						expectedDatum := CloneElevationChange(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/energy_test.go
+++ b/data/types/activity/physical/energy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -369,7 +370,7 @@ var _ = Describe("Energy", func() {
 						datum := NewEnergy()
 						mutator(datum)
 						expectedDatum := CloneEnergy(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/flight_test.go
+++ b/data/types/activity/physical/flight_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -95,7 +96,7 @@ var _ = Describe("Flight", func() {
 						datum := NewFlight()
 						mutator(datum)
 						expectedDatum := CloneFlight(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/lap_test.go
+++ b/data/types/activity/physical/lap_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -112,7 +113,7 @@ var _ = Describe("Lap", func() {
 						datum := NewLap()
 						mutator(datum)
 						expectedDatum := CloneLap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/physical_test.go
+++ b/data/types/activity/physical/physical_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -1313,7 +1314,7 @@ var _ = Describe("Physical", func() {
 						datum := NewPhysical()
 						mutator(datum)
 						expectedDatum := ClonePhysical(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/activity/physical/step_test.go
+++ b/data/types/activity/physical/step_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/activity/physical"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -95,7 +96,7 @@ var _ = Describe("Step", func() {
 						datum := NewStep()
 						mutator(datum)
 						expectedDatum := CloneStep(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/alert/alert_test.go
+++ b/data/types/alert/alert_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesAlertTest "github.com/tidepool-org/platform/data/types/alert/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -149,7 +150,7 @@ var _ = Describe("Alert", func() {
 					object := dataTypesAlertTest.NewObjectFromAlert(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesAlert.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -542,7 +543,7 @@ var _ = Describe("Alert", func() {
 						datum := dataTypesAlertTest.RandomAlert()
 						mutator(datum)
 						expectedDatum := dataTypesAlertTest.CloneAlert(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/basal/automated/automated_test.go
+++ b/data/types/basal/automated/automated_test.go
@@ -14,6 +14,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
@@ -100,7 +101,7 @@ var _ = Describe("Automated", func() {
 					object := dataTypesBasalAutomatedTest.NewObjectFromAutomated(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesBasalAutomated.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -437,7 +438,7 @@ var _ = Describe("Automated", func() {
 						datum := dataTypesBasalAutomatedTest.RandomAutomated()
 						mutator(datum)
 						expectedDatum := dataTypesBasalAutomatedTest.CloneAutomated(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -504,13 +505,13 @@ var _ = Describe("Automated", func() {
 
 		Context("ParseSuppressedAutomated", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesBasalAutomated.ParseSuppressedAutomated(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesBasalAutomated.ParseSuppressedAutomated(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 				object := dataTypesBasalAutomatedTest.NewObjectFromSuppressedAutomated(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesBasalAutomated.ParseSuppressedAutomated(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -671,7 +672,7 @@ var _ = Describe("Automated", func() {
 						datum := dataTypesBasalAutomatedTest.RandomSuppressedAutomated()
 						mutator(datum)
 						expectedDatum := dataTypesBasalAutomatedTest.CloneSuppressedAutomated(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/basal/scheduled/scheduled_test.go
+++ b/data/types/basal/scheduled/scheduled_test.go
@@ -15,6 +15,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -371,7 +372,7 @@ var _ = Describe("Scheduled", func() {
 						datum := NewScheduled()
 						mutator(datum)
 						expectedDatum := CloneScheduled(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -536,7 +537,7 @@ var _ = Describe("Scheduled", func() {
 						datum := dataTypesBasalScheduledTest.RandomSuppressedScheduled()
 						mutator(datum)
 						expectedDatum := dataTypesBasalScheduledTest.CloneSuppressedScheduled(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/basal/suspend/suspend_test.go
+++ b/data/types/basal/suspend/suspend_test.go
@@ -16,6 +16,7 @@ import (
 	dataTypesBasalTest "github.com/tidepool-org/platform/data/types/basal/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -355,7 +356,7 @@ var _ = Describe("Suspend", func() {
 						datum := NewSuspend()
 						mutator(datum)
 						expectedDatum := CloneSuspend(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/basal/temporary/temporary_test.go
+++ b/data/types/basal/temporary/temporary_test.go
@@ -15,6 +15,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -417,7 +418,7 @@ var _ = Describe("Temporary", func() {
 						datum := NewTemporary()
 						mutator(datum)
 						expectedDatum := CloneTemporary(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -606,7 +607,7 @@ var _ = Describe("Temporary", func() {
 						datum := dataTypesBasalTemporaryTest.RandomSuppressedTemporary(dataTypesBasalScheduledTest.RandomSuppressedScheduled())
 						mutator(datum)
 						expectedDatum := dataTypesBasalTemporaryTest.CloneSuppressedTemporary(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/base_test.go
+++ b/data/types/base_test.go
@@ -15,6 +15,7 @@ import (
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metadata"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/net"
@@ -814,7 +815,7 @@ var _ = Describe("Base", func() {
 						datum := dataTypesTest.RandomBase()
 						mutator(datum)
 						expectedDatum := dataTypesTest.CloneBase(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -838,7 +839,7 @@ var _ = Describe("Base", func() {
 					datum := dataTypesTest.RandomBase()
 					mutator(datum)
 					expectedDatum := dataTypesTest.CloneBase(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -875,7 +876,7 @@ var _ = Describe("Base", func() {
 						datum := dataTypesTest.RandomBase()
 						mutator(datum)
 						expectedDatum := dataTypesTest.CloneBase(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/blood/glucose/continuous/continuous_test.go
+++ b/data/types/blood/glucose/continuous/continuous_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesBloodGlucoseTest "github.com/tidepool-org/platform/data/types/blood/glucose/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -269,7 +270,7 @@ var _ = Describe("Continuous", func() {
 					datum := NewContinuous(units)
 					mutator(datum, units)
 					expectedDatum := CloneContinuous(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(origin))
 					Expect(normalizer.Error()).To(BeNil())
@@ -317,7 +318,7 @@ var _ = Describe("Continuous", func() {
 				datum := NewContinuous(units)
 				mutator(datum, units)
 				expectedDatum := CloneContinuous(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 				Expect(normalizer.Error()).To(BeNil())
@@ -394,7 +395,7 @@ var _ = Describe("Continuous", func() {
 					datum := NewContinuous(units)
 					mutator(datum, units)
 					expectedDatum := CloneContinuous(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(origin))
 					Expect(normalizer.Error()).To(BeNil())

--- a/data/types/blood/glucose/glucose_test.go
+++ b/data/types/blood/glucose/glucose_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesBloodGlucoseTest "github.com/tidepool-org/platform/data/types/blood/glucose/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -289,7 +290,7 @@ var _ = Describe("Glucose", func() {
 					datum := dataTypesBloodGlucoseTest.NewGlucose(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesBloodGlucoseTest.CloneGlucose(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(origin))
 					Expect(normalizer.Error()).To(BeNil())
@@ -327,7 +328,7 @@ var _ = Describe("Glucose", func() {
 				datum := dataTypesBloodGlucoseTest.NewGlucose(units)
 				mutator(datum, units)
 				expectedDatum := dataTypesBloodGlucoseTest.CloneGlucose(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 				Expect(normalizer.Error()).To(BeNil())
@@ -413,7 +414,7 @@ var _ = Describe("Glucose", func() {
 					datum := dataTypesBloodGlucoseTest.NewGlucose(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesBloodGlucoseTest.CloneGlucose(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(origin))
 					Expect(normalizer.Error()).To(BeNil())

--- a/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesBloodGlucoseTest "github.com/tidepool-org/platform/data/types/blood/glucose/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -290,7 +291,7 @@ var _ = Describe("SelfMonitored", func() {
 						datum := NewSelfMonitored(units)
 						mutator(datum, units)
 						expectedDatum := CloneSelfMonitored(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -353,7 +354,7 @@ var _ = Describe("SelfMonitored", func() {
 					datum := NewSelfMonitored(units)
 					mutator(datum, units)
 					expectedDatum := CloneSelfMonitored(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -425,7 +426,7 @@ var _ = Describe("SelfMonitored", func() {
 						datum := NewSelfMonitored(units)
 						mutator(datum, units)
 						expectedDatum := CloneSelfMonitored(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/blood/ketone/ketone_test.go
+++ b/data/types/blood/ketone/ketone_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesBloodTest "github.com/tidepool-org/platform/data/types/blood/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	"github.com/tidepool-org/platform/test"
@@ -253,7 +254,7 @@ var _ = Describe("Ketone", func() {
 						datum := NewKetone(units)
 						mutator(datum, units)
 						expectedDatum := CloneKetone(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -291,7 +292,7 @@ var _ = Describe("Ketone", func() {
 					datum := NewKetone(units)
 					mutator(datum, units)
 					expectedDatum := CloneKetone(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -337,7 +338,7 @@ var _ = Describe("Ketone", func() {
 						datum := NewKetone(units)
 						mutator(datum, units)
 						expectedDatum := CloneKetone(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/bolus/automated/automated_test.go
+++ b/data/types/bolus/automated/automated_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesBolusAutomatedTest "github.com/tidepool-org/platform/data/types/bolus/automated/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -79,7 +80,7 @@ var _ = Describe("Automated", func() {
 					object := dataTypesBolusAutomatedTest.NewObjectFromAutomated(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesBolusAutomated.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -328,7 +329,7 @@ var _ = Describe("Automated", func() {
 						datum := dataTypesBolusAutomatedTest.RandomAutomated()
 						mutator(datum)
 						expectedDatum := dataTypesBolusAutomatedTest.CloneAutomated(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/bolus/bolus_test.go
+++ b/data/types/bolus/bolus_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -119,7 +120,7 @@ var _ = Describe("Bolus", func() {
 						datum := dataTypesBolusTest.RandomBolus()
 						mutator(datum)
 						expectedDatum := dataTypesBolusTest.CloneBolus(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/bolus/combination/combination_test.go
+++ b/data/types/bolus/combination/combination_test.go
@@ -7,6 +7,7 @@ import (
 	dataTypesBolusCombinationTest "github.com/tidepool-org/platform/data/types/bolus/combination/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -1194,7 +1195,7 @@ var _ = Describe("Combination", func() {
 						datum := dataTypesBolusCombinationTest.NewCombination()
 						mutator(datum)
 						expectedDatum := dataTypesBolusCombinationTest.CloneCombination(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/bolus/extended/extended_test.go
+++ b/data/types/bolus/extended/extended_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesBolusExtendedTest "github.com/tidepool-org/platform/data/types/bolus/extended/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -508,7 +509,7 @@ var _ = Describe("Extended", func() {
 						datum := dataTypesBolusExtendedTest.NewExtended()
 						mutator(datum)
 						expectedDatum := dataTypesBolusExtendedTest.CloneExtended(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/bolus/normal/normal_test.go
+++ b/data/types/bolus/normal/normal_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesBolusNormalTest "github.com/tidepool-org/platform/data/types/bolus/normal/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -281,7 +282,7 @@ var _ = Describe("Normal", func() {
 						datum := dataTypesBolusNormalTest.NewNormal()
 						mutator(datum)
 						expectedDatum := dataTypesBolusNormalTest.CloneNormal(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/calculator/calculator_test.go
+++ b/data/types/calculator/calculator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/calculator"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -1817,7 +1818,7 @@ var _ = Describe("Calculator", func() {
 			It("does not modify datum if bolus is missing", func() {
 				datum := NewCalculatorWithBolusID(pointer.FromString("mmol/L"))
 				expectedDatum := CloneCalculator(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())
@@ -1830,7 +1831,7 @@ var _ = Describe("Calculator", func() {
 				datum := NewCalculatorWithBolusID(pointer.FromString("mmol/L"))
 				datum.Bolus = data.DatumAsPointer(datumBolus)
 				expectedDatum := CloneCalculator(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())
@@ -1845,7 +1846,7 @@ var _ = Describe("Calculator", func() {
 				datum := NewCalculatorWithBolusID(pointer.FromString("mmol/L"))
 				datum.Bolus = data.DatumAsPointer(datumBolus)
 				expectedDatum := CloneCalculator(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())
@@ -1860,7 +1861,7 @@ var _ = Describe("Calculator", func() {
 				datum := NewCalculatorWithBolusID(pointer.FromString("mmol/L"))
 				datum.Bolus = data.DatumAsPointer(datumBolus)
 				expectedDatum := CloneCalculator(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())
@@ -1876,7 +1877,7 @@ var _ = Describe("Calculator", func() {
 						datum := NewCalculator(units)
 						mutator(datum, units)
 						expectedDatum := CloneCalculator(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -1904,7 +1905,7 @@ var _ = Describe("Calculator", func() {
 					datum := NewCalculator(units)
 					mutator(datum, units)
 					expectedDatum := CloneCalculator(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -1954,7 +1955,7 @@ var _ = Describe("Calculator", func() {
 						datum := NewCalculator(units)
 						mutator(datum, units)
 						expectedDatum := CloneCalculator(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/calculator/recommended_test.go
+++ b/data/types/calculator/recommended_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/calculator"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -154,7 +155,7 @@ var _ = Describe("Recommended", func() {
 						datum := NewRecommended()
 						mutator(datum)
 						expectedDatum := CloneRecommended(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/alarm/alarm_test.go
+++ b/data/types/device/alarm/alarm_test.go
@@ -14,6 +14,7 @@ import (
 	dataTypesDeviceTest "github.com/tidepool-org/platform/data/types/device/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -283,7 +284,7 @@ var _ = Describe("Change", func() {
 			It("does not modify datum if status is missing", func() {
 				datum := NewAlarmWithStatusID()
 				expectedDatum := CloneAlarm(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())
@@ -296,7 +297,7 @@ var _ = Describe("Change", func() {
 				datum := NewAlarmWithStatusID()
 				datum.Status = data.DatumAsPointer(datumStatus)
 				expectedDatum := CloneAlarm(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/calibration/calibration_test.go
+++ b/data/types/device/calibration/calibration_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesDeviceTest "github.com/tidepool-org/platform/data/types/device/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -271,7 +272,7 @@ var _ = Describe("Calibration", func() {
 						datum := NewCalibration(units)
 						mutator(datum, units)
 						expectedDatum := CloneCalibration(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -309,7 +310,7 @@ var _ = Describe("Calibration", func() {
 					datum := NewCalibration(units)
 					mutator(datum, units)
 					expectedDatum := CloneCalibration(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -381,7 +382,7 @@ var _ = Describe("Calibration", func() {
 						datum := NewCalibration(units)
 						mutator(datum, units)
 						expectedDatum := CloneCalibration(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/override/settings/pump/pump_test.go
+++ b/data/types/device/override/settings/pump/pump_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesDeviceOverrideSettingsPumpTest "github.com/tidepool-org/platform/data/types/device/override/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -162,7 +163,7 @@ var _ = Describe("Pump", func() {
 					object := dataTypesDeviceOverrideSettingsPumpTest.NewObjectFromPump(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDeviceOverrideSettingsPump.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -723,7 +724,7 @@ var _ = Describe("Pump", func() {
 					datum := dataTypesDeviceOverrideSettingsPumpTest.RandomPump(unitsBloodGlucose)
 					mutator(datum, unitsBloodGlucose)
 					expectedDatum := dataTypesDeviceOverrideSettingsPumpTest.ClonePump(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -792,7 +793,7 @@ var _ = Describe("Pump", func() {
 						datum := dataTypesDeviceOverrideSettingsPumpTest.RandomPump(unitsBloodGlucose)
 						mutator(datum, unitsBloodGlucose)
 						expectedDatum := dataTypesDeviceOverrideSettingsPumpTest.ClonePump(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/override/settings/pump/units_test.go
+++ b/data/types/device/override/settings/pump/units_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesDeviceOverrideSettingsPumpTest "github.com/tidepool-org/platform/data/types/device/override/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -42,13 +43,13 @@ var _ = Describe("Units", func() {
 
 	Context("ParseUnits", func() {
 		It("returns nil when the object is missing", func() {
-			Expect(dataTypesDeviceOverrideSettingsPump.ParseUnits(structureParser.NewObject(nil))).To(BeNil())
+			Expect(dataTypesDeviceOverrideSettingsPump.ParseUnits(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 		})
 
 		It("returns new datum when the object is valid", func() {
 			datum := dataTypesDeviceOverrideSettingsPumpTest.RandomUnits()
 			object := dataTypesDeviceOverrideSettingsPumpTest.NewObjectFromUnits(datum, test.ObjectFormatJSON)
-			parser := structureParser.NewObject(&object)
+			parser := structureParser.NewObject(logTest.NewLogger(), &object)
 			Expect(dataTypesDeviceOverrideSettingsPump.ParseUnits(parser)).To(Equal(datum))
 			Expect(parser.Error()).ToNot(HaveOccurred())
 		})
@@ -67,7 +68,7 @@ var _ = Describe("Units", func() {
 				object := dataTypesDeviceOverrideSettingsPumpTest.NewObjectFromUnits(expectedDatum, test.ObjectFormatJSON)
 				mutator(object, expectedDatum)
 				datum := &dataTypesDeviceOverrideSettingsPump.Units{}
-				errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+				errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 				Expect(datum).To(Equal(expectedDatum))
 			},
 			Entry("succeeds",
@@ -133,7 +134,7 @@ var _ = Describe("Units", func() {
 					datum := dataTypesDeviceOverrideSettingsPumpTest.RandomUnits()
 					mutator(datum)
 					expectedDatum := dataTypesDeviceOverrideSettingsPumpTest.CloneUnits(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(origin))
 					Expect(normalizer.Error()).To(BeNil())
@@ -161,7 +162,7 @@ var _ = Describe("Units", func() {
 				datum := dataTypesDeviceOverrideSettingsPumpTest.RandomUnits()
 				mutator(datum)
 				expectedDatum := dataTypesDeviceOverrideSettingsPumpTest.CloneUnits(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 				Expect(normalizer.Error()).To(BeNil())
@@ -209,7 +210,7 @@ var _ = Describe("Units", func() {
 					datum := dataTypesDeviceOverrideSettingsPumpTest.RandomUnits()
 					mutator(datum)
 					expectedDatum := dataTypesDeviceOverrideSettingsPumpTest.CloneUnits(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(origin))
 					Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/prime/prime_test.go
+++ b/data/types/device/prime/prime_test.go
@@ -7,6 +7,7 @@ import (
 	dataTypesDeviceTest "github.com/tidepool-org/platform/data/types/device/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -221,7 +222,7 @@ var _ = Describe("Status", func() {
 						datum := NewPrime()
 						mutator(datum)
 						expectedDatum := ClonePrime(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/reservoirchange/reservoirchange_test.go
+++ b/data/types/device/reservoirchange/reservoirchange_test.go
@@ -14,6 +14,7 @@ import (
 	dataTypesDeviceTest "github.com/tidepool-org/platform/data/types/device/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -202,7 +203,7 @@ var _ = Describe("Change", func() {
 			It("does not modify datum if status is missing", func() {
 				datum := NewReservoirChangeWithStatusID()
 				expectedDatum := CloneReservoirChange(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())
@@ -215,7 +216,7 @@ var _ = Describe("Change", func() {
 				datum := NewReservoirChangeWithStatusID()
 				datum.Status = data.DatumAsPointer(datumStatus)
 				expectedDatum := CloneReservoirChange(datum)
-				normalizer := dataNormalizer.New()
+				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
 				datum.Normalize(normalizer)
 				Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/status/status_test.go
+++ b/data/types/device/status/status_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesDeviceStatusTest "github.com/tidepool-org/platform/data/types/device/status/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metadata"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -233,7 +234,7 @@ var _ = Describe("Status", func() {
 						datum := dataTypesDeviceStatusTest.NewStatus()
 						mutator(datum)
 						expectedDatum := dataTypesDeviceStatusTest.CloneStatus(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/timechange/change_test.go
+++ b/data/types/device/timechange/change_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesDeviceTimechangeTest "github.com/tidepool-org/platform/data/types/device/timechange/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -122,7 +123,7 @@ var _ = Describe("Change", func() {
 						datum := dataTypesDeviceTimechangeTest.RandomChange()
 						mutator(datum)
 						expectedDatum := dataTypesDeviceTimechangeTest.CloneChange(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/timechange/info_test.go
+++ b/data/types/device/timechange/info_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesDeviceTimechangeTest "github.com/tidepool-org/platform/data/types/device/timechange/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -98,7 +99,7 @@ var _ = Describe("Info", func() {
 						datum := dataTypesDeviceTimechangeTest.RandomInfo()
 						mutator(datum)
 						expectedDatum := dataTypesDeviceTimechangeTest.CloneInfo(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/device/timechange/timechange_test.go
+++ b/data/types/device/timechange/timechange_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesDeviceTimechangeTest "github.com/tidepool-org/platform/data/types/device/timechange/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -211,7 +212,7 @@ var _ = Describe("TimeChange", func() {
 							datum := dataTypesDeviceTimechangeTest.RandomTimeChange(deprecated)
 							mutator(datum)
 							expectedDatum := dataTypesDeviceTimechangeTest.CloneTimeChange(datum)
-							normalizer := dataNormalizer.New()
+							normalizer := dataNormalizer.New(logTest.NewLogger())
 							Expect(normalizer).ToNot(BeNil())
 							datum.Normalize(normalizer.WithOrigin(origin))
 							Expect(normalizer.Error()).To(BeNil())

--- a/data/types/dosingdecision/blood_glucose_test.go
+++ b/data/types/dosingdecision/blood_glucose_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -50,14 +51,14 @@ var _ = Describe("BloodGlucose", func() {
 
 		Context("ParseBloodGlucose", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseBloodGlucose(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseBloodGlucose(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				units := pointer.FromString(test.RandomStringFromArray(dataBloodGlucose.Units()))
 				datum := dataTypesDosingDecisionTest.RandomBloodGlucose(units)
 				object := dataTypesDosingDecisionTest.NewObjectFromBloodGlucose(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseBloodGlucose(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -80,7 +81,7 @@ var _ = Describe("BloodGlucose", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromBloodGlucose(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewBloodGlucose()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -248,7 +249,7 @@ var _ = Describe("BloodGlucose", func() {
 					datum := dataTypesDosingDecisionTest.RandomBloodGlucose(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesDosingDecisionTest.CloneBloodGlucose(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -300,7 +301,7 @@ var _ = Describe("BloodGlucose", func() {
 						datum := dataTypesDosingDecisionTest.RandomBloodGlucose(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesDosingDecisionTest.CloneBloodGlucose(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -366,14 +367,14 @@ var _ = Describe("BloodGlucose", func() {
 
 		Context("ParseBloodGlucoseArray", func() {
 			It("returns nil when the array is missing", func() {
-				Expect(dataTypesDosingDecision.ParseBloodGlucoseArray(structureParser.NewArray(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseBloodGlucoseArray(structureParser.NewArray(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the array is valid", func() {
 				units := pointer.FromString(test.RandomStringFromArray(dataBloodGlucose.Units()))
 				datum := dataTypesDosingDecisionTest.RandomBloodGlucoseArray(units)
 				array := dataTypesDosingDecisionTest.NewArrayFromBloodGlucoseArray(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				Expect(dataTypesDosingDecision.ParseBloodGlucoseArray(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -395,7 +396,7 @@ var _ = Describe("BloodGlucose", func() {
 					array := dataTypesDosingDecisionTest.NewArrayFromBloodGlucoseArray(expectedDatum, test.ObjectFormatJSON)
 					mutator(array, expectedDatum)
 					datum := dataTypesDosingDecision.NewBloodGlucoseArray()
-					errorsTest.ExpectEqual(structureParser.NewArray(&array).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewArray(logTest.NewLogger(), &array).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -494,7 +495,7 @@ var _ = Describe("BloodGlucose", func() {
 					datum := dataTypesDosingDecisionTest.RandomBloodGlucoseArray(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesDosingDecisionTest.CloneBloodGlucoseArray(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -550,7 +551,7 @@ var _ = Describe("BloodGlucose", func() {
 						datum := dataTypesDosingDecisionTest.RandomBloodGlucoseArray(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesDosingDecisionTest.CloneBloodGlucoseArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/dosingdecision/carbohydrates_on_board_test.go
+++ b/data/types/dosingdecision/carbohydrates_on_board_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -50,13 +51,13 @@ var _ = Describe("CarbohydratesOnBoard", func() {
 
 		Context("ParseCarbohydratesOnBoard", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseCarbohydratesOnBoard(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseCarbohydratesOnBoard(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomCarbohydratesOnBoard()
 				object := dataTypesDosingDecisionTest.NewObjectFromCarbohydratesOnBoard(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseCarbohydratesOnBoard(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -78,7 +79,7 @@ var _ = Describe("CarbohydratesOnBoard", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromCarbohydratesOnBoard(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewCarbohydratesOnBoard()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/dosing_decision_test.go
+++ b/data/types/dosingdecision/dosing_decision_test.go
@@ -13,6 +13,7 @@ import (
 	dataTypesSettingsPumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -116,7 +117,7 @@ var _ = Describe("DosingDecision", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromDosingDecision(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -525,7 +526,7 @@ var _ = Describe("DosingDecision", func() {
 					datum := dataTypesDosingDecisionTest.RandomDosingDecision(unitsBloodGlucose)
 					mutator(datum, unitsBloodGlucose)
 					expectedDatum := dataTypesDosingDecisionTest.CloneDosingDecision(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -599,7 +600,7 @@ var _ = Describe("DosingDecision", func() {
 						datum := dataTypesDosingDecisionTest.RandomDosingDecision(unitsBloodGlucose)
 						mutator(datum, unitsBloodGlucose)
 						expectedDatum := dataTypesDosingDecisionTest.CloneDosingDecision(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/dosingdecision/food_test.go
+++ b/data/types/dosingdecision/food_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -43,13 +44,13 @@ var _ = Describe("Food", func() {
 
 		Context("ParseFood", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseFood(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseFood(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomFood()
 				object := dataTypesDosingDecisionTest.NewObjectFromFood(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseFood(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -71,7 +72,7 @@ var _ = Describe("Food", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromFood(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewFood()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/insulin_on_board_test.go
+++ b/data/types/dosingdecision/insulin_on_board_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -50,13 +51,13 @@ var _ = Describe("InsulinOnBoard", func() {
 
 		Context("ParseInsulinOnBoard", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseInsulinOnBoard(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseInsulinOnBoard(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomInsulinOnBoard()
 				object := dataTypesDosingDecisionTest.NewObjectFromInsulinOnBoard(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseInsulinOnBoard(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -78,7 +79,7 @@ var _ = Describe("InsulinOnBoard", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromInsulinOnBoard(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewInsulinOnBoard()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/issue_test.go
+++ b/data/types/dosingdecision/issue_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metadata"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -52,13 +53,13 @@ var _ = Describe("Issue", func() {
 
 		Context("ParseIssue", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseIssue(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseIssue(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomIssue()
 				object := dataTypesDosingDecisionTest.NewObjectFromIssue(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseIssue(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -80,7 +81,7 @@ var _ = Describe("Issue", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromIssue(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewIssue()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -170,13 +171,13 @@ var _ = Describe("Issue", func() {
 
 		Context("ParseIssueArray", func() {
 			It("returns nil when the array is missing", func() {
-				Expect(dataTypesDosingDecision.ParseIssueArray(structureParser.NewArray(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseIssueArray(structureParser.NewArray(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the array is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomIssueArray()
 				array := dataTypesDosingDecisionTest.NewArrayFromIssueArray(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				Expect(dataTypesDosingDecision.ParseIssueArray(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -197,7 +198,7 @@ var _ = Describe("Issue", func() {
 					array := dataTypesDosingDecisionTest.NewArrayFromIssueArray(expectedDatum, test.ObjectFormatJSON)
 					mutator(array, expectedDatum)
 					datum := dataTypesDosingDecision.NewIssueArray()
-					errorsTest.ExpectEqual(structureParser.NewArray(&array).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewArray(logTest.NewLogger(), &array).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/recommended_basal_test.go
+++ b/data/types/dosingdecision/recommended_basal_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -58,13 +59,13 @@ var _ = Describe("RecommendedBasal", func() {
 
 		Context("ParseRecommendedBasal", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseRecommendedBasal(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseRecommendedBasal(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomRecommendedBasal()
 				object := dataTypesDosingDecisionTest.NewObjectFromRecommendedBasal(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseRecommendedBasal(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -86,7 +87,7 @@ var _ = Describe("RecommendedBasal", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromRecommendedBasal(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewRecommendedBasal()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/recommended_bolus_test.go
+++ b/data/types/dosingdecision/recommended_bolus_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -49,13 +50,13 @@ var _ = Describe("RecommendedBolus", func() {
 
 		Context("ParseRecommendedBolus", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseRecommendedBolus(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseRecommendedBolus(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomRecommendedBolus()
 				object := dataTypesDosingDecisionTest.NewObjectFromRecommendedBolus(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseRecommendedBolus(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -76,7 +77,7 @@ var _ = Describe("RecommendedBolus", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromRecommendedBolus(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewRecommendedBolus()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/requested_bolus_test.go
+++ b/data/types/dosingdecision/requested_bolus_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -49,13 +50,13 @@ var _ = Describe("RequestedBolus", func() {
 
 		Context("ParseRequestedBolus", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseRequestedBolus(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseRequestedBolus(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomRequestedBolus()
 				object := dataTypesDosingDecisionTest.NewObjectFromRequestedBolus(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseRequestedBolus(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -76,7 +77,7 @@ var _ = Describe("RequestedBolus", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromRequestedBolus(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewRequestedBolus()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/dosingdecision/units_test.go
+++ b/data/types/dosingdecision/units_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesDosingDecisionTest "github.com/tidepool-org/platform/data/types/dosingdecision/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -66,13 +67,13 @@ var _ = Describe("Units", func() {
 
 		Context("ParseUnits", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesDosingDecision.ParseUnits(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesDosingDecision.ParseUnits(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesDosingDecisionTest.RandomUnits(pointer.FromString("mg/dL"))
 				object := dataTypesDosingDecisionTest.NewObjectFromUnits(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesDosingDecision.ParseUnits(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -95,7 +96,7 @@ var _ = Describe("Units", func() {
 					object := dataTypesDosingDecisionTest.NewObjectFromUnits(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesDosingDecision.NewUnits()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -191,7 +192,7 @@ var _ = Describe("Units", func() {
 					datum := dataTypesDosingDecisionTest.RandomUnits(pointer.FromString("mmol/L"))
 					mutator(datum)
 					expectedDatum := dataTypesDosingDecisionTest.CloneUnits(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -271,7 +272,7 @@ var _ = Describe("Units", func() {
 						datum := dataTypesDosingDecisionTest.RandomUnits(pointer.FromString("mmol/L"))
 						mutator(datum)
 						expectedDatum := dataTypesDosingDecisionTest.CloneUnits(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/food/amount_test.go
+++ b/data/types/food/amount_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -52,13 +53,13 @@ var _ = Describe("Amount", func() {
 
 		Context("ParseAmount", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseAmount(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseAmount(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomAmount()
 				object := dataTypesFoodTest.NewObjectFromAmount(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseAmount(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -80,7 +81,7 @@ var _ = Describe("Amount", func() {
 					object := dataTypesFoodTest.NewObjectFromAmount(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.NewAmount()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/food/carbohydrate_test.go
+++ b/data/types/food/carbohydrate_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -85,13 +86,13 @@ var _ = Describe("Carbohydrate", func() {
 
 		Context("ParseCarbohydrate", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseCarbohydrate(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseCarbohydrate(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomCarbohydrate()
 				object := dataTypesFoodTest.NewObjectFromCarbohydrate(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseCarbohydrate(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})

--- a/data/types/food/energy_test.go
+++ b/data/types/food/energy_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -100,13 +101,13 @@ var _ = Describe("Energy", func() {
 
 		Context("ParseEnergy", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseEnergy(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseEnergy(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomEnergy()
 				object := dataTypesFoodTest.NewObjectFromEnergy(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseEnergy(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -128,7 +129,7 @@ var _ = Describe("Energy", func() {
 					object := dataTypesFoodTest.NewObjectFromEnergy(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.NewEnergy()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/food/fat_test.go
+++ b/data/types/food/fat_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -58,13 +59,13 @@ var _ = Describe("Fat", func() {
 
 		Context("ParseFat", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseFat(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseFat(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomFat()
 				object := dataTypesFoodTest.NewObjectFromFat(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseFat(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -86,7 +87,7 @@ var _ = Describe("Fat", func() {
 					object := dataTypesFoodTest.NewObjectFromFat(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.NewFat()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/food/food_test.go
+++ b/data/types/food/food_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -121,7 +122,7 @@ var _ = Describe("Food", func() {
 					object := dataTypesFoodTest.NewObjectFromFood(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -394,7 +395,7 @@ var _ = Describe("Food", func() {
 						datum := dataTypesFoodTest.RandomFood(3)
 						mutator(datum)
 						expectedDatum := dataTypesFoodTest.CloneFood(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/food/ingredient_test.go
+++ b/data/types/food/ingredient_test.go
@@ -5,6 +5,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -62,13 +63,13 @@ var _ = Describe("Ingredient", func() {
 
 		Context("ParseIngredient", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseIngredient(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseIngredient(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomIngredient(3)
 				object := dataTypesFoodTest.NewObjectFromIngredient(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseIngredient(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -94,7 +95,7 @@ var _ = Describe("Ingredient", func() {
 					object := dataTypesFoodTest.NewObjectFromIngredient(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.NewIngredient()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -259,13 +260,13 @@ var _ = Describe("Ingredient", func() {
 
 		Context("ParseIngredientArray", func() {
 			It("returns nil when the array is missing", func() {
-				Expect(dataTypesFood.ParseIngredientArray(structureParser.NewArray(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseIngredientArray(structureParser.NewArray(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the array is valid", func() {
 				datum := dataTypesFoodTest.RandomIngredientArray(3)
 				array := dataTypesFoodTest.NewArrayFromIngredientArray(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				Expect(dataTypesFood.ParseIngredientArray(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -286,7 +287,7 @@ var _ = Describe("Ingredient", func() {
 					array := dataTypesFoodTest.NewArrayFromIngredientArray(expectedDatum, test.ObjectFormatJSON)
 					mutator(array, expectedDatum)
 					datum := dataTypesFood.NewIngredientArray()
-					errorsTest.ExpectEqual(structureParser.NewArray(&array).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewArray(logTest.NewLogger(), &array).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/food/nutrition_test.go
+++ b/data/types/food/nutrition_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -53,13 +54,13 @@ var _ = Describe("Nutrition", func() {
 
 		Context("ParseNutrition", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseNutrition(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseNutrition(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomNutrition()
 				object := dataTypesFoodTest.NewObjectFromNutrition(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseNutrition(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -84,7 +85,7 @@ var _ = Describe("Nutrition", func() {
 					object := dataTypesFoodTest.NewObjectFromNutrition(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.NewNutrition()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/food/protein_test.go
+++ b/data/types/food/protein_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesFoodTest "github.com/tidepool-org/platform/data/types/food/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -58,13 +59,13 @@ var _ = Describe("Protein", func() {
 
 		Context("ParseProtein", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesFood.ParseProtein(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesFood.ParseProtein(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesFoodTest.RandomProtein()
 				object := dataTypesFoodTest.NewObjectFromProtein(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesFood.ParseProtein(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -86,7 +87,7 @@ var _ = Describe("Protein", func() {
 					object := dataTypesFoodTest.NewObjectFromProtein(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesFood.NewProtein()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/insulin/compound_test.go
+++ b/data/types/insulin/compound_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -84,7 +85,7 @@ var _ = Describe("Compound", func() {
 						datum := dataTypesInsulinTest.RandomCompound(3)
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneCompound(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -199,7 +200,7 @@ var _ = Describe("Compound", func() {
 						datum := dataTypesInsulinTest.RandomCompoundArray(3)
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneCompoundArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/insulin/concentration_test.go
+++ b/data/types/insulin/concentration_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -195,7 +196,7 @@ var _ = Describe("Concentration", func() {
 						datum := dataTypesInsulinTest.RandomConcentration()
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneConcentration(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/insulin/dose_test.go
+++ b/data/types/insulin/dose_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -184,7 +185,7 @@ var _ = Describe("Dose", func() {
 						datum := dataTypesInsulinTest.NewDose()
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneDose(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/insulin/formulation_test.go
+++ b/data/types/insulin/formulation_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -158,7 +159,7 @@ var _ = Describe("Formulation", func() {
 						datum := dataTypesInsulinTest.RandomFormulation(3)
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneFormulation(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/insulin/insulin_test.go
+++ b/data/types/insulin/insulin_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -144,7 +145,7 @@ var _ = Describe("Insulin", func() {
 						datum := NewInsulin()
 						mutator(datum)
 						expectedDatum := CloneInsulin(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/insulin/simple_test.go
+++ b/data/types/insulin/simple_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesInsulinTest "github.com/tidepool-org/platform/data/types/insulin/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -129,7 +130,7 @@ var _ = Describe("Simple", func() {
 						datum := dataTypesInsulinTest.RandomSimple()
 						mutator(datum)
 						expectedDatum := dataTypesInsulinTest.CloneSimple(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/cgm/alert_test.go
+++ b/data/types/settings/cgm/alert_test.go
@@ -7,6 +7,7 @@ import (
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -60,7 +61,7 @@ var _ = Describe("Alert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.Alerts), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomAlerts()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.Alerts) {},
@@ -250,7 +251,7 @@ var _ = Describe("Alert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.Alert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.Alert) {},

--- a/data/types/settings/cgm/cgm_test.go
+++ b/data/types/settings/cgm/cgm_test.go
@@ -13,6 +13,7 @@ import (
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureTest "github.com/tidepool-org/platform/structure/test"
@@ -483,7 +484,7 @@ var _ = Describe("CGM", func() {
 					datum := dataTypesSettingsCgmTest.RandomCGM(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesSettingsCgmTest.CloneCGM(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -561,7 +562,7 @@ var _ = Describe("CGM", func() {
 						datum := dataTypesSettingsCgmTest.RandomCGM(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneCGM(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/cgm/duration_alert_test.go
+++ b/data/types/settings/cgm/duration_alert_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -102,7 +103,7 @@ var _ = Describe("DurationAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.DurationAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomDurationAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.DurationAlert) {},
@@ -250,7 +251,7 @@ var _ = Describe("DurationAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.NoDataAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomNoDataAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.NoDataAlert) {},
@@ -488,7 +489,7 @@ var _ = Describe("DurationAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.OutOfRangeAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomOutOfRangeAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.OutOfRangeAlert) {},

--- a/data/types/settings/cgm/level_alert_DEPRECATED_test.go
+++ b/data/types/settings/cgm/level_alert_DEPRECATED_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -323,7 +324,7 @@ var _ = Describe("LevelAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomHighLevelAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneHighLevelAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -366,7 +367,7 @@ var _ = Describe("LevelAlertDEPRECATED", func() {
 					datum := dataTypesSettingsCgmTest.RandomHighLevelAlertDEPRECATED(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesSettingsCgmTest.CloneHighLevelAlertDEPRECATED(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -408,7 +409,7 @@ var _ = Describe("LevelAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomHighLevelAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneHighLevelAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -707,7 +708,7 @@ var _ = Describe("LevelAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomLowLevelAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneLowLevelAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -750,7 +751,7 @@ var _ = Describe("LevelAlertDEPRECATED", func() {
 					datum := dataTypesSettingsCgmTest.RandomLowLevelAlertDEPRECATED(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesSettingsCgmTest.CloneLowLevelAlertDEPRECATED(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -792,7 +793,7 @@ var _ = Describe("LevelAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomLowLevelAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneLowLevelAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/cgm/level_alert_test.go
+++ b/data/types/settings/cgm/level_alert_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -100,7 +101,7 @@ var _ = Describe("LevelAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.LevelAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomLevelAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.LevelAlert) {},
@@ -233,7 +234,7 @@ var _ = Describe("LevelAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.HighAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomHighAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.HighAlert) {},
@@ -432,7 +433,7 @@ var _ = Describe("LevelAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.LowAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomLowAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.LowAlert) {},
@@ -631,7 +632,7 @@ var _ = Describe("LevelAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.UrgentLowAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomUrgentLowAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.UrgentLowAlert) {},

--- a/data/types/settings/cgm/out_of_range_alert_DEPRECATED_test.go
+++ b/data/types/settings/cgm/out_of_range_alert_DEPRECATED_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -91,7 +92,7 @@ var _ = Describe("OutOfRangeAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomOutOfRangeAlertDEPRECATED()
 						mutator(datum)
 						expectedDatum := dataTypesSettingsCgmTest.CloneOutOfRangeAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/cgm/rate_alert_DEPRECATED_test.go
+++ b/data/types/settings/cgm/rate_alert_DEPRECATED_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -215,7 +216,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomFallRateAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneFallRateAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -253,7 +254,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 					datum := dataTypesSettingsCgmTest.RandomFallRateAlertDEPRECATED(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesSettingsCgmTest.CloneFallRateAlertDEPRECATED(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -295,7 +296,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomFallRateAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneFallRateAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -510,7 +511,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomRiseRateAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneRiseRateAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -548,7 +549,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 					datum := dataTypesSettingsCgmTest.RandomRiseRateAlertDEPRECATED(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesSettingsCgmTest.CloneRiseRateAlertDEPRECATED(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -590,7 +591,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomRiseRateAlertDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneRiseRateAlertDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -706,7 +707,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomRateAlertsDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneRateAlertsDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -749,7 +750,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 					datum := dataTypesSettingsCgmTest.RandomRateAlertsDEPRECATED(units)
 					mutator(datum, units)
 					expectedDatum := dataTypesSettingsCgmTest.CloneRateAlertsDEPRECATED(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -793,7 +794,7 @@ var _ = Describe("RateAlertDEPRECATED", func() {
 						datum := dataTypesSettingsCgmTest.RandomRateAlertsDEPRECATED(units)
 						mutator(datum, units)
 						expectedDatum := dataTypesSettingsCgmTest.CloneRateAlertsDEPRECATED(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/cgm/rate_alert_test.go
+++ b/data/types/settings/cgm/rate_alert_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -84,7 +85,7 @@ var _ = Describe("RateAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.RateAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomRateAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.RateAlert) {},
@@ -217,7 +218,7 @@ var _ = Describe("RateAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.FallAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomFallAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.FallAlert) {},
@@ -416,7 +417,7 @@ var _ = Describe("RateAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.RiseAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomRiseAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.RiseAlert) {},

--- a/data/types/settings/cgm/scheduled_alert_test.go
+++ b/data/types/settings/cgm/scheduled_alert_test.go
@@ -7,6 +7,7 @@ import (
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -91,7 +92,7 @@ var _ = Describe("ScheduledAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.ScheduledAlerts), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomScheduledAlerts(1, 3)
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.ScheduledAlerts) {},
@@ -175,7 +176,7 @@ var _ = Describe("ScheduledAlert", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.ScheduledAlert), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomScheduledAlert()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.ScheduledAlert) {},

--- a/data/types/settings/cgm/snooze_test.go
+++ b/data/types/settings/cgm/snooze_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	dataTypesSettingsCgmTest "github.com/tidepool-org/platform/data/types/settings/cgm/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -93,7 +94,7 @@ var _ = Describe("Snooze", func() {
 				func(mutator func(datum *dataTypesSettingsCgm.Snooze), expectedErrors ...error) {
 					datum := dataTypesSettingsCgmTest.RandomSnooze()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *dataTypesSettingsCgm.Snooze) {},

--- a/data/types/settings/controller/controller_test.go
+++ b/data/types/settings/controller/controller_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesSettingsControllerTest "github.com/tidepool-org/platform/data/types/settings/controller/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -71,7 +72,7 @@ var _ = Describe("Controller", func() {
 					object := dataTypesSettingsControllerTest.NewObjectFromController(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesSettingsController.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -169,7 +170,7 @@ var _ = Describe("Controller", func() {
 					datum := dataTypesSettingsControllerTest.RandomController()
 					mutator(datum)
 					expectedDatum := dataTypesSettingsControllerTest.CloneController(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -193,7 +194,7 @@ var _ = Describe("Controller", func() {
 						datum := dataTypesSettingsControllerTest.RandomController()
 						mutator(datum)
 						expectedDatum := dataTypesSettingsControllerTest.CloneController(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/controller/device_test.go
+++ b/data/types/settings/controller/device_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesSettingsControllerTest "github.com/tidepool-org/platform/data/types/settings/controller/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -82,13 +83,13 @@ var _ = Describe("Device", func() {
 
 		Context("ParseDevice", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesSettingsController.ParseDevice(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesSettingsController.ParseDevice(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesSettingsControllerTest.RandomDevice()
 				object := dataTypesSettingsControllerTest.NewObjectFromDevice(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesSettingsController.ParseDevice(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -115,7 +116,7 @@ var _ = Describe("Device", func() {
 					object := dataTypesSettingsControllerTest.NewObjectFromDevice(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesSettingsController.NewDevice()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -351,7 +352,7 @@ var _ = Describe("Device", func() {
 					datum := dataTypesSettingsControllerTest.RandomDevice()
 					mutator(datum)
 					expectedDatum := dataTypesSettingsControllerTest.CloneDevice(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -375,7 +376,7 @@ var _ = Describe("Device", func() {
 						datum := dataTypesSettingsControllerTest.RandomDevice()
 						mutator(datum)
 						expectedDatum := dataTypesSettingsControllerTest.CloneDevice(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/controller/notifications_test.go
+++ b/data/types/settings/controller/notifications_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesSettingsControllerTest "github.com/tidepool-org/platform/data/types/settings/controller/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -89,13 +90,13 @@ var _ = Describe("Notifications", func() {
 
 		Context("ParseNotifications", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesSettingsController.ParseNotifications(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesSettingsController.ParseNotifications(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesSettingsControllerTest.RandomNotifications()
 				object := dataTypesSettingsControllerTest.NewObjectFromNotifications(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesSettingsController.ParseNotifications(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -124,7 +125,7 @@ var _ = Describe("Notifications", func() {
 					object := dataTypesSettingsControllerTest.NewObjectFromNotifications(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesSettingsController.NewNotifications()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/settings/pump/basal_rate_maximum_test.go
+++ b/data/types/settings/pump/basal_rate_maximum_test.go
@@ -11,6 +11,7 @@ import (
 	pumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -195,7 +196,7 @@ var _ = Describe("BasalRateMaximum", func() {
 						datum := pumpTest.NewBasalRateMaximum()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBasalRateMaximum(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/basal_rate_start_test.go
+++ b/data/types/settings/pump/basal_rate_start_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -138,7 +139,7 @@ var _ = Describe("BasalRateStart", func() {
 						datum := pumpTest.NewBasalRateStart(pump.BasalRateStartStartMinimum + 1)
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBasalRateStart(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -242,7 +243,7 @@ var _ = Describe("BasalRateStart", func() {
 						datum := pumpTest.NewBasalRateStartArray()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBasalRateStartArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -397,7 +398,7 @@ var _ = Describe("BasalRateStart", func() {
 						datum := pumpTest.NewBasalRateStartArrayMap()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBasalRateStartArrayMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/basal_temporary_test.go
+++ b/data/types/settings/pump/basal_temporary_test.go
@@ -6,6 +6,7 @@ import (
 	pumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -89,7 +90,7 @@ var _ = Describe("BasalTemporary", func() {
 						datum := pumpTest.NewBasalTemporary()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBasalTemporary(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/basal_test.go
+++ b/data/types/settings/pump/basal_test.go
@@ -9,6 +9,7 @@ import (
 	pumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -77,7 +78,7 @@ var _ = Describe("Basal", func() {
 						datum := pumpTest.NewBasal()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBasal(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/blood_glucose_target_start_test.go
+++ b/data/types/settings/pump/blood_glucose_target_start_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -131,7 +132,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 						datum := test.RandomBloodGlucoseTargetStart(units, pump.BloodGlucoseTargetStartStartMinimum+1)
 						mutator(datum, units)
 						expectedDatum := test.CloneBloodGlucoseTargetStart(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -169,7 +170,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 					datum := test.RandomBloodGlucoseTargetStart(units, pump.BloodGlucoseTargetStartStartMinimum+1)
 					mutator(datum, units)
 					expectedDatum := test.CloneBloodGlucoseTargetStart(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -211,7 +212,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 						datum := test.RandomBloodGlucoseTargetStart(units, pump.BloodGlucoseTargetStartStartMinimum+1)
 						mutator(datum, units)
 						expectedDatum := test.CloneBloodGlucoseTargetStart(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -339,7 +340,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 						datum := test.RandomBloodGlucoseTargetStartArray(units)
 						mutator(datum, units)
 						expectedDatum := test.CloneBloodGlucoseTargetStartArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -377,7 +378,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 					datum := test.RandomBloodGlucoseTargetStartArray(units)
 					mutator(datum, units)
 					expectedDatum := test.CloneBloodGlucoseTargetStartArray(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -423,7 +424,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 						datum := test.RandomBloodGlucoseTargetStartArray(units)
 						mutator(datum, units)
 						expectedDatum := test.CloneBloodGlucoseTargetStartArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -605,7 +606,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 						datum := test.NewBloodGlucoseTargetStartArrayMap(units)
 						mutator(datum, units)
 						expectedDatum := test.CloneBloodGlucoseTargetStartArrayMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -647,7 +648,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 					datum := test.NewBloodGlucoseTargetStartArrayMap(units)
 					mutator(datum, units)
 					expectedDatum := test.CloneBloodGlucoseTargetStartArrayMap(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -697,7 +698,7 @@ var _ = Describe("BloodGlucoseTargetStart", func() {
 						datum := test.NewBloodGlucoseTargetStartArrayMap(units)
 						mutator(datum, units)
 						expectedDatum := test.CloneBloodGlucoseTargetStartArrayMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/bolus_amount_maximum_test.go
+++ b/data/types/settings/pump/bolus_amount_maximum_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -196,7 +197,7 @@ var _ = Describe("BolusAmountMaximum", func() {
 						datum := pumpTest.NewBolusAmountMaximum()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBolusAmountMaximum(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/bolus_calculator_insulin_test.go
+++ b/data/types/settings/pump/bolus_calculator_insulin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -286,7 +287,7 @@ var _ = Describe("BolusCalculatorInsulin", func() {
 						datum := pumpTest.NewBolusCalculatorInsulin()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBolusCalculatorInsulin(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/bolus_calculator_test.go
+++ b/data/types/settings/pump/bolus_calculator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -79,7 +80,7 @@ var _ = Describe("BolusCalculator", func() {
 						datum := pumpTest.NewBolusCalculator()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBolusCalculator(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/bolus_extended_test.go
+++ b/data/types/settings/pump/bolus_extended_test.go
@@ -9,6 +9,7 @@ import (
 	pumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -66,7 +67,7 @@ var _ = Describe("BolusExtended", func() {
 						datum := pumpTest.NewBolusExtended()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBolusExtended(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/bolus_test.go
+++ b/data/types/settings/pump/bolus_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -78,7 +79,7 @@ var _ = Describe("Bolus", func() {
 						datum := pumpTest.NewBolus()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneBolus(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/carbohydrate_ratio_start_test.go
+++ b/data/types/settings/pump/carbohydrate_ratio_start_test.go
@@ -9,6 +9,7 @@ import (
 	pumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -137,7 +138,7 @@ var _ = Describe("CarbohydrateRatioStart", func() {
 						datum := pumpTest.NewCarbohydrateRatioStart(pump.CarbohydrateRatioStartStartMinimum + 1)
 						mutator(datum)
 						expectedDatum := pumpTest.CloneCarbohydrateRatioStart(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -241,7 +242,7 @@ var _ = Describe("CarbohydrateRatioStart", func() {
 						datum := pumpTest.NewCarbohydrateRatioStartArray()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneCarbohydrateRatioStartArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -398,7 +399,7 @@ var _ = Describe("CarbohydrateRatioStart", func() {
 						datum := pumpTest.NewCarbohydrateRatioStartArrayMap()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneCarbohydrateRatioStartArrayMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/display_blood_glucose_test.go
+++ b/data/types/settings/pump/display_blood_glucose_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -83,7 +84,7 @@ var _ = Describe("DisplayBloodGlucose", func() {
 						datum := pumpTest.NewDisplayBloodGlucose()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneDisplayBloodGlucose(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/display_test.go
+++ b/data/types/settings/pump/display_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -66,7 +67,7 @@ var _ = Describe("Display", func() {
 						datum := pumpTest.NewDisplay()
 						mutator(datum)
 						expectedDatum := pumpTest.CloneDisplay(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/insulin_sensitivity_start_test.go
+++ b/data/types/settings/pump/insulin_sensitivity_start_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -257,7 +258,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 						datum := pumpTest.NewInsulinSensitivityStart(units, pump.InsulinSensitivityStartStartMinimum+1)
 						mutator(datum, units)
 						expectedDatum := pumpTest.CloneInsulinSensitivityStart(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -295,7 +296,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 					datum := pumpTest.NewInsulinSensitivityStart(units, pump.InsulinSensitivityStartStartMinimum+1)
 					mutator(datum, units)
 					expectedDatum := pumpTest.CloneInsulinSensitivityStart(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -337,7 +338,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 						datum := pumpTest.NewInsulinSensitivityStart(units, pump.InsulinSensitivityStartStartMinimum+1)
 						mutator(datum, units)
 						expectedDatum := pumpTest.CloneInsulinSensitivityStart(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -465,7 +466,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 						datum := pumpTest.NewInsulinSensitivityStartArray(units)
 						mutator(datum, units)
 						expectedDatum := pumpTest.CloneInsulinSensitivityStartArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -503,7 +504,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 					datum := pumpTest.NewInsulinSensitivityStartArray(units)
 					mutator(datum, units)
 					expectedDatum := pumpTest.CloneInsulinSensitivityStartArray(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -549,7 +550,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 						datum := pumpTest.NewInsulinSensitivityStartArray(units)
 						mutator(datum, units)
 						expectedDatum := pumpTest.CloneInsulinSensitivityStartArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -683,7 +684,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 						datum := pumpTest.NewInsulinSensitivityStartArrayMap(units)
 						mutator(datum, units)
 						expectedDatum := pumpTest.CloneInsulinSensitivityStartArrayMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())
@@ -725,7 +726,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 					datum := pumpTest.NewInsulinSensitivityStartArrayMap(units)
 					mutator(datum, units)
 					expectedDatum := pumpTest.CloneInsulinSensitivityStartArrayMap(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), units)
 					Expect(normalizer.Error()).To(BeNil())
@@ -775,7 +776,7 @@ var _ = Describe("InsulinSensitivityStart", func() {
 						datum := pumpTest.NewInsulinSensitivityStartArrayMap(units)
 						mutator(datum, units)
 						expectedDatum := pumpTest.CloneInsulinSensitivityStartArrayMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), units)
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/override_preset_test.go
+++ b/data/types/settings/pump/override_preset_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesSettingsPumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -85,13 +86,13 @@ var _ = Describe("OverridePreset", func() {
 
 		Context("ParseOverridePreset", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesSettingsPump.ParseOverridePreset(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesSettingsPump.ParseOverridePreset(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesSettingsPumpTest.RandomOverridePreset(pointer.FromString(dataBloodGlucoseTest.RandomUnits()))
 				object := dataTypesSettingsPumpTest.NewObjectFromOverridePreset(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesSettingsPump.ParseOverridePreset(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -117,7 +118,7 @@ var _ = Describe("OverridePreset", func() {
 					object := dataTypesSettingsPumpTest.NewObjectFromOverridePreset(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesSettingsPump.NewOverridePreset()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -402,7 +403,7 @@ var _ = Describe("OverridePreset", func() {
 					datum := dataTypesSettingsPumpTest.RandomOverridePreset(unitsBloodGlucose)
 					mutator(datum, unitsBloodGlucose)
 					expectedDatum := dataTypesSettingsPumpTest.CloneOverridePreset(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), unitsBloodGlucose)
 					Expect(normalizer.Error()).To(BeNil())
@@ -468,7 +469,7 @@ var _ = Describe("OverridePreset", func() {
 						datum := dataTypesSettingsPumpTest.RandomOverridePreset(unitsBloodGlucose)
 						mutator(datum, unitsBloodGlucose)
 						expectedDatum := dataTypesSettingsPumpTest.CloneOverridePreset(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), unitsBloodGlucose)
 						Expect(normalizer.Error()).To(BeNil())
@@ -523,13 +524,13 @@ var _ = Describe("OverridePreset", func() {
 
 		Context("ParseOverridePresetMap", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesSettingsPump.ParseOverridePresetMap(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesSettingsPump.ParseOverridePresetMap(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesSettingsPumpTest.RandomOverridePresetMap(pointer.FromString(dataBloodGlucoseTest.RandomUnits()))
 				object := dataTypesSettingsPumpTest.NewObjectFromOverridePresetMap(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesSettingsPump.ParseOverridePresetMap(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -548,7 +549,7 @@ var _ = Describe("OverridePreset", func() {
 					object := dataTypesSettingsPumpTest.NewObjectFromOverridePresetMap(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesSettingsPump.NewOverridePresetMap()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -642,7 +643,7 @@ var _ = Describe("OverridePreset", func() {
 					datum := dataTypesSettingsPumpTest.RandomOverridePresetMap(unitsBloodGlucose)
 					mutator(datum, unitsBloodGlucose)
 					expectedDatum := dataTypesSettingsPumpTest.CloneOverridePresetMap(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal), unitsBloodGlucose)
 					Expect(normalizer.Error()).To(BeNil())
@@ -716,7 +717,7 @@ var _ = Describe("OverridePreset", func() {
 						datum := dataTypesSettingsPumpTest.RandomOverridePresetMap(unitsBloodGlucose)
 						mutator(datum, unitsBloodGlucose)
 						expectedDatum := dataTypesSettingsPumpTest.CloneOverridePresetMap(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin), unitsBloodGlucose)
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/pump_test.go
+++ b/data/types/settings/pump/pump_test.go
@@ -16,6 +16,7 @@ import (
 	pumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -730,7 +731,7 @@ var _ = Describe("Pump", func() {
 					datum := pumpTest.NewPump(unitsBloodGlucose)
 					mutator(datum, unitsBloodGlucose)
 					expectedDatum := pumpTest.ClonePump(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -866,7 +867,7 @@ var _ = Describe("Pump", func() {
 						datum := pumpTest.NewPump(unitsBloodGlucose)
 						mutator(datum, unitsBloodGlucose)
 						expectedDatum := pumpTest.ClonePump(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/settings/pump/units_test.go
+++ b/data/types/settings/pump/units_test.go
@@ -11,6 +11,7 @@ import (
 	dataTypesSettingsPumpTest "github.com/tidepool-org/platform/data/types/settings/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -66,13 +67,13 @@ var _ = Describe("Units", func() {
 
 		Context("ParseUnits", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesSettingsPump.ParseUnits(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesSettingsPump.ParseUnits(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesSettingsPumpTest.RandomUnits(pointer.FromString("mg/dL"))
 				object := dataTypesSettingsPumpTest.NewObjectFromUnits(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesSettingsPump.ParseUnits(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -95,7 +96,7 @@ var _ = Describe("Units", func() {
 					object := dataTypesSettingsPumpTest.NewObjectFromUnits(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesSettingsPump.NewUnits()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -190,7 +191,7 @@ var _ = Describe("Units", func() {
 					datum := dataTypesSettingsPumpTest.RandomUnits(pointer.FromString("mmol/L"))
 					mutator(datum)
 					expectedDatum := dataTypesSettingsPumpTest.CloneUnits(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -270,7 +271,7 @@ var _ = Describe("Units", func() {
 						datum := dataTypesSettingsPumpTest.RandomUnits(pointer.FromString("mmol/L"))
 						mutator(datum)
 						expectedDatum := dataTypesSettingsPumpTest.CloneUnits(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/state/reported/reported_test.go
+++ b/data/types/state/reported/reported_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/state/reported"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -143,7 +144,7 @@ var _ = Describe("Reported", func() {
 						datum := NewReported()
 						mutator(datum)
 						expectedDatum := CloneReported(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/state/reported/state_test.go
+++ b/data/types/state/reported/state_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/state/reported"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -294,7 +295,7 @@ var _ = Describe("State", func() {
 						datum := NewState("state")
 						mutator(datum)
 						expectedDatum := CloneState(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
@@ -414,7 +415,7 @@ var _ = Describe("State", func() {
 						datum := NewStateArray(NewState("alcohol"), NewState("stress"))
 						mutator(datum)
 						expectedDatum := CloneStateArray(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/status/controller/battery_test.go
+++ b/data/types/status/controller/battery_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesStatusControllerTest "github.com/tidepool-org/platform/data/types/status/controller/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -76,13 +77,13 @@ var _ = Describe("Battery", func() {
 
 		Context("ParseBattery", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusController.ParseBattery(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusController.ParseBattery(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusControllerTest.RandomBattery()
 				object := dataTypesStatusControllerTest.NewObjectFromBattery(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusController.ParseBattery(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -106,7 +107,7 @@ var _ = Describe("Battery", func() {
 					object := dataTypesStatusControllerTest.NewObjectFromBattery(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusController.NewBattery()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/status/controller/controller_test.go
+++ b/data/types/status/controller/controller_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesStatusControllerTest "github.com/tidepool-org/platform/data/types/status/controller/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	"github.com/tidepool-org/platform/test"
@@ -68,7 +69,7 @@ var _ = Describe("Controller", func() {
 					object := dataTypesStatusControllerTest.NewObjectFromController(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusController.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -142,7 +143,7 @@ var _ = Describe("Controller", func() {
 						datum := dataTypesStatusControllerTest.RandomController()
 						mutator(datum)
 						expectedDatum := dataTypesStatusControllerTest.CloneController(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/status/pump/basal_delivery_test.go
+++ b/data/types/status/pump/basal_delivery_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesStatusPumpTest "github.com/tidepool-org/platform/data/types/status/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -91,13 +92,13 @@ var _ = Describe("BasalDelivery", func() {
 
 		Context("ParseBasalDelivery", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusPump.ParseBasalDelivery(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusPump.ParseBasalDelivery(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusPumpTest.RandomBasalDelivery()
 				object := dataTypesStatusPumpTest.NewObjectFromBasalDelivery(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusPump.ParseBasalDelivery(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -120,7 +121,7 @@ var _ = Describe("BasalDelivery", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromBasalDelivery(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.NewBasalDelivery()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -380,13 +381,13 @@ var _ = Describe("BasalDelivery", func() {
 
 		Context("ParseBasalDose", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusPump.ParseBasalDose(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusPump.ParseBasalDose(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusPumpTest.RandomBasalDose()
 				object := dataTypesStatusPumpTest.NewObjectFromBasalDose(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusPump.ParseBasalDose(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -410,7 +411,7 @@ var _ = Describe("BasalDelivery", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromBasalDose(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.NewBasalDose()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/status/pump/battery_test.go
+++ b/data/types/status/pump/battery_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesStatusPumpTest "github.com/tidepool-org/platform/data/types/status/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -76,13 +77,13 @@ var _ = Describe("Battery", func() {
 
 		Context("ParseBattery", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusPump.ParseBattery(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusPump.ParseBattery(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusPumpTest.RandomBattery()
 				object := dataTypesStatusPumpTest.NewObjectFromBattery(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusPump.ParseBattery(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -106,7 +107,7 @@ var _ = Describe("Battery", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromBattery(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.NewBattery()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/status/pump/bolus_delivery_test.go
+++ b/data/types/status/pump/bolus_delivery_test.go
@@ -5,6 +5,7 @@ import (
 	dataTypesStatusPumpTest "github.com/tidepool-org/platform/data/types/status/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -78,13 +79,13 @@ var _ = Describe("BolusDelivery", func() {
 
 		Context("ParseBolusDelivery", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusPump.ParseBolusDelivery(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusPump.ParseBolusDelivery(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusPumpTest.RandomBolusDelivery()
 				object := dataTypesStatusPumpTest.NewObjectFromBolusDelivery(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusPump.ParseBolusDelivery(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -106,7 +107,7 @@ var _ = Describe("BolusDelivery", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromBolusDelivery(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.NewBolusDelivery()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -240,13 +241,13 @@ var _ = Describe("BolusDelivery", func() {
 
 		Context("ParseBolusDose", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusPump.ParseBolusDose(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusPump.ParseBolusDose(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusPumpTest.RandomBolusDose()
 				object := dataTypesStatusPumpTest.NewObjectFromBolusDose(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusPump.ParseBolusDose(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -269,7 +270,7 @@ var _ = Describe("BolusDelivery", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromBolusDose(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.NewBolusDose()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/status/pump/pump_test.go
+++ b/data/types/status/pump/pump_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesStatusPumpTest "github.com/tidepool-org/platform/data/types/status/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -75,7 +76,7 @@ var _ = Describe("Pump", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromPump(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.New()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -184,7 +185,7 @@ var _ = Describe("Pump", func() {
 						datum := dataTypesStatusPumpTest.RandomPump()
 						mutator(datum)
 						expectedDatum := dataTypesStatusPumpTest.ClonePump(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/status/pump/reservoir_test.go
+++ b/data/types/status/pump/reservoir_test.go
@@ -8,6 +8,7 @@ import (
 	dataTypesStatusPumpTest "github.com/tidepool-org/platform/data/types/status/pump/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -59,13 +60,13 @@ var _ = Describe("Reservoir", func() {
 
 		Context("ParseReservoir", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(dataTypesStatusPump.ParseReservoir(structureParser.NewObject(nil))).To(BeNil())
+				Expect(dataTypesStatusPump.ParseReservoir(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := dataTypesStatusPumpTest.RandomReservoir()
 				object := dataTypesStatusPumpTest.NewObjectFromReservoir(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(dataTypesStatusPump.ParseReservoir(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -88,7 +89,7 @@ var _ = Describe("Reservoir", func() {
 					object := dataTypesStatusPumpTest.NewObjectFromReservoir(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := dataTypesStatusPump.NewReservoir()
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",

--- a/data/types/test/test.go
+++ b/data/types/test/test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
@@ -60,7 +61,7 @@ func NewVersionInternal() int {
 }
 
 func ValidateWithOrigin(validatable structure.Validatable, origin structure.Origin, expectedErrors ...error) {
-	validator := structureValidator.New()
+	validator := structureValidator.New(logTest.NewLogger())
 	gomega.Expect(validator).ToNot(gomega.BeNil())
 	validatable.Validate(validator.WithOrigin(origin))
 	errorsTest.ExpectEqual(validator.Error(), expectedErrors...)

--- a/data/types/upload/client_test.go
+++ b/data/types/upload/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidepool-org/platform/data/types/upload"
 	dataTypesUploadTest "github.com/tidepool-org/platform/data/types/upload/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metadata"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/net"
@@ -102,7 +103,7 @@ var _ = Describe("Client", func() {
 						datum := dataTypesUploadTest.NewClient()
 						mutator(datum)
 						expectedDatum := dataTypesUploadTest.CloneClient(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/upload/upload_test.go
+++ b/data/types/upload/upload_test.go
@@ -12,6 +12,7 @@ import (
 	dataTypesUpload "github.com/tidepool-org/platform/data/types/upload"
 	dataTypesUploadTest "github.com/tidepool-org/platform/data/types/upload/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
@@ -442,7 +443,7 @@ var _ = Describe("Upload", func() {
 					datum := dataTypesUploadTest.RandomUpload()
 					mutator(datum)
 					expectedDatum := dataTypesUploadTest.CloneUpload(datum)
-					normalizer := dataNormalizer.New()
+					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
@@ -499,7 +500,7 @@ var _ = Describe("Upload", func() {
 						datum := dataTypesUploadTest.RandomUpload()
 						mutator(datum)
 						expectedDatum := dataTypesUploadTest.CloneUpload(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/water/amount_test.go
+++ b/data/types/water/amount_test.go
@@ -10,6 +10,7 @@ import (
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	"github.com/tidepool-org/platform/data/types/water"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -373,7 +374,7 @@ var _ = Describe("Amount", func() {
 						datum := NewAmount()
 						mutator(datum)
 						expectedDatum := CloneAmount(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/data/types/water/water_test.go
+++ b/data/types/water/water_test.go
@@ -9,6 +9,7 @@ import (
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	"github.com/tidepool-org/platform/data/types/water"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -106,7 +107,7 @@ var _ = Describe("Water", func() {
 						datum := NewWater()
 						mutator(datum)
 						expectedDatum := CloneWater(datum)
-						normalizer := dataNormalizer.New()
+						normalizer := dataNormalizer.New(logTest.NewLogger())
 						Expect(normalizer).ToNot(BeNil())
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())

--- a/devicetokens/devicetokens_test.go
+++ b/devicetokens/devicetokens_test.go
@@ -2,6 +2,7 @@ package devicetokens
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"testing"
@@ -23,45 +24,45 @@ var _ = Describe("DeviceToken", func() {
 	It("parses", func() {
 		buf := buff(`{"apple":{"token":"c29tZXRoaW5n","environment":"sandbox"}}`)
 		token := &DeviceToken{}
-		err := request.DecodeObject(nil, buf, token)
+		err := request.DecodeObject(context.Background(), nil, buf, token)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("validates environment", func() {
 		token := &DeviceToken{}
 		bad := buff(`{"apple":{"token":"c29tZXRoaW5n","environment":"bad"}}`)
-		err := request.DecodeObject(nil, bad, token)
+		err := request.DecodeObject(context.Background(), nil, bad, token)
 		Expect(err).To(MatchError("value \"bad\" is not one of [\"production\", \"sandbox\"]"))
 
 		prod := buff(`{"apple":{"token":"c29tZXRoaW5n","environment":"production"}}`)
-		err = request.DecodeObject(nil, prod, token)
+		err = request.DecodeObject(context.Background(), nil, prod, token)
 		Expect(err).ToNot(HaveOccurred())
 
 		sbox := buff(`{"apple":{"token":"c29tZXRoaW5n","environment":"sandbox"}}`)
-		err = request.DecodeObject(nil, sbox, token)
+		err = request.DecodeObject(context.Background(), nil, sbox, token)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("validates token", func() {
 		token := &DeviceToken{}
 		buf := buff(`{"apple":{"token":"","environment":"sandbox"}}`)
-		err := request.DecodeObject(nil, buf, token)
+		err := request.DecodeObject(context.Background(), nil, buf, token)
 		Expect(err).To(MatchError("value is empty"))
 
 		buf = buff(`{"apple":{"token":"not-base64","environment":"sandbox"}}`)
-		err = request.DecodeObject(nil, buf, token)
+		err = request.DecodeObject(context.Background(), nil, buf, token)
 		Expect(err).To(MatchError("json is malformed"))
 
 		testToken := buildTokenLongerThan(MaxTokenLen)
 		buf = buff(`{"apple":{"token":"%s","environment":"sandbox"}}`, testToken)
-		err = request.DecodeObject(nil, buf, token)
+		err = request.DecodeObject(context.Background(), nil, buf, token)
 		Expect(err).To(MatchError(ContainSubstring("is not less than or equal to")))
 	})
 
 	It("apple must exist (there's no other supported device yet)", func() {
 		token := &DeviceToken{}
 		buf := buff(`{}`)
-		err := request.DecodeObject(nil, buf, token)
+		err := request.DecodeObject(context.Background(), nil, buf, token)
 		Expect(err).To(MatchError(ContainSubstring("value does not exist")))
 	})
 
@@ -81,7 +82,7 @@ var _ = Describe("DeviceToken", func() {
 		It("produces a hash", func() {
 			token := &DeviceToken{}
 			buf := buff(`{"apple":{"token":"c29tZXRoaW5n","environment":"sandbox"}}`)
-			err := request.DecodeObject(nil, buf, token)
+			err := request.DecodeObject(context.Background(), nil, buf, token)
 			Expect(err).ToNot(HaveOccurred())
 			key := token.key()
 			Expect(key).To(HaveLen(64))

--- a/dexcom/alert_schedule_test.go
+++ b/dexcom/alert_schedule_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tidepool-org/platform/dexcom"
 	"github.com/tidepool-org/platform/dexcom/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureTest "github.com/tidepool-org/platform/structure/test"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -260,7 +261,7 @@ var _ = Describe("Alert", func() {
 		DescribeTable("empty",
 			func(value *dexcom.AlertSchedules) {
 				Expect(value).ToNot(BeNil())
-				testValidator := structureValidator.New()
+				testValidator := structureValidator.New(logTest.NewLogger())
 				value.Validate(testValidator)
 				Expect(testValidator.HasError()).To(BeFalse())
 				Expect(len(*value)).To(Equal(0))
@@ -270,7 +271,7 @@ var _ = Describe("Alert", func() {
 		DescribeTable("AlertScheduleSettings",
 			func(setupFunc func() *dexcom.AlertScheduleSettings) {
 				val := setupFunc()
-				testValidator := structureValidator.New()
+				testValidator := structureValidator.New(logTest.NewLogger())
 				val.Validate(testValidator)
 				Expect(testValidator.HasError()).To(BeFalse())
 			},
@@ -352,7 +353,7 @@ var _ = Describe("Alert", func() {
 		DescribeTable("AlertScheduleSettings",
 			func(setupFunc func() *dexcom.AlertScheduleSettings, expectError bool) {
 				val := setupFunc()
-				testValidator := structureValidator.New()
+				testValidator := structureValidator.New(logTest.NewLogger())
 				val.Validate(testValidator)
 				Expect(testValidator.HasError()).To(Equal(expectError))
 			},
@@ -464,7 +465,7 @@ var _ = Describe("Alert", func() {
 		DescribeTable("AlertSetting",
 			func(setupFunc func() *dexcom.AlertSetting, expectError bool) {
 				val := setupFunc()
-				testValidator := structureValidator.New()
+				testValidator := structureValidator.New(logTest.NewLogger())
 
 				val.Validate(testValidator)
 				Expect(testValidator.HasError()).To(Equal(expectError))

--- a/dexcom/alert_test.go
+++ b/dexcom/alert_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/dexcom"
 	"github.com/tidepool-org/platform/dexcom/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure/validator"
 )
@@ -45,7 +46,7 @@ var _ = Describe("Alert", func() {
 		DescribeTable("requires",
 			func(setupAlertFunc func() *dexcom.Alert) {
 				testAlert := setupAlertFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testAlert.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 			},

--- a/dexcom/calibration_test.go
+++ b/dexcom/calibration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/dexcom"
 	"github.com/tidepool-org/platform/dexcom/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure/validator"
 )
 
@@ -31,11 +32,12 @@ var _ = Describe("Calibration", func() {
 		Expect(dexcom.CalibrationUnits()).To(Equal([]string{"unknown", "mg/dL", "mmol/L"}))
 		Expect(dexcom.CalibrationUnits()).To(Equal([]string{dexcom.CalibrationUnitUnknown, dexcom.CalibrationUnitMgdL, dexcom.CalibrationUnitMmolL}))
 	})
+
 	Describe("Validate", func() {
 		DescribeTable("errors when",
 			func(setupFunc func() *dexcom.Calibration) {
 				testCalibration := setupFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testCalibration.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 			},

--- a/dexcom/client/client_test.go
+++ b/dexcom/client/client_test.go
@@ -735,7 +735,7 @@ var _ = Describe("Client", func() {
 						It("returns success", func() {
 							devicesResponse, err := clnt.GetDevices(ctx, startTime, endTime, tokenSource)
 							Expect(err).ToNot(HaveOccurred())
-							Expect(structureNormalizer.New().Normalize(responseDevicesResponse)).To(Succeed())
+							Expect(structureNormalizer.New(logTest.NewLogger()).Normalize(responseDevicesResponse)).To(Succeed())
 							Expect(devicesResponse).To(Equal(responseDevicesResponse))
 						})
 					})

--- a/dexcom/default_test.go
+++ b/dexcom/default_test.go
@@ -4,10 +4,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/dexcom"
-	"github.com/tidepool-org/platform/structure/parser"
-
 	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
+	"github.com/tidepool-org/platform/dexcom"
+	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/structure/parser"
 )
 
 var _ = Describe("Default", func() {
@@ -21,7 +21,7 @@ var _ = Describe("Default", func() {
 				"unit":      dataBloodGlucose.MmolL,
 				"empty-val": "",
 			}
-			objParser = parser.NewObject(&objectData)
+			objParser = parser.NewObject(logTest.NewLogger(), &objectData)
 		})
 
 		It("returns the unit value when set", func() {

--- a/dexcom/device_test.go
+++ b/dexcom/device_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/dexcom"
 	"github.com/tidepool-org/platform/dexcom/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure/validator"
 )
 
@@ -40,7 +41,7 @@ var _ = Describe("Device", func() {
 		DescribeTable("errors when",
 			func(setupDeviceFunc func() *dexcom.Device) {
 				testDevice := setupDeviceFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testDevice.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 			},
@@ -68,7 +69,7 @@ var _ = Describe("Device", func() {
 		DescribeTable("does not error when",
 			func(setupDeviceFunc func() *dexcom.Device) {
 				testDevice := setupDeviceFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testDevice.Validate(validator)
 				Expect(validator.Error()).ToNot(HaveOccurred())
 			},

--- a/dexcom/egv_test.go
+++ b/dexcom/egv_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/dexcom"
 	"github.com/tidepool-org/platform/dexcom/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure/validator"
 
@@ -84,7 +85,7 @@ var _ = Describe("EGV", func() {
 		DescribeTable("requires",
 			func(setupEGVFunc func() *dexcom.EGV) {
 				testEGV := setupEGVFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testEGV.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 			},
@@ -144,7 +145,7 @@ var _ = Describe("EGV", func() {
 		DescribeTable("does not require",
 			func(setupEGVFunc func() *dexcom.EGV) {
 				testEGV := setupEGVFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testEGV.Validate(validator)
 				Expect(validator.Error()).ToNot(HaveOccurred())
 			},

--- a/dexcom/event_test.go
+++ b/dexcom/event_test.go
@@ -6,11 +6,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/tidepool-org/platform/dexcom"
 	"github.com/tidepool-org/platform/dexcom/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure/validator"
-
-	"github.com/tidepool-org/platform/dexcom"
 )
 
 var _ = Describe("Event", func() {
@@ -116,14 +116,14 @@ var _ = Describe("Event", func() {
 			event := test.RandomEvent(pointer.FromString(dexcom.EventTypeHealth))
 			event.Unit = nil
 			event.Value = pointer.FromString("stuff")
-			validator := validator.New()
+			validator := validator.New(logTest.NewLogger())
 			event.Validate(validator)
 			Expect(validator.Error()).ToNot(HaveOccurred())
 		})
 		DescribeTable("requires",
 			func(setupEventFunc func() *dexcom.Event) {
 				testEvent := setupEventFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testEvent.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 			},
@@ -178,7 +178,7 @@ var _ = Describe("Event", func() {
 		DescribeTable("expects value to be valid",
 			func(setupEventFunc func() *dexcom.Event) {
 				testEvent := setupEventFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testEvent.Validate(validator)
 				Expect(validator.Error()).To(HaveOccurred())
 			},
@@ -206,7 +206,7 @@ var _ = Describe("Event", func() {
 		DescribeTable("value is valid at minimum",
 			func(setupEventFunc func() *dexcom.Event) {
 				testEvent := setupEventFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testEvent.Validate(validator)
 				Expect(validator.Error()).ToNot(HaveOccurred())
 			},
@@ -234,7 +234,7 @@ var _ = Describe("Event", func() {
 		DescribeTable("does not require",
 			func(setupEventFunc func() *dexcom.Event) {
 				testEvent := setupEventFunc()
-				validator := validator.New()
+				validator := validator.New(logTest.NewLogger())
 				testEvent.Validate(validator)
 				Expect(validator.Error()).ToNot(HaveOccurred())
 			},

--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -189,7 +189,7 @@ func (t *TaskRunner) Run(ctx context.Context) error {
 	}
 
 	t.context = ctx
-	t.validator = structureValidator.New()
+	t.validator = structureValidator.New(log.LoggerFromContext(t.context))
 
 	if err := t.getProviderSession(); err != nil {
 		return err
@@ -481,7 +481,7 @@ func (t *TaskRunner) fetchDevices(startTime time.Time, endTime time.Time) (*dexc
 	var devicesDatumArray data.Data
 	for _, device := range *devices {
 		if t.updateDeviceHash(device) {
-			devicesDatumArray = append(devicesDatumArray, translateDeviceToDatum(device))
+			devicesDatumArray = append(devicesDatumArray, translateDeviceToDatum(t.context, device))
 		}
 	}
 
@@ -553,7 +553,7 @@ func (t *TaskRunner) fetchCalibrations(startTime time.Time, endTime time.Time) (
 	datumArray := data.Data{}
 	for _, c := range *response.Calibrations {
 		if t.afterLatestDataTime(c.SystemTime.Raw()) {
-			datumArray = append(datumArray, translateCalibrationToDatum(c))
+			datumArray = append(datumArray, translateCalibrationToDatum(t.context, c))
 		}
 	}
 
@@ -576,7 +576,7 @@ func (t *TaskRunner) fetchAlerts(startTime time.Time, endTime time.Time) (data.D
 	datumArray := data.Data{}
 	for _, c := range *response.Alerts {
 		if t.afterLatestDataTime(c.SystemTime.Raw()) {
-			datumArray = append(datumArray, translateAlertToDatum(c, response.RecordVersion))
+			datumArray = append(datumArray, translateAlertToDatum(t.context, c, response.RecordVersion))
 		}
 	}
 
@@ -601,7 +601,7 @@ func (t *TaskRunner) fetchEGVs(startTime time.Time, endTime time.Time) (data.Dat
 	datumArray := data.Data{}
 	for _, e := range *response.EGVs {
 		if t.afterLatestDataTime(e.SystemTime.Raw()) {
-			datumArray = append(datumArray, translateEGVToDatum(e))
+			datumArray = append(datumArray, translateEGVToDatum(t.context, e))
 		}
 	}
 
@@ -629,17 +629,17 @@ func (t *TaskRunner) fetchEvents(startTime time.Time, endTime time.Time) (data.D
 			if t.afterLatestDataTime(e.SystemTime.Raw()) {
 				switch *e.Type {
 				case dexcom.EventTypeCarbs:
-					datumArray = append(datumArray, translateEventCarbsToDatum(e))
+					datumArray = append(datumArray, translateEventCarbsToDatum(t.context, e))
 				case dexcom.EventTypeExercise:
-					datumArray = append(datumArray, translateEventExerciseToDatum(e))
+					datumArray = append(datumArray, translateEventExerciseToDatum(t.context, e))
 				case dexcom.EventTypeHealth:
-					datumArray = append(datumArray, translateEventHealthToDatum(e))
+					datumArray = append(datumArray, translateEventHealthToDatum(t.context, e))
 				case dexcom.EventTypeInsulin:
-					datumArray = append(datumArray, translateEventInsulinToDatum(e))
+					datumArray = append(datumArray, translateEventInsulinToDatum(t.context, e))
 				case dexcom.EventTypeBG:
-					datumArray = append(datumArray, translateEventBGToDatum(e))
+					datumArray = append(datumArray, translateEventBGToDatum(t.context, e))
 				case dexcom.EventTypeNote, dexcom.EventTypeNotes:
-					datumArray = append(datumArray, translateEventNoteToDatum(e))
+					datumArray = append(datumArray, translateEventNoteToDatum(t.context, e))
 				}
 			}
 		case dexcom.EventStatusUpdated, dexcom.EventStatusDeleted:

--- a/dexcom/fetch/translate_test.go
+++ b/dexcom/fetch/translate_test.go
@@ -1,6 +1,7 @@
 package fetch_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -10,6 +11,8 @@ import (
 	dataTypes "github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/dexcom"
 	dexcomFetch "github.com/tidepool-org/platform/dexcom/fetch"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 )
 
@@ -32,6 +35,8 @@ var _ = Describe("Translate", func() {
 				var datum *dataTypes.Base
 				var err error
 
+				ctx := log.NewContextWithLogger(context.Background(), logTest.NewLogger())
+
 				dexcomSystemTime, err = dexcom.TimeFromString(systemTime)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(dexcomSystemTime).ToNot(BeNil())
@@ -42,7 +47,7 @@ var _ = Describe("Translate", func() {
 				}
 				datum = &dataTypes.Base{}
 
-				dexcomFetch.TranslateTime(dexcomSystemTime, dexcomDisplayTime, datum)
+				dexcomFetch.TranslateTime(ctx, dexcomSystemTime, dexcomDisplayTime, datum)
 				Expect(datum.Time).To(Equal(expectedDatum.Time))
 				Expect(datum.DeviceTime).To(Equal(expectedDatum.DeviceTime))
 				Expect(datum.TimeZoneOffset).To(Equal(expectedDatum.TimeZoneOffset))

--- a/dexcom/time_test.go
+++ b/dexcom/time_test.go
@@ -8,13 +8,14 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/tidepool-org/platform/dexcom"
+	logTest "github.com/tidepool-org/platform/log/test"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 )
 
 var _ = Describe("Time", func() {
 	Context("ParseTime", func() {
 		It("returns nil if key not present in parser", func() {
-			parser := structureParser.NewObject(&map[string]any{})
+			parser := structureParser.NewObject(logTest.NewLogger(), &map[string]any{})
 			tm := dexcom.ParseTime(parser, "test")
 			Expect(tm).To(BeNil())
 			Expect(parser.HasError()).To(BeFalse())
@@ -22,7 +23,7 @@ var _ = Describe("Time", func() {
 
 		DescribeTable("does not parse an invalid time string",
 			func(timeString string) {
-				parser := structureParser.NewObject(&map[string]any{"test": timeString})
+				parser := structureParser.NewObject(logTest.NewLogger(), &map[string]any{"test": timeString})
 				tm := dexcom.ParseTime(parser, "test")
 				Expect(parser.HasError()).To(BeTrue())
 				Expect(parser.Error()).To(MatchError(fmt.Sprintf(`value "%s" is not a parsable time of format "2006-01-02T15:04:05.999999999Z07:00"`, timeString)))
@@ -54,7 +55,7 @@ var _ = Describe("Time", func() {
 
 		DescribeTable("parses the time appropriately",
 			func(timeString string, expectedTime time.Time) {
-				parser := structureParser.NewObject(&map[string]any{"test": timeString})
+				parser := structureParser.NewObject(logTest.NewLogger(), &map[string]any{"test": timeString})
 				tm := dexcom.ParseTime(parser, "test")
 				Expect(parser.HasError()).To(BeFalse())
 				Expect(tm).ToNot(BeNil())

--- a/ehr/reconcile/runner_test.go
+++ b/ehr/reconcile/runner_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Runner", func() {
 			tasks = make(map[string]task.Task)
 			for _, clinic := range clinics {
 				clinic := clinic
-				tsk, err := task.NewTask(sync.NewTaskCreate(*clinic.Id))
+				tsk, err := task.NewTask(context.Background(), sync.NewTaskCreate(*clinic.Id))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(tsk).ToNot(BeNil())
 				tasks[*clinic.Id] = *tsk
@@ -132,7 +132,7 @@ var _ = Describe("Runner", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(runner).ToNot(BeNil())
 
-				t, err := task.NewTask(reconcile.NewTaskCreate())
+				t, err := task.NewTask(context.Background(), reconcile.NewTaskCreate())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(t).ToNot(BeNil())
 

--- a/ehr/sync/runner_test.go
+++ b/ehr/sync/runner_test.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,7 +42,7 @@ var _ = Describe("Runner", func() {
 
 		BeforeEach(func() {
 			clinic = clinicsTest.NewRandomClinic()
-			t, err := task.NewTask(NewTaskCreate(*clinic.Id))
+			t, err := task.NewTask(context.Background(), NewTaskCreate(*clinic.Id))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(t).ToNot(BeNil())
 			tsk = *t
@@ -53,7 +55,7 @@ var _ = Describe("Runner", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(runner).ToNot(BeNil())
-			Expect(runner.Run(nil, &tsk)).To(BeTrue())
+			runner.Run(context.Background(), &tsk)
 		})
 	})
 })

--- a/guardrails/basal_rate_max_test.go
+++ b/guardrails/basal_rate_max_test.go
@@ -3,13 +3,14 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidepool-org/devices/api"
 
-	"github.com/tidepool-org/platform/guardrails"
+	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/guardrails"
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -22,7 +23,7 @@ var _ = Describe("ValidateBasalRateMaximum", func() {
 
 	BeforeEach(func() {
 		guardRail = test.NewBasalRateMaximumGuardRail()
-		validator = structureValidator.New()
+		validator = structureValidator.New(logTest.NewLogger())
 		basalRateSchedule = make(pump.BasalRateStartArray, 0)
 		carbRatioSchedule = make(pump.CarbohydrateRatioStartArray, 0)
 	})

--- a/guardrails/basal_rate_schedule_test.go
+++ b/guardrails/basal_rate_schedule_test.go
@@ -3,13 +3,14 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidepool-org/devices/api"
 
-	"github.com/tidepool-org/platform/guardrails"
+	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/guardrails"
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -20,7 +21,7 @@ var _ = Describe("ValidateBasalRateSchedule", func() {
 
 	BeforeEach(func() {
 		guardRail = test.NewBasalRatesGuardRail()
-		validator = structureValidator.New()
+		validator = structureValidator.New(logTest.NewLogger())
 	})
 
 	It("doesn't return error with a single valid value", func() {

--- a/guardrails/bolus_amount_max_test.go
+++ b/guardrails/bolus_amount_max_test.go
@@ -3,13 +3,14 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidepool-org/devices/api"
 
-	"github.com/tidepool-org/platform/guardrails"
+	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/guardrails"
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -20,7 +21,7 @@ var _ = Describe("ValidateBolusAmountMaximum", func() {
 
 	BeforeEach(func() {
 		guardRail = test.NewBolusAmountMaximumGuardRail()
-		validator = structureValidator.New()
+		validator = structureValidator.New(logTest.NewLogger())
 	})
 
 	It("doesn't return error with a valid value", func() {

--- a/guardrails/carb_ratio_schedule_test.go
+++ b/guardrails/carb_ratio_schedule_test.go
@@ -3,13 +3,14 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidepool-org/devices/api"
 
-	"github.com/tidepool-org/platform/guardrails"
+	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/guardrails"
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -20,7 +21,7 @@ var _ = Describe("ValidateCarbohydrateRatioSchedule", func() {
 
 	BeforeEach(func() {
 		guardRail = test.NewCarbohydrateRatioGuardRail()
-		validator = structureValidator.New()
+		validator = structureValidator.New(logTest.NewLogger())
 	})
 
 	It("doesn't return error with a single valid value", func() {

--- a/guardrails/correction_range_test.go
+++ b/guardrails/correction_range_test.go
@@ -3,6 +3,7 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/blood/glucose"
@@ -10,6 +11,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/guardrails"
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -30,7 +32,7 @@ var _ = Describe("Correction Range", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 				})
 
 				It("doesn't return error with a single valid value", func() {
@@ -101,7 +103,7 @@ var _ = Describe("Correction Range", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 				})
 
 				It("doesn't return error with a single valid value", func() {
@@ -167,7 +169,7 @@ var _ = Describe("Correction Range", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 				})
 
 				It("doesn't return error with a single valid value", func() {
@@ -234,7 +236,7 @@ var _ = Describe("Correction Range", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 				})
 
 				It("doesn't return error with a single valid value", func() {
@@ -309,7 +311,7 @@ var _ = Describe("Correction Range", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 					guardRail = test.NewPremealCorrectionRangeGuardRail()
 				})
 
@@ -383,7 +385,7 @@ var _ = Describe("Correction Range", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 					guardRail = test.NewWorkoutCorrectionRangeGuardRail()
 				})
 

--- a/guardrails/glucose_safety_limit_test.go
+++ b/guardrails/glucose_safety_limit_test.go
@@ -3,14 +3,15 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/guardrails"
-
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -22,7 +23,7 @@ var _ = Describe("ValidateGlucoseSafetyLimit", func() {
 
 	BeforeEach(func() {
 		guardRail = test.NewGlucoseSafetyLimitGuardRail()
-		validator = structureValidator.New()
+		validator = structureValidator.New(logTest.NewLogger())
 		correctionRanges = guardrails.CorrectionRanges{}
 	})
 

--- a/guardrails/insulin_sensitivity_schedule_test.go
+++ b/guardrails/insulin_sensitivity_schedule_test.go
@@ -3,13 +3,14 @@ package guardrails_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/tidepool-org/devices/api"
 
-	"github.com/tidepool-org/platform/guardrails"
+	"github.com/tidepool-org/devices/api"
 
 	"github.com/tidepool-org/platform/data/types/settings/pump"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/guardrails"
 	"github.com/tidepool-org/platform/guardrails/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
@@ -20,7 +21,7 @@ var _ = Describe("ValidateInsulinSensitivitySchedule", func() {
 
 	BeforeEach(func() {
 		guardRail = test.NewInsulinSensitivityGuardRail()
-		validator = structureValidator.New()
+		validator = structureValidator.New(logTest.NewLogger())
 	})
 
 	It("doesn't return error with a single valid value", func() {

--- a/location/accuracy_test.go
+++ b/location/accuracy_test.go
@@ -9,6 +9,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/location"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -70,13 +71,13 @@ var _ = Describe("Accuracy", func() {
 
 		Context("ParseAccuracy", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(location.ParseAccuracy(structureParser.NewObject(nil))).To(BeNil())
+				Expect(location.ParseAccuracy(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := locationTest.RandomAccuracy()
 				object := locationTest.NewObjectFromAccuracy(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(location.ParseAccuracy(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -95,7 +96,7 @@ var _ = Describe("Accuracy", func() {
 					object := locationTest.NewObjectFromAccuracy(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &location.Accuracy{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -119,7 +120,7 @@ var _ = Describe("Accuracy", func() {
 				func(mutator func(datum *location.Accuracy), expectedErrors ...error) {
 					datum := locationTest.RandomAccuracy()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *location.Accuracy) {},

--- a/location/elevation_test.go
+++ b/location/elevation_test.go
@@ -9,6 +9,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/location"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -70,13 +71,13 @@ var _ = Describe("Elevation", func() {
 
 		Context("ParseElevation", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(location.ParseElevation(structureParser.NewObject(nil))).To(BeNil())
+				Expect(location.ParseElevation(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := locationTest.RandomElevation()
 				object := locationTest.NewObjectFromElevation(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(location.ParseElevation(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -95,7 +96,7 @@ var _ = Describe("Elevation", func() {
 					object := locationTest.NewObjectFromElevation(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &location.Elevation{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -119,7 +120,7 @@ var _ = Describe("Elevation", func() {
 				func(mutator func(datum *location.Elevation), expectedErrors ...error) {
 					datum := locationTest.RandomElevation()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *location.Elevation) {},

--- a/location/gps_test.go
+++ b/location/gps_test.go
@@ -4,6 +4,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/location"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	originTest "github.com/tidepool-org/platform/origin/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -54,13 +55,13 @@ var _ = Describe("GPS", func() {
 
 		Context("ParseGPS", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(location.ParseGPS(structureParser.NewObject(nil))).To(BeNil())
+				Expect(location.ParseGPS(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := locationTest.RandomGPS()
 				object := locationTest.NewObjectFromGPS(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(location.ParseGPS(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -79,7 +80,7 @@ var _ = Describe("GPS", func() {
 					object := locationTest.NewObjectFromGPS(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &location.GPS{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -118,7 +119,7 @@ var _ = Describe("GPS", func() {
 				func(mutator func(datum *location.GPS), expectedErrors ...error) {
 					datum := locationTest.RandomGPS()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *location.GPS) {},

--- a/location/latitude_test.go
+++ b/location/latitude_test.go
@@ -9,6 +9,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/location"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -58,13 +59,13 @@ var _ = Describe("Latitude", func() {
 
 		Context("ParseLatitude", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(location.ParseLatitude(structureParser.NewObject(nil))).To(BeNil())
+				Expect(location.ParseLatitude(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := locationTest.RandomLatitude()
 				object := locationTest.NewObjectFromLatitude(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(location.ParseLatitude(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -83,7 +84,7 @@ var _ = Describe("Latitude", func() {
 					object := locationTest.NewObjectFromLatitude(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &location.Latitude{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -107,7 +108,7 @@ var _ = Describe("Latitude", func() {
 				func(mutator func(datum *location.Latitude), expectedErrors ...error) {
 					datum := locationTest.RandomLatitude()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *location.Latitude) {},

--- a/location/location_test.go
+++ b/location/location_test.go
@@ -7,6 +7,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/location"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -44,13 +45,13 @@ var _ = Describe("Location", func() {
 
 		Context("ParseLocation", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(location.ParseLocation(structureParser.NewObject(nil))).To(BeNil())
+				Expect(location.ParseLocation(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := locationTest.RandomLocation()
 				object := locationTest.NewObjectFromLocation(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(location.ParseLocation(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -69,7 +70,7 @@ var _ = Describe("Location", func() {
 					object := locationTest.NewObjectFromLocation(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &location.Location{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -93,7 +94,7 @@ var _ = Describe("Location", func() {
 				func(mutator func(datum *location.Location), expectedErrors ...error) {
 					datum := locationTest.RandomLocation()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *location.Location) {},

--- a/location/longitude_test.go
+++ b/location/longitude_test.go
@@ -9,6 +9,7 @@ import (
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/location"
 	locationTest "github.com/tidepool-org/platform/location/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -58,13 +59,13 @@ var _ = Describe("Longitude", func() {
 
 		Context("ParseLongitude", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(location.ParseLongitude(structureParser.NewObject(nil))).To(BeNil())
+				Expect(location.ParseLongitude(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := locationTest.RandomLongitude()
 				object := locationTest.NewObjectFromLongitude(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(location.ParseLongitude(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -83,7 +84,7 @@ var _ = Describe("Longitude", func() {
 					object := locationTest.NewObjectFromLongitude(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &location.Longitude{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -107,7 +108,7 @@ var _ = Describe("Longitude", func() {
 				func(mutator func(datum *location.Longitude), expectedErrors ...error) {
 					datum := locationTest.RandomLongitude()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *location.Longitude) {},

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,15 +1,16 @@
 package metadata_test
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metadata"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Metadata", func() {
@@ -41,13 +42,13 @@ var _ = Describe("Metadata", func() {
 
 		Context("ParseMetadata", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(metadata.ParseMetadata(structureParser.NewObject(nil))).To(BeNil())
+				Expect(metadata.ParseMetadata(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := metadataTest.RandomMetadata()
 				object := metadataTest.NewObjectFromMetadata(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(metadata.ParseMetadata(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -66,7 +67,7 @@ var _ = Describe("Metadata", func() {
 					object := metadataTest.NewObjectFromMetadata(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &metadata.Metadata{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -80,7 +81,7 @@ var _ = Describe("Metadata", func() {
 				func(mutator func(datum *metadata.Metadata), expectedErrors ...error) {
 					datum := metadataTest.RandomMetadata()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *metadata.Metadata) {},
@@ -182,13 +183,13 @@ var _ = Describe("Metadata", func() {
 	Context("MetadataArray", func() {
 		Context("ParseMetadataArray", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(metadata.ParseMetadataArray(structureParser.NewArray(nil))).To(BeNil())
+				Expect(metadata.ParseMetadataArray(structureParser.NewArray(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := metadataTest.RandomMetadataArray()
 				array := metadataTest.NewArrayFromMetadataArray(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				Expect(metadata.ParseMetadataArray(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -202,7 +203,7 @@ var _ = Describe("Metadata", func() {
 
 		Context("Parse", func() {
 			It("successfully parses a nil array", func() {
-				parser := structureParser.NewArray(nil)
+				parser := structureParser.NewArray(logTest.NewLogger(), nil)
 				datum := metadata.NewMetadataArray()
 				datum.Parse(parser)
 				Expect(datum).To(Equal(metadata.NewMetadataArray()))
@@ -210,7 +211,7 @@ var _ = Describe("Metadata", func() {
 			})
 
 			It("successfully parses an empty array", func() {
-				parser := structureParser.NewArray(&[]interface{}{})
+				parser := structureParser.NewArray(logTest.NewLogger(), &[]interface{}{})
 				datum := metadata.NewMetadataArray()
 				datum.Parse(parser)
 				Expect(datum).To(Equal(metadata.NewMetadataArray()))
@@ -220,7 +221,7 @@ var _ = Describe("Metadata", func() {
 			It("successfully parses a non-empty array", func() {
 				expectedDatum := metadataTest.RandomMetadataArray()
 				array := metadataTest.NewArrayFromMetadataArray(expectedDatum, test.ObjectFormatJSON)
-				parser := structureParser.NewArray(&array)
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
 				datum := metadata.NewMetadataArray()
 				datum.Parse(parser)
 				Expect(datum).To(Equal(expectedDatum))
@@ -233,7 +234,7 @@ var _ = Describe("Metadata", func() {
 				func(mutator func(datum *metadata.MetadataArray), expectedErrors ...error) {
 					datum := metadataTest.RandomMetadataArray()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *metadata.MetadataArray) {},

--- a/origin/origin_test.go
+++ b/origin/origin_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metadata"
 	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/origin"
@@ -80,13 +81,13 @@ var _ = Describe("Origin", func() {
 
 		Context("ParseOrigin", func() {
 			It("returns nil when the object is missing", func() {
-				Expect(origin.ParseOrigin(structureParser.NewObject(nil))).To(BeNil())
+				Expect(origin.ParseOrigin(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
 			})
 
 			It("returns new datum when the object is valid", func() {
 				datum := originTest.RandomOrigin()
 				object := originTest.NewObjectFromOrigin(datum, test.ObjectFormatJSON)
-				parser := structureParser.NewObject(&object)
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
 				Expect(origin.ParseOrigin(parser)).To(Equal(datum))
 				Expect(parser.Error()).ToNot(HaveOccurred())
 			})
@@ -105,7 +106,7 @@ var _ = Describe("Origin", func() {
 					object := originTest.NewObjectFromOrigin(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &origin.Origin{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -141,7 +142,7 @@ var _ = Describe("Origin", func() {
 				func(mutator func(datum *origin.Origin), expectedErrors ...error) {
 					datum := originTest.RandomOrigin()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *origin.Origin) {},

--- a/page/pagination_test.go
+++ b/page/pagination_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/page"
 	pageTest "github.com/tidepool-org/platform/page/test"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -62,7 +63,7 @@ var _ = Describe("Pagination", func() {
 			Context("Parse", func() {
 				It("parses the page", func() {
 					object := map[string]interface{}{"page": 2}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					datum.Parse(parser)
 					Expect(datum.Page).To(Equal(2))
 					Expect(datum.Size).To(Equal(original.Size))
@@ -71,7 +72,7 @@ var _ = Describe("Pagination", func() {
 
 				It("parses the size", func() {
 					object := map[string]interface{}{"size": 10}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					datum.Parse(parser)
 					Expect(datum.Page).To(Equal(original.Page))
 					Expect(datum.Size).To(Equal(10))
@@ -80,7 +81,7 @@ var _ = Describe("Pagination", func() {
 
 				It("parses the page and size", func() {
 					object := map[string]interface{}{"page": 2, "size": 10}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					datum.Parse(parser)
 					Expect(datum.Page).To(Equal(2))
 					Expect(datum.Size).To(Equal(10))
@@ -89,7 +90,7 @@ var _ = Describe("Pagination", func() {
 
 				It("reports an error if page is not an int", func() {
 					object := map[string]interface{}{"page": false, "size": 10}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					datum.Parse(parser)
 					Expect(datum.Page).To(Equal(original.Page))
 					Expect(datum.Size).To(Equal(10))
@@ -99,7 +100,7 @@ var _ = Describe("Pagination", func() {
 
 				It("reports an error if size is not an int", func() {
 					object := map[string]interface{}{"page": 2, "size": false}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					datum.Parse(parser)
 					Expect(datum.Page).To(Equal(2))
 					Expect(datum.Size).To(Equal(original.Size))
@@ -109,7 +110,7 @@ var _ = Describe("Pagination", func() {
 
 				It("reports an error if page and size are not ints", func() {
 					object := map[string]interface{}{"page": false, "size": false}
-					parser := structureParser.NewObject(&object)
+					parser := structureParser.NewObject(logTest.NewLogger(), &object)
 					datum.Parse(parser)
 					Expect(datum.Page).To(Equal(original.Page))
 					Expect(datum.Size).To(Equal(original.Size))
@@ -127,7 +128,7 @@ var _ = Describe("Pagination", func() {
 				var validator *structureValidator.Validator
 
 				BeforeEach(func() {
-					validator = structureValidator.New()
+					validator = structureValidator.New(logTest.NewLogger())
 				})
 
 				It("succeeds with defaults", func() {

--- a/prescription/api/v1.go
+++ b/prescription/api/v1.go
@@ -7,6 +7,7 @@ import (
 	clinic "github.com/tidepool-org/clinic/client"
 
 	"github.com/tidepool-org/platform/clinics"
+	"github.com/tidepool-org/platform/log"
 
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 
@@ -36,7 +37,7 @@ func (r *Router) CreatePrescription(res rest.ResponseWriter, req *rest.Request) 
 		return
 	}
 
-	validator := structureValidator.New().WithReference("initialSettings")
+	validator := structureValidator.New(log.LoggerFromContext(ctx)).WithReference("initialSettings")
 	if err := r.deviceSettingsValidator.Validate(ctx, create.InitialSettings, validator); err != nil {
 		responder.Error(http.StatusInternalServerError, err)
 		return
@@ -236,7 +237,7 @@ func (r *Router) AddRevision(res rest.ResponseWriter, req *rest.Request) {
 		return
 	}
 
-	validator := structureValidator.New().WithReference("initialSettings")
+	validator := structureValidator.New(log.LoggerFromContext(ctx)).WithReference("initialSettings")
 	if err := r.deviceSettingsValidator.Validate(ctx, create.InitialSettings, validator); err != nil {
 		responder.Error(http.StatusInternalServerError, err)
 		return

--- a/prescription/calculator_test.go
+++ b/prescription/calculator_test.go
@@ -4,12 +4,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
-	"github.com/tidepool-org/platform/structure"
-	"github.com/tidepool-org/platform/structure/validator"
-
 	"github.com/tidepool-org/platform/prescription"
 	"github.com/tidepool-org/platform/prescription/test"
+	"github.com/tidepool-org/platform/structure"
+	"github.com/tidepool-org/platform/structure/validator"
 )
 
 var _ = Describe("Calculator", func() {
@@ -18,13 +18,13 @@ var _ = Describe("Calculator", func() {
 
 	BeforeEach(func() {
 		calculator = test.RandomCalculator()
-		validate = validator.New()
+		validate = validator.New(logTest.NewLogger())
 		Expect(validate.Validate(calculator)).ToNot(HaveOccurred())
 	})
 
 	Describe("Validate", func() {
 		BeforeEach(func() {
-			validate = validator.New()
+			validate = validator.New(logTest.NewLogger())
 		})
 
 		It("doesn't fail with nil method", func() {

--- a/prescription/prescription_test.go
+++ b/prescription/prescription_test.go
@@ -4,20 +4,19 @@ import (
 	"fmt"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"syreclabs.com/go/faker"
-
-	"github.com/tidepool-org/platform/structure"
-	"github.com/tidepool-org/platform/structure/validator"
-	userTest "github.com/tidepool-org/platform/user/test"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/prescription/test"
-	"github.com/tidepool-org/platform/user"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"syreclabs.com/go/faker"
 
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/prescription"
+	"github.com/tidepool-org/platform/prescription/test"
+	"github.com/tidepool-org/platform/structure"
+	"github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/user"
+	userTest "github.com/tidepool-org/platform/user/test"
 )
 
 var _ = Describe("Prescription", func() {
@@ -253,7 +252,7 @@ var _ = Describe("Prescription", func() {
 					filter, err = prescription.NewPatientFilter(*usr.UserID)
 					Expect(err).ToNot(HaveOccurred())
 
-					validate = validator.New()
+					validate = validator.New(logTest.NewLogger())
 					Expect(validate.Validate(filter)).ToNot(HaveOccurred())
 				})
 
@@ -353,7 +352,7 @@ var _ = Describe("Prescription", func() {
 					filter, err = prescription.NewClinicFilter(clinicID)
 					Expect(err).ToNot(HaveOccurred())
 
-					validate = validator.New()
+					validate = validator.New(logTest.NewLogger())
 					Expect(validate.Validate(filter)).ToNot(HaveOccurred())
 				})
 

--- a/prescription/revision_test.go
+++ b/prescription/revision_test.go
@@ -3,16 +3,16 @@ package prescription_test
 import (
 	"time"
 
-	"github.com/tidepool-org/platform/pointer"
-	"github.com/tidepool-org/platform/structure"
-	"github.com/tidepool-org/platform/structure/validator"
-	test2 "github.com/tidepool-org/platform/test"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/prescription"
 	"github.com/tidepool-org/platform/prescription/test"
+	"github.com/tidepool-org/platform/structure"
+	"github.com/tidepool-org/platform/structure/validator"
+	test2 "github.com/tidepool-org/platform/test"
 	userTest "github.com/tidepool-org/platform/user/test"
 )
 
@@ -145,13 +145,13 @@ var _ = Describe("Revision", func() {
 
 		BeforeEach(func() {
 			revision = test.RandomRevision()
-			validate = validator.New()
+			validate = validator.New(logTest.NewLogger())
 			Expect(validate.Validate(revision)).ToNot(HaveOccurred())
 		})
 
 		Context("Validate", func() {
 			BeforeEach(func() {
-				validate = validator.New()
+				validate = validator.New(logTest.NewLogger())
 			})
 
 			It("fails when revision id is negative", func() {
@@ -187,14 +187,14 @@ var _ = Describe("Revision", func() {
 
 		BeforeEach(func() {
 			attr = test.RandomAttribtues()
-			validate = validator.New()
+			validate = validator.New(logTest.NewLogger())
 			Expect(validate.Validate(attr)).ToNot(HaveOccurred())
 		})
 
 		Describe("Validate", func() {
 			When("state is 'submitted'", func() {
 				BeforeEach(func() {
-					validate = validator.New()
+					validate = validator.New(logTest.NewLogger())
 					attr.State = prescription.StateSubmitted
 				})
 
@@ -472,7 +472,7 @@ var _ = Describe("Revision", func() {
 
 		BeforeEach(func() {
 			weight = test.RandomWeight()
-			validate = validator.New()
+			validate = validator.New(logTest.NewLogger())
 		})
 
 		Describe("Validate", func() {

--- a/prescription/settings_test.go
+++ b/prescription/settings_test.go
@@ -4,11 +4,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/structure"
-	"github.com/tidepool-org/platform/structure/validator"
-
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/prescription"
 	"github.com/tidepool-org/platform/prescription/test"
+	"github.com/tidepool-org/platform/structure"
+	"github.com/tidepool-org/platform/structure/validator"
 )
 
 var _ = Describe("Initial Settings", func() {
@@ -17,13 +17,13 @@ var _ = Describe("Initial Settings", func() {
 
 	BeforeEach(func() {
 		settings = test.RandomInitialSettings()
-		validate = validator.New()
+		validate = validator.New(logTest.NewLogger())
 		Expect(validate.Validate(settings)).ToNot(HaveOccurred())
 	})
 
 	Describe("ValidateSubmittedPrescription", func() {
 		BeforeEach(func() {
-			validate = validator.New()
+			validate = validator.New(logTest.NewLogger())
 		})
 
 		It("fails with empty basal rate schedule", func() {

--- a/prescription/store/mongo/prescription_repository.go
+++ b/prescription/store/mongo/prescription_repository.go
@@ -76,7 +76,7 @@ func (p *PrescriptionRepository) CreatePrescription(ctx context.Context, create 
 	}
 
 	model := prescription.NewPrescription(create)
-	if err := structureValidator.New().Validate(model); err != nil {
+	if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(model); err != nil {
 		return nil, errors.Wrap(err, "prescription is invalid")
 	}
 
@@ -98,13 +98,13 @@ func (p *PrescriptionRepository) ListPrescriptions(ctx context.Context, filter *
 	}
 	if filter == nil {
 		return nil, errors.New("filter is missing")
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -204,7 +204,7 @@ func (p *PrescriptionRepository) AddRevision(ctx context.Context, prescriptionID
 	}
 
 	prescriptionUpdate := prescription.NewPrescriptionAddRevisionUpdate(prescr, create)
-	if err := structureValidator.New().Validate(prescriptionUpdate); err != nil {
+	if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(prescriptionUpdate); err != nil {
 		return nil, errors.Wrap(err, "the prescription update is invalid")
 	}
 
@@ -251,7 +251,7 @@ func (p *PrescriptionRepository) ClaimPrescription(ctx context.Context, claim *p
 
 	id := prescr.ID
 	prescriptionUpdate := prescription.NewPrescriptionClaimUpdate(claim.PatientID, prescr)
-	if err := structureValidator.New().Validate(prescriptionUpdate); err != nil {
+	if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(prescriptionUpdate); err != nil {
 		return nil, errors.Wrap(err, "the prescription update is invalid")
 	}
 
@@ -318,7 +318,7 @@ func (p *PrescriptionRepository) UpdatePrescriptionState(ctx context.Context, pr
 	}
 
 	prescriptionUpdate := prescription.NewPrescriptionStateUpdate(prescr, update)
-	if err := structureValidator.New().Validate(prescriptionUpdate); err != nil {
+	if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(prescriptionUpdate); err != nil {
 		return nil, errors.Wrap(err, "the prescription update is invalid")
 	}
 	mongoUpdate := newMongoUpdateFromPrescriptionUpdate(prescriptionUpdate)

--- a/request/condition_test.go
+++ b/request/condition_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	requestTest "github.com/tidepool-org/platform/request/test"
@@ -36,7 +37,7 @@ var _ = Describe("Condition", func() {
 					object := requestTest.NewObjectFromCondition(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &request.Condition{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(Equal(expectedDatum))
 				},
 				Entry("succeeds",
@@ -71,7 +72,7 @@ var _ = Describe("Condition", func() {
 				func(mutator func(datum *request.Condition), expectedErrors ...error) {
 					datum := requestTest.RandomCondition()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *request.Condition) {},

--- a/request/parser.go
+++ b/request/parser.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/tidepool-org/platform/crypto"
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/net"
 	"github.com/tidepool-org/platform/structure"
 	structureNormalizer "github.com/tidepool-org/platform/structure/normalizer"
@@ -27,10 +29,10 @@ func DecodeRequestBody(req *http.Request, object interface{}) error {
 	}
 
 	defer req.Body.Close()
-	return DecodeObject(structure.NewPointerSource(), req.Body, object)
+	return DecodeObject(req.Context(), structure.NewPointerSource(), req.Body, object)
 }
 
-func DecodeResponseBody(res *http.Response, object interface{}) error {
+func DecodeResponseBody(ctx context.Context, res *http.Response, object interface{}) error {
 	if res == nil {
 		return errors.New("response is missing")
 	}
@@ -39,56 +41,56 @@ func DecodeResponseBody(res *http.Response, object interface{}) error {
 	}
 
 	defer res.Body.Close()
-	return DecodeObject(structure.NewPointerSource(), res.Body, object)
+	return DecodeObject(ctx, structure.NewPointerSource(), res.Body, object)
 }
 
-func DecodeObject(source structure.Source, reader io.Reader, object interface{}) error {
-	if err := ParseStreamObject(source, reader, object); err != nil {
+func DecodeObject(ctx context.Context, source structure.Source, reader io.Reader, object interface{}) error {
+	if err := ParseStreamObject(ctx, source, reader, object); err != nil {
 		return err
 	}
-	if err := ValidateObjects(source, object); err != nil {
+	if err := ValidateObjects(ctx, source, object); err != nil {
 		return err
 	}
-	return NormalizeObjects(source, object)
+	return NormalizeObjects(ctx, source, object)
 }
 
-func ParseStreamObject(source structure.Source, reader io.Reader, object interface{}) error {
+func ParseStreamObject(ctx context.Context, source structure.Source, reader io.Reader, object interface{}) error {
 	if objectParsable, ok := object.(structure.ObjectParsable); ok {
-		return ParseObjectParseableStreamObject(source, reader, objectParsable)
+		return ParseObjectParseableStreamObject(ctx, source, reader, objectParsable)
 	}
 	if arrayParsable, ok := object.(structure.ArrayParsable); ok {
-		return ParseArrayParseableStreamObject(source, reader, arrayParsable)
+		return ParseArrayParseableStreamObject(ctx, source, reader, arrayParsable)
 	}
-	return ParseSimpleStreamObject(reader, object)
+	return ParseSimpleStreamObject(ctx, reader, object)
 }
 
-func ParseObjectParseableStreamObject(source structure.Source, reader io.Reader, objectParsable structure.ObjectParsable) error {
+func ParseObjectParseableStreamObject(ctx context.Context, source structure.Source, reader io.Reader, objectParsable structure.ObjectParsable) error {
 	object := &map[string]interface{}{}
-	if err := ParseSimpleStreamObject(reader, object); err != nil {
+	if err := ParseSimpleStreamObject(ctx, reader, object); err != nil {
 		return err
 	}
 
-	parser := structureParser.NewObject(object).WithSource(source)
+	parser := structureParser.NewObject(log.LoggerFromContext(ctx), object).WithSource(source)
 	objectParsable.Parse(parser)
 	parser.NotParsed()
 
 	return parser.Error()
 }
 
-func ParseArrayParseableStreamObject(source structure.Source, reader io.Reader, arrayParsable structure.ArrayParsable) error {
+func ParseArrayParseableStreamObject(ctx context.Context, source structure.Source, reader io.Reader, arrayParsable structure.ArrayParsable) error {
 	array := &[]interface{}{}
-	if err := ParseSimpleStreamObject(reader, array); err != nil {
+	if err := ParseSimpleStreamObject(ctx, reader, array); err != nil {
 		return err
 	}
 
-	parser := structureParser.NewArray(array).WithSource(source)
+	parser := structureParser.NewArray(log.LoggerFromContext(ctx), array).WithSource(source)
 	arrayParsable.Parse(parser)
 	parser.NotParsed()
 
 	return parser.Error()
 }
 
-func ParseSimpleStreamObject(reader io.Reader, object interface{}) error {
+func ParseSimpleStreamObject(ctx context.Context, reader io.Reader, object interface{}) error {
 	if reader == nil {
 		return errors.New("reader is missing")
 	}
@@ -106,7 +108,7 @@ func ParseSimpleStreamObject(reader io.Reader, object interface{}) error {
 	return nil
 }
 
-func ValidateObjects(source structure.Source, objects ...interface{}) error {
+func ValidateObjects(ctx context.Context, source structure.Source, objects ...interface{}) error {
 	validatables := []structure.Validatable{}
 	for _, object := range objects {
 		if validatable, ok := object.(structure.Validatable); ok {
@@ -114,14 +116,14 @@ func ValidateObjects(source structure.Source, objects ...interface{}) error {
 		}
 	}
 
-	validator := structureValidator.New().WithSource(source)
+	validator := structureValidator.New(log.LoggerFromContext(ctx)).WithSource(source)
 	for _, validatable := range validatables {
 		validatable.Validate(validator)
 	}
 	return validator.Error()
 }
 
-func NormalizeObjects(source structure.Source, objects ...interface{}) error {
+func NormalizeObjects(ctx context.Context, source structure.Source, objects ...interface{}) error {
 	normalizables := []structure.Normalizable{}
 	for _, object := range objects {
 		if normalizable, ok := object.(structure.Normalizable); ok {
@@ -129,7 +131,7 @@ func NormalizeObjects(source structure.Source, objects ...interface{}) error {
 		}
 	}
 
-	normalizer := structureNormalizer.New().WithSource(source)
+	normalizer := structureNormalizer.New(log.LoggerFromContext(ctx)).WithSource(source)
 	for _, normalizable := range normalizables {
 		normalizable.Normalize(normalizer)
 	}
@@ -149,26 +151,26 @@ func DecodeRequestQuery(req *http.Request, objectParsables ...structure.ObjectPa
 		return errors.New("unable to parse request query")
 	}
 
-	return DecodeValues((map[string][]string)(values), objectParsables...)
+	return DecodeValues(req.Context(), (map[string][]string)(values), objectParsables...)
 }
 
-func DecodeValues(values map[string][]string, objectParsables ...structure.ObjectParsable) error {
+func DecodeValues(ctx context.Context, values map[string][]string, objectParsables ...structure.ObjectParsable) error {
 	objects := []interface{}{}
 	for _, object := range objectParsables {
 		objects = append(objects, object)
 	}
 
-	if err := ParseValuesObjects(values, objectParsables...); err != nil {
+	if err := ParseValuesObjects(ctx, values, objectParsables...); err != nil {
 		return err
 	}
-	if err := ValidateObjects(structure.NewParameterSource(), objects...); err != nil {
+	if err := ValidateObjects(ctx, structure.NewParameterSource(), objects...); err != nil {
 		return err
 	}
-	return NormalizeObjects(structure.NewParameterSource(), objects...)
+	return NormalizeObjects(ctx, structure.NewParameterSource(), objects...)
 }
 
-func ParseValuesObjects(values map[string][]string, objectParsables ...structure.ObjectParsable) error {
-	parser := NewValues(&values)
+func ParseValuesObjects(ctx context.Context, values map[string][]string, objectParsables ...structure.ObjectParsable) error {
+	parser := NewValues(log.LoggerFromContext(ctx), &values)
 	for _, objectParsable := range objectParsables {
 		objectParsable.Parse(parser)
 	}

--- a/store/unstructured/file/file.go
+++ b/store/unstructured/file/file.go
@@ -76,7 +76,7 @@ func (s *Store) Put(ctx context.Context, key string, reader io.Reader, options *
 	}
 	if options == nil {
 		options = storeUnstructured.NewOptions()
-	} else if err := structureValidator.New().Validate(options); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(options); err != nil {
 		return errors.Wrap(err, "options is invalid")
 	}
 

--- a/store/unstructured/s3/s3.go
+++ b/store/unstructured/s3/s3.go
@@ -89,7 +89,7 @@ func (s *Store) Put(ctx context.Context, key string, reader io.Reader, options *
 	}
 	if options == nil {
 		options = storeUnstructured.NewOptions()
-	} else if err := structureValidator.New().Validate(options); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(options); err != nil {
 		return errors.Wrap(err, "options is invalid")
 	}
 

--- a/store/unstructured/unstructured_test.go
+++ b/store/unstructured/unstructured_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/net"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
@@ -28,7 +29,7 @@ var _ = Describe("Unstructured", func() {
 				func(mutator func(datum *storeUnstructured.Options), expectedErrors ...error) {
 					datum := storeUnstructuredTest.RandomOptions()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *storeUnstructured.Options) {},

--- a/structure/base/base.go
+++ b/structure/base/base.go
@@ -2,21 +2,28 @@ package base
 
 import (
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/structure"
 )
 
 type Base struct {
+	logger       log.Logger
 	origin       structure.Origin
 	source       structure.Source
 	meta         interface{}
 	serializable *errors.Serializable
 }
 
-func New() *Base {
+func New(logger log.Logger) *Base {
 	return &Base{
+		logger:       logger,
 		origin:       structure.OriginExternal,
 		serializable: &errors.Serializable{},
 	}
+}
+
+func (b *Base) Logger() log.Logger {
+	return b.logger
 }
 
 func (b *Base) Origin() structure.Origin {
@@ -57,6 +64,7 @@ func (b *Base) ReportError(err error) {
 
 func (b *Base) WithOrigin(origin structure.Origin) *Base {
 	return &Base{
+		logger:       b.logger,
 		origin:       origin,
 		source:       b.source,
 		meta:         b.meta,
@@ -66,6 +74,7 @@ func (b *Base) WithOrigin(origin structure.Origin) *Base {
 
 func (b *Base) WithSource(source structure.Source) *Base {
 	return &Base{
+		logger:       b.logger,
 		origin:       b.origin,
 		source:       source,
 		meta:         b.meta,
@@ -75,6 +84,7 @@ func (b *Base) WithSource(source structure.Source) *Base {
 
 func (b *Base) WithMeta(meta interface{}) *Base {
 	return &Base{
+		logger:       b.logger.WithField("meta", meta),
 		origin:       b.origin,
 		source:       b.source,
 		meta:         meta,
@@ -84,6 +94,7 @@ func (b *Base) WithMeta(meta interface{}) *Base {
 
 func (b *Base) WithReference(reference string) *Base {
 	base := &Base{
+		logger:       b.logger,
 		origin:       b.origin,
 		source:       b.source,
 		meta:         b.meta,

--- a/structure/base/base_test.go
+++ b/structure/base/base_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
@@ -15,13 +16,14 @@ import (
 var _ = Describe("Base", func() {
 	Context("New", func() {
 		It("returns successfully", func() {
-			Expect(structureBase.New()).ToNot(BeNil())
+			Expect(structureBase.New(logTest.NewLogger())).ToNot(BeNil())
 		})
 	})
 
 	Context("with source, meta, and new base", func() {
 		var src *structureTest.Source
 		var meta interface{}
+		var logger *logTest.Logger
 		var base *structureBase.Base
 
 		BeforeEach(func() {
@@ -29,12 +31,19 @@ var _ = Describe("Base", func() {
 			src.ParameterOutput = pointer.FromString(errorsTest.NewSourceParameter())
 			src.PointerOutput = pointer.FromString(errorsTest.NewSourcePointer())
 			meta = errorsTest.NewMeta()
-			base = structureBase.New()
+			logger = logTest.NewLogger()
+			base = structureBase.New(logger)
 			Expect(base).ToNot(BeNil())
 		})
 
 		AfterEach(func() {
 			src.Expectations()
+		})
+
+		Context("Logger", func() {
+			It("returns the logger", func() {
+				Expect(base.Logger()).To(BeIdenticalTo(logger))
+			})
 		})
 
 		Context("Origin", func() {

--- a/structure/normalizer.go
+++ b/structure/normalizer.go
@@ -5,6 +5,7 @@ type Normalizable interface {
 }
 
 type Normalizer interface {
+	LoggerReporter
 	OriginReporter
 	SourceReporter
 	MetaReporter

--- a/structure/normalizer/normalizer.go
+++ b/structure/normalizer/normalizer.go
@@ -1,6 +1,7 @@
 package normalizer
 
 import (
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 )
@@ -9,14 +10,18 @@ type Normalizer struct {
 	base *structureBase.Base
 }
 
-func New() *Normalizer {
-	return NewNormalizer(structureBase.New().WithSource(structure.NewPointerSource()))
+func New(logger log.Logger) *Normalizer {
+	return NewNormalizer(structureBase.New(logger).WithSource(structure.NewPointerSource()))
 }
 
 func NewNormalizer(base *structureBase.Base) *Normalizer {
 	return &Normalizer{
 		base: base,
 	}
+}
+
+func (n *Normalizer) Logger() log.Logger {
+	return n.base.Logger()
 }
 
 func (n *Normalizer) Origin() structure.Origin {

--- a/structure/normalizer/normalizer_test.go
+++ b/structure/normalizer/normalizer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
@@ -18,22 +19,30 @@ import (
 var _ = Describe("Normalizer", func() {
 	Context("New", func() {
 		It("returns successfully", func() {
-			Expect(structureNormalizer.New()).ToNot(BeNil())
+			Expect(structureNormalizer.New(logTest.NewLogger())).ToNot(BeNil())
 		})
 	})
 
 	Context("NewNormalizer", func() {
 		It("returns successfully", func() {
-			Expect(structureNormalizer.NewNormalizer(structureBase.New())).ToNot(BeNil())
+			Expect(structureNormalizer.NewNormalizer(structureBase.New(logTest.NewLogger()))).ToNot(BeNil())
 		})
 	})
 
 	Context("with new normalizer", func() {
+		var logger *logTest.Logger
 		var normalizer *structureNormalizer.Normalizer
 
 		BeforeEach(func() {
-			normalizer = structureNormalizer.New()
+			logger = logTest.NewLogger()
+			normalizer = structureNormalizer.New(logger)
 			Expect(normalizer).ToNot(BeNil())
+		})
+
+		Context("Logger", func() {
+			It("returns the logger", func() {
+				Expect(normalizer.Logger()).To(BeIdenticalTo(logger))
+			})
 		})
 
 		Context("Origin", func() {

--- a/structure/parser.go
+++ b/structure/parser.go
@@ -7,6 +7,7 @@ type ObjectParsable interface {
 }
 
 type ObjectParser interface {
+	LoggerReporter
 	OriginReporter
 	SourceReporter
 	MetaReporter
@@ -26,7 +27,6 @@ type ObjectParser interface {
 	String(reference string) *string
 	StringArray(reference string) *[]string
 	Time(reference string, layout string) *time.Time
-	ForgivingTime(reference string, layout string) *time.Time
 
 	Object(reference string) *map[string]interface{}
 	Array(reference string) *[]interface{}
@@ -48,6 +48,7 @@ type ArrayParsable interface {
 }
 
 type ArrayParser interface {
+	LoggerReporter
 	OriginReporter
 	SourceReporter
 	MetaReporter
@@ -81,19 +82,4 @@ type ArrayParser interface {
 	WithReferenceObjectParser(reference int) ObjectParser
 	WithReferenceArrayParser(reference int) ArrayParser
 	WithReferenceErrorReporter(reference int) ErrorReporter
-}
-
-// ForgivingTimeString is a helper function added specifically to handle https://tidepool.atlassian.net/browse/BACK-1161
-// It should be deprecated once Dexcom fixes their API.
-func ForgivingTimeString(stringValue string) (forgivingTime string) {
-	if len(stringValue) < 19 {
-		forgivingBytes := []byte("0000-01-01T00:00:00")
-		for i := range stringValue {
-			forgivingBytes[i] = stringValue[i]
-		}
-		forgivingTime = string(forgivingBytes)
-	} else {
-		forgivingTime = stringValue
-	}
-	return forgivingTime
 }

--- a/structure/parser/array_parser.go
+++ b/structure/parser/array_parser.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 )
@@ -15,8 +16,8 @@ type Array struct {
 	parsed []bool
 }
 
-func NewArray(array *[]interface{}) *Array {
-	return NewArrayParser(structureBase.New().WithSource(structure.NewPointerSource()), array)
+func NewArray(logger log.Logger, array *[]interface{}) *Array {
+	return NewArrayParser(structureBase.New(logger).WithSource(structure.NewPointerSource()), array)
 }
 
 func NewArrayParser(base *structureBase.Base, array *[]interface{}) *Array {
@@ -30,6 +31,10 @@ func NewArrayParser(base *structureBase.Base, array *[]interface{}) *Array {
 		array:  array,
 		parsed: parsed,
 	}
+}
+
+func (a *Array) Logger() log.Logger {
+	return a.base.Logger()
 }
 
 func (a *Array) Origin() structure.Origin {

--- a/structure/parser/array_parser_test.go
+++ b/structure/parser/array_parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -15,15 +16,17 @@ import (
 )
 
 var _ = Describe("Array", func() {
+	var logger *logTest.Logger
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		logger = logTest.NewLogger()
+		base = structureBase.New(logger).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewArray", func() {
 		It("returns successfully", func() {
-			Expect(structureParser.NewArray(nil)).ToNot(BeNil())
+			Expect(structureParser.NewArray(logTest.NewLogger(), nil)).ToNot(BeNil())
 		})
 	})
 
@@ -39,6 +42,12 @@ var _ = Describe("Array", func() {
 		BeforeEach(func() {
 			parser = structureParser.NewArrayParser(base, nil)
 			Expect(parser).ToNot(BeNil())
+		})
+
+		Context("Logger", func() {
+			It("returns the logger", func() {
+				Expect(parser.Logger()).To(BeIdenticalTo(logger))
+			})
 		})
 
 		Context("Origin", func() {

--- a/structure/parser/object_parser.go
+++ b/structure/parser/object_parser.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 )
@@ -15,8 +16,8 @@ type Object struct {
 	parsed map[string]bool
 }
 
-func NewObject(object *map[string]interface{}) *Object {
-	return NewObjectParser(structureBase.New().WithSource(structure.NewPointerSource()), object)
+func NewObject(logger log.Logger, object *map[string]interface{}) *Object {
+	return NewObjectParser(structureBase.New(logger).WithSource(structure.NewPointerSource()), object)
 }
 
 func NewObjectParser(base *structureBase.Base, object *map[string]interface{}) *Object {
@@ -30,6 +31,10 @@ func NewObjectParser(base *structureBase.Base, object *map[string]interface{}) *
 		object: object,
 		parsed: parsed,
 	}
+}
+
+func (o *Object) Logger() log.Logger {
+	return o.base.Logger()
 }
 
 func (o *Object) Origin() structure.Origin {
@@ -219,30 +224,6 @@ func (o *Object) Time(reference string, layout string) *time.Time {
 			o.base.WithReference(reference).ReportError(ErrorValueTimeNotParsable(stringValue, layout))
 			return nil
 		}
-	}
-
-	return &timeValue
-}
-
-// ForgivingTime is a parser added specifically to handle https://tidepool.atlassian.net/browse/BACK-1161
-// It should be deprecated once Dexcom fixes their API.
-func (o *Object) ForgivingTime(reference string, layout string) *time.Time {
-	rawValue, ok := o.raw(reference)
-	if !ok {
-		return nil
-	}
-
-	stringValue, ok := rawValue.(string)
-	if !ok {
-		o.base.WithReference(reference).ReportError(ErrorTypeNotTime(rawValue))
-		return nil
-	}
-
-	forgivingTime := structure.ForgivingTimeString(stringValue)
-	timeValue, err := time.Parse(layout, forgivingTime)
-	if err != nil {
-		o.base.WithReference(reference).ReportError(ErrorValueTimeNotParsable(stringValue, layout))
-		return nil
 	}
 
 	return &timeValue

--- a/structure/parser/object_parser_test.go
+++ b/structure/parser/object_parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -15,15 +16,17 @@ import (
 )
 
 var _ = Describe("Object", func() {
+	var logger *logTest.Logger
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		logger = logTest.NewLogger()
+		base = structureBase.New(logger).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewObject", func() {
 		It("returns successfully", func() {
-			Expect(structureParser.NewObject(nil)).ToNot(BeNil())
+			Expect(structureParser.NewObject(logTest.NewLogger(), nil)).ToNot(BeNil())
 		})
 	})
 
@@ -39,6 +42,12 @@ var _ = Describe("Object", func() {
 		BeforeEach(func() {
 			parser = structureParser.NewObjectParser(base, nil)
 			Expect(parser).ToNot(BeNil())
+		})
+
+		Context("Logger", func() {
+			It("returns the logger", func() {
+				Expect(parser.Logger()).To(BeIdenticalTo(logger))
+			})
 		})
 
 		Context("Origin", func() {
@@ -569,54 +578,6 @@ var _ = Describe("Object", func() {
 			value := parser.Time("three", time.RFC3339Nano)
 			Expect(value).ToNot(BeNil())
 			Expect(*value).To(BeTemporally("==", now))
-			Expect(base.Error()).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("ForgivingTime", func() {
-		var now time.Time
-		var parser *structureParser.Object
-
-		BeforeEach(func() {
-			now = time.Now()
-			parser = structureParser.NewObjectParser(base, &map[string]interface{}{
-				"zero":  false,
-				"one":   "abc",
-				"two":   now.Format(time.RFC3339Nano),
-				"three": "2020-02-01T00:13",
-			})
-			Expect(parser).ToNot(BeNil())
-		})
-
-		It("with key not found in the object returns nil", func() {
-			Expect(parser.ForgivingTime("unknown", time.RFC3339Nano)).To(BeNil())
-			Expect(base.Error()).ToNot(HaveOccurred())
-		})
-
-		It("with key with different type returns nil and reports an ErrorCodeTypeNotTime", func() {
-			Expect(parser.ForgivingTime("zero", time.RFC3339Nano)).To(BeNil())
-			Expect(base.Error()).To(HaveOccurred())
-			errorsTest.ExpectEqual(base.Error(), errorsTest.WithPointerSource(structureParser.ErrorTypeNotTime(false), "/zero"))
-		})
-
-		It("with key with different type returns nil and reports an ErrorCodeTimeNotParsable", func() {
-			Expect(parser.ForgivingTime("one", time.RFC3339Nano)).To(BeNil())
-			Expect(base.Error()).To(HaveOccurred())
-			errorsTest.ExpectEqual(base.Error(), errorsTest.WithPointerSource(structureParser.ErrorValueTimeNotParsable("abc", time.RFC3339Nano), "/one"))
-		})
-
-		It("with key with string type returns value", func() {
-			value := parser.ForgivingTime("two", time.RFC3339Nano)
-			Expect(value).ToNot(BeNil())
-			Expect(*value).To(BeTemporally("==", now))
-			Expect(base.Error()).ToNot(HaveOccurred())
-		})
-
-		It("with key with partial string type returns value", func() {
-			value := parser.ForgivingTime("three", "2006-01-02T15:04:05")
-			expectedValue, _ := time.Parse("2006-01-02T15:04:05", "2020-02-01T00:13:00")
-			Expect(value).ToNot(BeNil())
-			Expect(*value).To(BeTemporally("==", expectedValue))
 			Expect(base.Error()).ToNot(HaveOccurred())
 		})
 	})

--- a/structure/structure.go
+++ b/structure/structure.go
@@ -1,6 +1,10 @@
 package structure
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/tidepool-org/platform/log"
+)
 
 type Origin int
 
@@ -16,6 +20,10 @@ func Origins() []Origin {
 		OriginInternal,
 		OriginExternal,
 	}
+}
+
+type LoggerReporter interface {
+	Logger() log.Logger
 }
 
 type OriginReporter interface {

--- a/structure/validator.go
+++ b/structure/validator.go
@@ -10,6 +10,7 @@ type Validatable interface {
 }
 
 type Validator interface {
+	LoggerReporter
 	OriginReporter
 	SourceReporter
 	MetaReporter

--- a/structure/validator/array_test.go
+++ b/structure/validator/array_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -14,7 +15,7 @@ var _ = Describe("Array", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewArray", func() {

--- a/structure/validator/bool_test.go
+++ b/structure/validator/bool_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -14,7 +15,7 @@ var _ = Describe("Bool", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewBool", func() {

--- a/structure/validator/bytes_test.go
+++ b/structure/validator/bytes_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	"github.com/tidepool-org/platform/structure/base"
 )
@@ -50,6 +51,6 @@ var _ = Describe("Bytes", func() {
 })
 
 func newTestValidator() (structure.Validator, *base.Base) {
-	b := base.New().WithSource(structure.NewPointerSource())
+	b := base.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	return NewValidator(b), b
 }

--- a/structure/validator/float64_test.go
+++ b/structure/validator/float64_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -14,7 +15,7 @@ var _ = Describe("Float64", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewFloat64", func() {

--- a/structure/validator/int_test.go
+++ b/structure/validator/int_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -14,7 +15,7 @@ var _ = Describe("Int", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewInt", func() {

--- a/structure/validator/object_test.go
+++ b/structure/validator/object_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -14,7 +15,7 @@ var _ = Describe("Object", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewObject", func() {

--- a/structure/validator/string_array_test.go
+++ b/structure/validator/string_array_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -17,7 +18,7 @@ var _ = Describe("StringArray", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewStringArray", func() {

--- a/structure/validator/string_test.go
+++ b/structure/validator/string_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
@@ -19,7 +20,7 @@ var _ = Describe("String", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewString", func() {

--- a/structure/validator/time_test.go
+++ b/structure/validator/time_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -17,7 +18,7 @@ var _ = Describe("Time", func() {
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New().WithSource(structure.NewPointerSource())
+		base = structureBase.New(logTest.NewLogger()).WithSource(structure.NewPointerSource())
 	})
 
 	Context("NewTime", func() {

--- a/structure/validator/validator.go
+++ b/structure/validator/validator.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"time"
 
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 )
@@ -11,14 +12,18 @@ type Validator struct {
 	base *structureBase.Base
 }
 
-func New() *Validator {
-	return NewValidator(structureBase.New().WithSource(structure.NewPointerSource()))
+func New(logger log.Logger) *Validator {
+	return NewValidator(structureBase.New(logger).WithSource(structure.NewPointerSource()))
 }
 
 func NewValidator(base *structureBase.Base) *Validator {
 	return &Validator{
 		base: base,
 	}
+}
+
+func (v *Validator) Logger() log.Logger {
+	return v.base.Logger()
 }
 
 func (v *Validator) Origin() structure.Origin {

--- a/structure/validator/validator_test.go
+++ b/structure/validator/validator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/structure"
 	structureBase "github.com/tidepool-org/platform/structure/base"
 	structureTest "github.com/tidepool-org/platform/structure/test"
@@ -14,15 +15,17 @@ import (
 )
 
 var _ = Describe("Validator", func() {
+	var logger *logTest.Logger
 	var base *structureBase.Base
 
 	BeforeEach(func() {
-		base = structureBase.New()
+		logger = logTest.NewLogger()
+		base = structureBase.New(logger)
 	})
 
 	Context("New", func() {
 		It("returns successfully", func() {
-			Expect(structureValidator.New()).ToNot(BeNil())
+			Expect(structureValidator.New(logTest.NewLogger())).ToNot(BeNil())
 		})
 	})
 
@@ -38,6 +41,12 @@ var _ = Describe("Validator", func() {
 		BeforeEach(func() {
 			validator = structureValidator.NewValidator(base)
 			Expect(validator).ToNot(BeNil())
+		})
+
+		Context("Logger", func() {
+			It("returns the logger", func() {
+				Expect(validator.Logger()).To(BeIdenticalTo(logger))
+			})
 		})
 
 		Context("Origin", func() {

--- a/task/client/client.go
+++ b/task/client/client.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/platform"
 	"github.com/tidepool-org/platform/request"
@@ -33,12 +34,12 @@ func (c *Client) ListTasks(ctx context.Context, filter *task.TaskFilter, paginat
 	}
 	if filter == nil {
 		filter = task.NewTaskFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, errors.Wrap(err, "filter is invalid")
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, errors.Wrap(err, "pagination is invalid")
 	}
 
@@ -57,7 +58,7 @@ func (c *Client) CreateTask(ctx context.Context, create *task.TaskCreate) (*task
 	}
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.New("create is invalid")
 	}
 
@@ -99,7 +100,7 @@ func (c *Client) UpdateTask(ctx context.Context, id string, update *task.TaskUpd
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, errors.Wrap(err, "update is invalid")
 	}
 

--- a/task/store/mongo/mongo.go
+++ b/task/store/mongo/mongo.go
@@ -181,10 +181,10 @@ func (t *TaskRepository) EnsureEHRReconcileTask(ctx context.Context) error {
 }
 
 func (t *TaskRepository) ensureTask(ctx context.Context, create *task.TaskCreate) error {
-	tsk, err := task.NewTask(create)
+	tsk, err := task.NewTask(ctx, create)
 	if err != nil {
 		return err
-	} else if err = structureValidator.New().Validate(tsk); err != nil {
+	} else if err = structureValidator.New(log.LoggerFromContext(ctx)).Validate(tsk); err != nil {
 		return fmt.Errorf("task is invalid: %w", err)
 	}
 	if err := t.assertType(t.typeFilter, &tsk.Type); err != nil {
@@ -219,12 +219,12 @@ func (t *TaskRepository) ListTasks(ctx context.Context, filter *task.TaskFilter,
 	}
 	if filter == nil {
 		filter = task.NewTaskFilter()
-	} else if err := structureValidator.New().Validate(filter); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
 		return nil, fmt.Errorf("filter is invalid: %w", err)
 	}
 	if pagination == nil {
 		pagination = page.NewPagination()
-	} else if err := structureValidator.New().Validate(pagination); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(pagination); err != nil {
 		return nil, fmt.Errorf("pagination is invalid: %w", err)
 	}
 	if err := t.assertType(t.typeFilter, filter.Type); err != nil {
@@ -270,10 +270,10 @@ func (t *TaskRepository) CreateTask(ctx context.Context, create *task.TaskCreate
 		return nil, errors.New("context is missing")
 	}
 
-	tsk, err := task.NewTask(create)
+	tsk, err := task.NewTask(ctx, create)
 	if err != nil {
 		return nil, err
-	} else if err = structureValidator.New().Validate(tsk); err != nil {
+	} else if err = structureValidator.New(log.LoggerFromContext(ctx)).Validate(tsk); err != nil {
 		return nil, fmt.Errorf("task is invalid: %w", err)
 	}
 	if err := t.assertType(t.typeFilter, &tsk.Type); err != nil {
@@ -332,7 +332,7 @@ func (t *TaskRepository) UpdateTask(ctx context.Context, id string, update *task
 	}
 	if update == nil {
 		return nil, errors.New("update is missing")
-	} else if err := structureValidator.New().Validate(update); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
 		return nil, fmt.Errorf("update is invalid: %w", err)
 	}
 

--- a/task/store/mongo/mongo_test.go
+++ b/task/store/mongo/mongo_test.go
@@ -5,24 +5,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/testutil"
-	"go.mongodb.org/mongo-driver/bson"
-
-	"errors"
-
-	"github.com/tidepool-org/platform/log"
-	logTest "github.com/tidepool-org/platform/log/test"
-	"github.com/tidepool-org/platform/pointer"
-	"github.com/tidepool-org/platform/task"
-
-	"go.mongodb.org/mongo-driver/mongo"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/pointer"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
+	"github.com/tidepool-org/platform/task"
 	taskStore "github.com/tidepool-org/platform/task/store"
 	taskStoreMongo "github.com/tidepool-org/platform/task/store/mongo"
 )
@@ -137,7 +134,7 @@ var _ = Describe("Mongo", func() {
 
 				BeforeEach(func() {
 					var err error
-					tsk, err = task.NewTask(&task.TaskCreate{
+					tsk, err = task.NewTask(context.Background(), &task.TaskCreate{
 						Name:           pointer.FromString("test"),
 						Type:           "fetch",
 						Priority:       0,
@@ -164,7 +161,7 @@ var _ = Describe("Mongo", func() {
 					BeforeEach(func() {
 						taskStoreMongo.TasksStateTotal.Reset()
 						var err error
-						updated, err = task.NewTask(&task.TaskCreate{
+						updated, err = task.NewTask(context.Background(), &task.TaskCreate{
 							Name:           pointer.FromString("updated"),
 							Type:           "fetch",
 							Priority:       0,

--- a/task/summary/backfillrunner.go
+++ b/task/summary/backfillrunner.go
@@ -165,7 +165,7 @@ func (t *BackfillTaskRunner) Run(ctx context.Context) error {
 	}
 
 	t.context = ctx
-	t.validator = structureValidator.New()
+	t.validator = structureValidator.New(log.LoggerFromContext(ctx))
 
 	t.logger.Debug("Starting User CGM Summary Creation")
 	count, err := t.dataClient.BackfillSummaries(t.context, "cgm")

--- a/task/summary/migrationrunner.go
+++ b/task/summary/migrationrunner.go
@@ -170,7 +170,7 @@ func (t *MigrationTaskRunner) Run(ctx context.Context, batch int) error {
 	}
 
 	t.context = ctx
-	t.validator = structureValidator.New()
+	t.validator = structureValidator.New(log.LoggerFromContext(ctx))
 
 	pagination := page.NewPagination()
 	pagination.Size = batch

--- a/task/summary/updaterunner.go
+++ b/task/summary/updaterunner.go
@@ -174,7 +174,7 @@ func (t *UpdateTaskRunner) Run(ctx context.Context, batch int) error {
 	}
 
 	t.context = ctx
-	t.validator = structureValidator.New()
+	t.validator = structureValidator.New(log.LoggerFromContext(ctx))
 	targetTime := time.Now().UTC().Add(-1 * time.Minute)
 
 	pagination := page.NewPagination()

--- a/task/task.go
+++ b/task/task.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/id"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
@@ -192,10 +193,10 @@ type Task struct {
 	ModifiedTime   *time.Time             `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
 }
 
-func NewTask(create *TaskCreate) (*Task, error) {
+func NewTask(ctx context.Context, create *TaskCreate) (*Task, error) {
 	if create == nil {
 		return nil, errors.New("create is missing")
-	} else if err := structureValidator.New().Validate(create); err != nil {
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
 		return nil, errors.Wrap(err, "create is invalid")
 	}
 

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -8,6 +8,7 @@ import (
 
 	authTest "github.com/tidepool-org/platform/auth/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
@@ -50,7 +51,7 @@ var _ = Describe("User", func() {
 					object := userTest.NewObjectFromUser(expectedDatum, test.ObjectFormatJSON)
 					mutator(object, expectedDatum)
 					datum := &user.User{}
-					errorsTest.ExpectEqual(structureParser.NewObject(&object).Parse(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
 					Expect(datum).To(userTest.MatchUser(expectedDatum))
 				},
 				Entry("succeeds",
@@ -153,7 +154,7 @@ var _ = Describe("User", func() {
 				func(mutator func(datum *user.User), expectedErrors ...error) {
 					datum := userTest.RandomUser()
 					mutator(datum)
-					errorsTest.ExpectEqual(structureValidator.New().Validate(datum), expectedErrors...)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
 				},
 				Entry("succeeds",
 					func(datum *user.User) {},


### PR DESCRIPTION
- Include logger in structure validator, parser, and normalizer
- Update all downstream code
- Update tests to use test logger

This PR looks very large, but really it is just one change, adding a logger to the structure validator, parser, and normalizer. The important change is in the `structure` package, while everything else is just adding a logger to each validator, parser, and normalizer. Sorry, for the size of the PR, but it is really a fairly simple change.

NOTE: This is a part of the overall Dexcom work which will be collected into a final PR for final approval. However, since the work covers a number of different issues, I broke up the development into multiple smaller and more focused PRs. Once all of the smaller PRs are approved, I'll create a final overall PR for approval that will eventually be tested and deployed. (The smaller PRs will not be tested nor deployed.)