### PR TITLE
Minor errors updates

### DIFF
--- a/errors/caller_test.go
+++ b/errors/caller_test.go
@@ -2,7 +2,118 @@ package errors_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/errors"
+	logTest "github.com/tidepool-org/platform/log/test"
+	structureNormalizer "github.com/tidepool-org/platform/structure/normalizer"
+	structureParser "github.com/tidepool-org/platform/structure/parser"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
 
 var _ = Describe("Caller", func() {
+	Context("GetCaller", func() {
+		It("returns the Caller", func() {
+			caller := errors.GetCaller(-1) // Hack to get caller from errors.go
+			Expect(caller).ToNot(BeNil())
+			Expect(caller.Package).To(Equal("github.com/tidepool-org/platform/errors"))
+			Expect(caller.Function).To(Equal("GetCaller"))
+			Expect(caller.File).To(Equal("errors/caller.go"))
+			Expect(caller.Line).To(Equal(19))
+		})
+	})
+
+	Context("Caller", func() {
+		Context("PackageName", func() {
+			It("returns the package name", func() {
+				caller := errors.GetCaller(-1) // Hack to get caller from errors.go
+				Expect(caller).ToNot(BeNil())
+				Expect(caller.PackageName()).To(Equal("errors"))
+			})
+		})
+
+		Context("FileName", func() {
+			It("returns the file name", func() {
+				caller := errors.GetCaller(-1) // Hack to get caller from errors.go
+				Expect(caller).ToNot(BeNil())
+				Expect(caller.FileName()).To(Equal("caller.go"))
+			})
+		})
+
+		Context("Parse", func() {
+			It("successefully parses the data", func() {
+				object := &map[string]any{
+					"package":  "test-package",
+					"function": "test-function",
+					"file":     "test-file",
+					"line":     123,
+				}
+				parser := structureParser.NewObject(logTest.NewLogger(), object)
+				caller := &errors.Caller{}
+				caller.Parse(parser)
+				Expect(caller.Package).To(Equal("test-package"))
+				Expect(caller.Function).To(Equal("test-function"))
+				Expect(caller.File).To(Equal("test-file"))
+				Expect(caller.Line).To(Equal(123))
+				Expect(parser.Error()).ToNot(HaveOccurred())
+			})
+
+			It("reports errors", func() {
+				object := &map[string]any{
+					"package":  true,
+					"function": true,
+					"file":     true,
+					"line":     true,
+				}
+				parser := structureParser.NewObject(logTest.NewLogger(), object)
+				caller := &errors.Caller{}
+				caller.Parse(parser)
+				Expect(caller.Package).To(BeZero())
+				Expect(caller.Function).To(BeZero())
+				Expect(caller.File).To(BeZero())
+				Expect(caller.Line).To(BeZero())
+				Expect(parser.Error()).To(MatchError("type is not string, but bool, type is not string, but bool, type is not string, but bool, type is not int, but bool"))
+			})
+		})
+
+		Context("Validate", func() {
+			It("successfully validates the caller", func() {
+				validator := structureValidator.New(logTest.NewLogger())
+				caller := &errors.Caller{
+					Package:  "test-package",
+					Function: "test-function",
+					File:     "test-file",
+					Line:     123,
+				}
+				caller.Validate(validator)
+				Expect(validator.Error()).ToNot(HaveOccurred())
+			})
+
+			It("reports errors", func() {
+				validator := structureValidator.New(logTest.NewLogger())
+				caller := &errors.Caller{
+					Package:  "",
+					Function: "",
+					File:     "",
+					Line:     -1,
+				}
+				caller.Validate(validator)
+				Expect(validator.Error()).To(MatchError("value is empty, value is empty, value is empty, value -1 is not greater than or equal to 0"))
+			})
+		})
+
+		Context("Normalize", func() {
+			It("successfully normalizes the caller", func() {
+				normalizer := structureNormalizer.New(logTest.NewLogger())
+				caller := &errors.Caller{
+					Package:  "test-package",
+					Function: "test-function",
+					File:     "test-file",
+					Line:     123,
+				}
+				caller.Normalize(normalizer)
+				Expect(normalizer.Error()).ToNot(HaveOccurred())
+			})
+		})
+	})
 })

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,6 +15,11 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+// NOTE: Should only be used with standard library or third-party library errors
+func Is(err error, target error) bool {
+	return errors.Is(err, target)
+}
+
 type Source interface {
 	Parameter() string
 	Pointer() string
@@ -222,6 +227,20 @@ func Append(errs ...error) error {
 			Errors: errors,
 		}
 	}
+}
+
+func First(err error) error {
+	if arrayErr, arrayOK := err.(*array); arrayOK {
+		return arrayErr.First()
+	}
+	return err
+}
+
+func Last(err error) error {
+	if arrayErr, arrayOK := err.(*array); arrayOK {
+		return arrayErr.Last()
+	}
+	return err
 }
 
 func appendErrors(errors []error, err error) []error {
@@ -481,6 +500,20 @@ func (a *array) Sanitize() error {
 	return &array{
 		Errors: errors,
 	}
+}
+
+func (a *array) First() error {
+	if errorsLength := len(a.Errors); errorsLength > 0 {
+		return a.Errors[0]
+	}
+	return nil
+}
+
+func (a *array) Last() error {
+	if errorsLength := len(a.Errors); errorsLength > 0 {
+		return a.Errors[errorsLength-1]
+	}
+	return nil
 }
 
 type object struct {


### PR DESCRIPTION
- Minor errors updates
- Add First and Last function for use with error arrays
- Add and update tests

A few small changes to the `errors` package and a bunch of tests.

NOTE: This is a part of the overall Dexcom work which will be collected into a final PR for final approval. However, since the work covers a number of different issues, I broke up the development into multiple smaller and more focused PRs. Once all of the smaller PRs are approved, I'll create a final overall PR for approval that will eventually be tested and deployed. (The smaller PRs will not be tested nor deployed.)