### PR TITLE
Fix task service shutdown, errors, and task handling

### DIFF
--- a/dexcom/fetch/runner.go
+++ b/dexcom/fetch/runner.go
@@ -105,11 +105,15 @@ func (r *Runner) GetRunnerDeadline() time.Time {
 	return time.Now().Add(TaskDurationMaximum * 3)
 }
 
-func (r *Runner) GetRunnerMaximumDuration() time.Duration {
+func (r *Runner) GetRunnerTimeout() time.Duration {
+	return TaskDurationMaximum * 2
+}
+
+func (r *Runner) GetRunnerDurationMaximum() time.Duration {
 	return TaskDurationMaximum
 }
 
-func (r *Runner) Run(ctx context.Context, tsk *task.Task) bool {
+func (r *Runner) Run(ctx context.Context, tsk *task.Task) {
 	now := time.Now()
 
 	ctx = log.NewContextWithLogger(ctx, r.Logger())
@@ -137,11 +141,6 @@ func (r *Runner) Run(ctx context.Context, tsk *task.Task) bool {
 	if !tsk.IsFailed() {
 		tsk.RepeatAvailableAfter(AvailableAfterDurationMinimum + time.Duration(rand.Int63n(int64(AvailableAfterDurationMaximum-AvailableAfterDurationMinimum+1))))
 	}
-
-	if taskDuration := time.Since(now); taskDuration > TaskDurationMaximum {
-		r.Logger().WithField("taskDuration", taskDuration.Truncate(time.Millisecond).Seconds()).Warn("Task duration exceeds maximum")
-	}
-	return true
 }
 
 func (r *Runner) ignoreAndLogTaskError(tsk *task.Task, err error) {

--- a/ehr/reconcile/runner.go
+++ b/ehr/reconcile/runner.go
@@ -47,22 +47,19 @@ func (r *Runner) GetRunnerDeadline() time.Time {
 	return time.Now().Add(TaskDurationMaximum * 3)
 }
 
-func (r *Runner) GetRunnerMaximumDuration() time.Duration {
+func (r *Runner) GetRunnerTimeout() time.Duration {
+	return TaskDurationMaximum * 2
+}
+
+func (r *Runner) GetRunnerDurationMaximum() time.Duration {
 	return TaskDurationMaximum
 }
 
-func (r *Runner) Run(ctx context.Context, tsk *task.Task) bool {
-	now := time.Now()
+func (r *Runner) Run(ctx context.Context, tsk *task.Task) {
 	tsk.ClearError()
 
 	r.doRun(ctx, tsk)
 	tsk.RepeatAvailableAfter(AvailableAfterDurationMinimum + time.Duration(rand.Int63n(int64(AvailableAfterDurationMaximum-AvailableAfterDurationMinimum+1))))
-
-	if taskDuration := time.Since(now); taskDuration > TaskDurationMaximum {
-		r.logger.WithField("taskDuration", taskDuration.Truncate(time.Millisecond).Seconds()).Warn("Task duration exceeds maximum")
-	}
-
-	return true
 }
 
 func (r *Runner) doRun(ctx context.Context, tsk *task.Task) {

--- a/ehr/sync/runner.go
+++ b/ehr/sync/runner.go
@@ -39,12 +39,15 @@ func (r *Runner) GetRunnerDeadline() time.Time {
 	return time.Now().Add(TaskDurationMaximum * 3)
 }
 
-func (r *Runner) GetRunnerMaximumDuration() time.Duration {
+func (r *Runner) GetRunnerTimeout() time.Duration {
+	return TaskDurationMaximum * 2
+}
+
+func (r *Runner) GetRunnerDurationMaximum() time.Duration {
 	return TaskDurationMaximum
 }
 
-func (r *Runner) Run(ctx context.Context, tsk *task.Task) bool {
-	now := time.Now()
+func (r *Runner) Run(ctx context.Context, tsk *task.Task) {
 	tsk.ClearError()
 
 	r.doRun(ctx, tsk)
@@ -56,12 +59,6 @@ func (r *Runner) Run(ctx context.Context, tsk *task.Task) bool {
 			tsk.RepeatAvailableAfter(OnSuccessAvailableAfterDurationMinimum + time.Duration(rand.Int63n(int64(OnSuccessAvailableAfterDurationMaximum-OnSuccessAvailableAfterDurationMinimum+1))))
 		}
 	}
-
-	if taskDuration := time.Since(now); taskDuration > TaskDurationMaximum {
-		r.logger.WithField("taskDuration", taskDuration.Truncate(time.Millisecond).Seconds()).Warn("Task duration exceeds maximum")
-	}
-
-	return true
 }
 
 func (r *Runner) doRun(ctx context.Context, tsk *task.Task) {

--- a/task/queue/multi.go
+++ b/task/queue/multi.go
@@ -1,8 +1,7 @@
 package queue
 
 import (
-	"fmt"
-
+	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/task/store"
 )
@@ -27,7 +26,7 @@ func NewMultiQueue(cfg *Config, lgr log.Logger, str store.Store) (Queue, error) 
 func (m *MultiQueue) RegisterRunner(runner Runner) error {
 	typ := runner.GetRunnerType()
 	if _, ok := m.queues[typ]; ok {
-		return fmt.Errorf("runner of the same type is already registered")
+		return errors.New("runner of the same type is already registered")
 	}
 
 	str := m.str.WithTypeFilter(typ)

--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -67,10 +67,27 @@ func (c *Config) Validate() error {
 }
 
 type Runner interface {
+
+	// The type of tasks that the runner supports.
 	GetRunnerType() string
+
+	// The time after which the task manager will forcefully reset the task back to pending
+	// and available. This is calculated based upon the current time and a duration significantly
+	// longer that the task duration maximum. Normally this would only be used on a task that
+	// is in the running state even though it is not running (likely due to a system crash or interruption).
 	GetRunnerDeadline() time.Time
-	GetRunnerMaximumDuration() time.Duration
-	Run(ctx context.Context, tsk *task.Task) bool
+
+	// The duration of a task where the task manager will forcefully cancel the task context to interrupt
+	// the task and force completion. This is typically a duration somewhat longer than the task
+	// duration maximum.
+	GetRunnerTimeout() time.Duration
+
+	// The typical duration maximum of the task after which a warning will be displayed.
+	GetRunnerDurationMaximum() time.Duration
+
+	// Execute the specified task within the specified context. The context will be forcefully
+	// canceled after a duration specified by GetRunnerTimeout.
+	Run(ctx context.Context, tsk *task.Task)
 }
 
 type Queue interface {
@@ -85,8 +102,10 @@ type queue struct {
 	workers           int
 	delay             time.Duration
 	runners           map[string]Runner
-	cancelFunc        context.CancelFunc
-	waitGroup         sync.WaitGroup
+	workersCancelFunc context.CancelFunc
+	workersWaitGroup  sync.WaitGroup
+	managerCancelFunc context.CancelFunc
+	managerWaitGroup  sync.WaitGroup
 	workersAvailable  int
 	dispatchChannel   chan *task.Task
 	completionChannel chan *task.Task
@@ -94,8 +113,6 @@ type queue struct {
 	taskRepository    store.TaskRepository
 	iterator          *mongo.Cursor
 }
-
-var _ Queue = &queue{}
 
 func New(cfg *Config, lgr log.Logger, str store.Store) (Queue, error) {
 	if cfg == nil {
@@ -136,22 +153,33 @@ func (q *queue) RegisterRunner(runner Runner) error {
 }
 
 func (q *queue) Start() {
-	if q.cancelFunc == nil {
-		ctx, cancelFunc := context.WithCancel(log.NewContextWithLogger(context.Background(), q.logger))
-		q.cancelFunc = cancelFunc
+	backgroundCtx := log.NewContextWithLogger(context.Background(), q.logger)
+	if q.workersCancelFunc == nil {
+		ctx, workersCancelFunc := context.WithCancel(backgroundCtx)
+		q.workersCancelFunc = workersCancelFunc
 
 		q.startWorkers(ctx)
+	}
+	if q.managerCancelFunc == nil {
+		ctx, managerCancelFunc := context.WithCancel(backgroundCtx)
+		q.managerCancelFunc = managerCancelFunc
+
 		q.startManager(ctx)
 	}
 }
 
 func (q *queue) Stop() {
-	if q.cancelFunc != nil {
-		q.cancelFunc()
-		q.cancelFunc = nil
-
-		q.waitGroup.Wait()
+	if q.workersCancelFunc != nil {
+		q.workersCancelFunc()
+		q.workersCancelFunc = nil
 	}
+	q.workersWaitGroup.Wait()
+
+	if q.managerCancelFunc != nil {
+		q.managerCancelFunc()
+		q.managerCancelFunc = nil
+	}
+	q.managerWaitGroup.Wait()
 }
 
 func (q *queue) startWorkers(ctx context.Context) {
@@ -161,9 +189,9 @@ func (q *queue) startWorkers(ctx context.Context) {
 }
 
 func (q *queue) startWorker(ctx context.Context) {
-	q.waitGroup.Add(1)
+	q.workersWaitGroup.Add(1)
 	go func() {
-		defer q.waitGroup.Done()
+		defer q.workersWaitGroup.Done()
 
 		for {
 			select {
@@ -178,39 +206,41 @@ func (q *queue) startWorker(ctx context.Context) {
 }
 
 func (q *queue) runTask(ctx context.Context, tsk *task.Task) {
-	logger := q.logger.WithField("taskId", tsk.ID)
+	ctx = log.ContextWithField(ctx, "taskId", tsk.ID)
 
 	defer func() {
 		if err := recover(); err != nil {
-			logger.WithFields(log.Fields{"error": err, "stack": string(debug.Stack())}).Error("Unhandled panic")
+			log.LoggerFromContext(ctx).WithFields(log.Fields{"error": err, "stack": string(debug.Stack())}).Error("Unhandled panic")
 			tsk.AppendError(errors.New("unhandled panic"))
 		}
 	}()
 
 	if runner, ok := q.runners[tsk.Type]; ok {
-		status := make(chan bool, 1)
-		go func() {
-			status <- runner.Run(ctx, tsk)
-		}()
-		select {
-		case <-time.After(2 * runner.GetRunnerMaximumDuration()):
-			tsk.AppendError(errors.New("Task timed out"))
-			tsk.RepeatAvailableAfter(2 * runner.GetRunnerMaximumDuration())
-			return
-		case <-status:
-			return
-		}
-	}
 
-	logger.Error("Runner not found for task")
-	tsk.AppendError(errors.New("runner not found for task"))
+		// If runner does not respect its own maximum duration, then enforce a context-based timeout.
+		// This forces the task to cancel via the context.
+		ctx, cancel := context.WithTimeout(ctx, runner.GetRunnerTimeout())
+		defer cancel()
+
+		startTime := time.Now()
+
+		// Run the task via the runner
+		runner.Run(ctx, tsk)
+
+		if taskDuration := time.Since(startTime); taskDuration > runner.GetRunnerDurationMaximum() {
+			log.LoggerFromContext(ctx).WithField("taskDuration", taskDuration.Truncate(time.Millisecond).Seconds()).Warn("Task duration exceeds maximum")
+		}
+	} else {
+		tsk.AppendError(errors.New("runner not found for task"))
+		tsk.SetFailed()
+	}
 }
 
 func (q *queue) startManager(ctx context.Context) {
-	q.waitGroup.Add(1)
+	q.managerWaitGroup.Add(1)
 
 	go func() {
-		defer q.waitGroup.Done()
+		defer q.managerWaitGroup.Done()
 
 		q.startTimer(time.Duration(rand.Int63n(int64(q.delay)) + 1))
 		defer q.stopTimer()
@@ -226,8 +256,15 @@ func (q *queue) startManager(ctx context.Context) {
 			}
 
 			select {
-			case <-ctx.Done():
-				return
+			case <-ctx.Done(): // Drain and complete any interrupted tasks
+				for {
+					select {
+					case tsk := <-q.completionChannel:
+						q.completeTask(ctx, tsk)
+					default:
+						return
+					}
+				}
 			case tsk := <-q.completionChannel:
 				q.stopTimer()
 				q.completeTask(ctx, tsk)
@@ -246,19 +283,22 @@ func (q *queue) unstickTasks(ctx context.Context) {
 		q.logger.WithError(err).Error("Failure in unsticking tasks")
 	}
 	if count > 0 {
-		q.logger.WithField("unstickCount", count).Info("Unstuck Tasks")
+		q.logger.WithField("unstickCount", count).Warn("Unstuck tasks")
 	}
 }
 
 func (q *queue) dispatchTasks(ctx context.Context) time.Duration {
-	defer q.stopPendingIterator()
+	defer q.stopPendingIterator(ctx)
 	for q.workersAvailable > 0 {
-		iter := q.startPendingIterator(ctx)
+		iter, err := q.startPendingIterator(ctx)
+		if err != nil {
+			q.logger.WithError(err).Error("Failure starting pending iterator")
+			return q.delay
+		}
 
 		tsk := &task.Task{}
 		if iter.Next(ctx) {
-			err := iter.Decode(tsk)
-			if err != nil {
+			if err := iter.Decode(tsk); err != nil {
 				q.logger.WithError(err).Error("Failure iterating tasks")
 				return q.delay
 			}
@@ -272,7 +312,7 @@ func (q *queue) dispatchTasks(ctx context.Context) time.Duration {
 }
 
 func (q *queue) dispatchTask(ctx context.Context, tsk *task.Task) {
-	logger := q.logger.WithField("taskId", tsk.ID)
+	ctx = log.ContextWithField(ctx, "taskId", tsk.ID)
 
 	repository := q.store.NewTaskRepository()
 
@@ -285,14 +325,14 @@ func (q *queue) dispatchTask(ctx context.Context, tsk *task.Task) {
 	}
 
 	var err error
-	tsk, err = repository.UpdateFromState(ctx, tsk, task.TaskStatePending)
+	tsk, err = repository.UpdateFromState(context.WithoutCancel(ctx), tsk, task.TaskStatePending)
 	if err != nil {
-		if err == task.AlreadyClaimedTask {
-			logger.Infof("Failure to claim task %s (%s) as it is already in progress or is no longer available.", tsk.Name, tsk.ID)
+		if errors.Is(err, task.AlreadyClaimedTask) {
+			log.LoggerFromContext(ctx).Warnf("Failure to claim task %s (%s) as it is already in progress or is no longer available.", tsk.Name, tsk.ID)
 			return
 		}
 
-		logger.WithError(err).Error("Failure to update state during dispatch task")
+		log.LoggerFromContext(ctx).WithError(err).Error("Failure to update state during dispatch task")
 		return
 	}
 
@@ -301,7 +341,7 @@ func (q *queue) dispatchTask(ctx context.Context, tsk *task.Task) {
 }
 
 func (q *queue) completeTask(ctx context.Context, tsk *task.Task) {
-	logger := q.logger.WithField("taskId", tsk.ID)
+	ctx = log.ContextWithField(ctx, "taskId", tsk.ID)
 
 	q.workersAvailable++
 
@@ -312,13 +352,14 @@ func (q *queue) completeTask(ctx context.Context, tsk *task.Task) {
 	}
 	q.computeState(tsk)
 
-	_, err := repository.UpdateFromState(ctx, tsk, task.TaskStateRunning)
+	// Without cancel to ensure task is updated in the database
+	_, err := repository.UpdateFromState(context.WithoutCancel(ctx), tsk, task.TaskStateRunning)
 	if err != nil {
-		logger.WithError(err).Error("Failure to update state during complete task")
+		log.LoggerFromContext(ctx).WithError(err).Error("Failure to update state during complete task")
 	}
 
 	if tsk.HasError() {
-		logger.WithError(tsk.Error.Error).Error("Error occurred while running task")
+		log.LoggerFromContext(ctx).WithError(tsk.Error.Error).Error("Error occurred while running task")
 	}
 }
 
@@ -327,18 +368,18 @@ func (q *queue) computeState(tsk *task.Task) {
 	case task.TaskStatePending:
 		if tsk.AvailableTime == nil || time.Now().After(*tsk.AvailableTime) {
 			tsk.AppendError(errors.New("pending task requires future available time"))
-			tsk.State = task.TaskStateFailed
+			tsk.SetFailed()
 		}
 	case task.TaskStateRunning:
 		if tsk.HasError() {
-			tsk.State = task.TaskStateFailed
+			tsk.SetFailed()
 		} else {
-			tsk.State = task.TaskStateCompleted
+			tsk.SetCompleted()
 		}
 	case task.TaskStateFailed, task.TaskStateCompleted:
 	default:
 		tsk.AppendError(errors.New("unknown state"))
-		tsk.State = task.TaskStateFailed
+		tsk.SetFailed()
 	}
 }
 
@@ -360,19 +401,25 @@ func (q *queue) stopTimer() {
 	}
 }
 
-func (q *queue) startPendingIterator(ctx context.Context) *mongo.Cursor {
+func (q *queue) startPendingIterator(ctx context.Context) (*mongo.Cursor, error) {
 	if q.taskRepository == nil {
 		q.taskRepository = q.store.NewTaskRepository()
 	}
 	if q.iterator == nil {
-		// TODO: What happens when an error is returned?
-		q.iterator, _ = q.taskRepository.IteratePending(ctx)
+		if iterator, err := q.taskRepository.IteratePending(ctx); err != nil {
+			return nil, err
+		} else {
+			q.iterator = iterator
+		}
 	}
-	return q.iterator
+	return q.iterator, nil
 }
 
-func (q *queue) stopPendingIterator() {
+func (q *queue) stopPendingIterator(ctx context.Context) {
 	if q.iterator != nil {
+		if err := q.iterator.Close(context.WithoutCancel(ctx)); err != nil {
+			q.logger.WithError(err).Warn("failure closing pending iterator")
+		}
 		q.iterator = nil
 	}
 	if q.taskRepository != nil {

--- a/task/queue/test/runner.go
+++ b/task/queue/test/runner.go
@@ -30,17 +30,20 @@ func (c *CountingRunner) GetRunnerDeadline() time.Time {
 	return time.Now().Add(time.Second * 10)
 }
 
-func (c *CountingRunner) GetRunnerMaximumDuration() time.Duration {
+func (c *CountingRunner) GetRunnerTimeout() time.Duration {
+	return time.Second * 5
+}
+
+func (c *CountingRunner) GetRunnerDurationMaximum() time.Duration {
 	return time.Second
 }
 
-func (c *CountingRunner) Run(ctx context.Context, tsk *task.Task) bool {
+func (c *CountingRunner) Run(ctx context.Context, tsk *task.Task) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.count += 1
 	tsk.SetCompleted()
-	return true
 }
 
 func (c *CountingRunner) GetCount() int {

--- a/task/service/service/service.go
+++ b/task/service/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/tidepool-org/platform/clinics"
 	"github.com/tidepool-org/platform/ehr/reconcile"
@@ -78,15 +77,16 @@ func (s *Service) Initialize(provider application.Provider) error {
 }
 
 func (s *Service) Terminate() {
-	s.Authenticated.Terminate()
-
 	s.terminateRouter()
 	s.terminateTaskQueue()
+	s.terminateClinicsClient()
 	s.terminateDexcomClient()
 	s.terminateDataSourceClient()
 	s.terminateDataClient()
 	s.terminateTaskClient()
 	s.terminateTaskStore()
+
+	s.Authenticated.Terminate()
 }
 
 func (s *Service) TaskStore() store.Store {
@@ -269,6 +269,13 @@ func (s *Service) initializeClinicsClient() error {
 	return nil
 }
 
+func (s *Service) terminateClinicsClient() {
+	if s.clinicsClient != nil {
+		s.Logger().Debug("Destroying clinics client")
+		s.clinicsClient = nil
+	}
+}
+
 func (s *Service) initializeTaskQueue() error {
 	s.Logger().Debug("Loading task queue config")
 
@@ -287,6 +294,7 @@ func (s *Service) initializeTaskQueue() error {
 	s.taskQueue = taskQueue
 
 	var runners []queue.Runner
+
 	if s.dexcomClient != nil {
 		s.Logger().Debug("Creating dexcom fetch runner")
 
@@ -306,23 +314,31 @@ func (s *Service) initializeTaskQueue() error {
 	}
 	runners = append(runners, summaryUpdateRnnr)
 
+	s.Logger().Debug("Creating summary backfill runner")
+
 	summaryBackfillRnnr, summaryBackfillRnnrErr := summaryUpdate.NewBackfillRunner(s.Logger(), s.VersionReporter(), s.AuthClient(), s.dataClient)
 	if summaryBackfillRnnrErr != nil {
 		return errors.Wrap(summaryBackfillRnnrErr, "unable to create summary backfill runner")
 	}
 	runners = append(runners, summaryBackfillRnnr)
 
+	s.Logger().Debug("Creating summary migration runner")
+
 	summaryMigrationRnnr, summaryMigrationRnnrErr := summaryUpdate.NewMigrationRunner(s.Logger(), s.VersionReporter(), s.AuthClient(), s.dataClient)
 	if summaryMigrationRnnrErr != nil {
 		return errors.Wrap(summaryMigrationRnnrErr, "unable to create summary migration runner")
 	}
-	taskQueue.RegisterRunner(summaryMigrationRnnr)
+	runners = append(runners, summaryMigrationRnnr)
+
+	s.Logger().Debug("Creating ehr reconcile runner")
 
 	ehrReconcileRnnr, err := reconcile.NewRunner(s.AuthClient(), s.clinicsClient, s.taskClient, s.Logger())
 	if err != nil {
 		return errors.Wrap(err, "unable to create ehr reconcile runner")
 	}
 	runners = append(runners, ehrReconcileRnnr)
+
+	s.Logger().Debug("Creating ehr sync runner")
 
 	ehrSyncRnnr, err := sync.NewRunner(s.clinicsClient, s.Logger())
 	if err != nil {
@@ -333,7 +349,7 @@ func (s *Service) initializeTaskQueue() error {
 	for _, r := range runners {
 		r := r
 		if err := taskQueue.RegisterRunner(r); err != nil {
-			return fmt.Errorf("unable to register runner %s: %w", r.GetRunnerType(), err)
+			return errors.Wrapf(err, "unable to register runner %s", r.GetRunnerType())
 		}
 	}
 

--- a/task/summary/migrationrunner.go
+++ b/task/summary/migrationrunner.go
@@ -68,7 +68,11 @@ func (r *MigrationRunner) GetRunnerDeadline() time.Time {
 	return time.Now().Add(MigrationTaskDurationMaximum * 3)
 }
 
-func (r *MigrationRunner) GetRunnerMaximumDuration() time.Duration {
+func (r *MigrationRunner) GetRunnerTimeout() time.Duration {
+	return MigrationTaskDurationMaximum * 2
+}
+
+func (r *MigrationRunner) GetRunnerDurationMaximum() time.Duration {
 	return MigrationTaskDurationMaximum
 }
 
@@ -111,9 +115,7 @@ func (r *MigrationRunner) GetConfig(tsk *task.Task) TaskConfiguration {
 	return config
 }
 
-func (r *MigrationRunner) Run(ctx context.Context, tsk *task.Task) bool {
-	now := time.Now()
-
+func (r *MigrationRunner) Run(ctx context.Context, tsk *task.Task) {
 	ctx = log.NewContextWithLogger(ctx, r.logger)
 	ctx = auth.NewContextWithServerSessionTokenProvider(ctx, r.authClient)
 
@@ -130,12 +132,6 @@ func (r *MigrationRunner) Run(ctx context.Context, tsk *task.Task) bool {
 	if !tsk.IsFailed() {
 		tsk.RepeatAvailableAfter(r.GenerateNextTime(config.Interval))
 	}
-
-	if taskDuration := time.Since(now); taskDuration > UpdateTaskDurationMaximum {
-		r.logger.WithField("taskDuration", taskDuration.Truncate(time.Millisecond).Seconds()).Warn("Task duration exceeds maximum")
-	}
-
-	return true
 }
 
 type MigrationTaskRunner struct {

--- a/task/summary/updaterunner.go
+++ b/task/summary/updaterunner.go
@@ -72,7 +72,11 @@ func (r *UpdateRunner) GetRunnerDeadline() time.Time {
 	return time.Now().Add(UpdateTaskDurationMaximum * 3)
 }
 
-func (r *UpdateRunner) GetRunnerMaximumDuration() time.Duration {
+func (r *UpdateRunner) GetRunnerTimeout() time.Duration {
+	return UpdateTaskDurationMaximum * 2
+}
+
+func (r *UpdateRunner) GetRunnerDurationMaximum() time.Duration {
 	return UpdateTaskDurationMaximum
 }
 
@@ -115,9 +119,7 @@ func (r *UpdateRunner) GetConfig(tsk *task.Task) TaskConfiguration {
 	return config
 }
 
-func (r *UpdateRunner) Run(ctx context.Context, tsk *task.Task) bool {
-	now := time.Now()
-
+func (r *UpdateRunner) Run(ctx context.Context, tsk *task.Task) {
 	ctx = log.NewContextWithLogger(ctx, r.logger)
 	ctx = auth.NewContextWithServerSessionTokenProvider(ctx, r.authClient)
 
@@ -134,12 +136,6 @@ func (r *UpdateRunner) Run(ctx context.Context, tsk *task.Task) bool {
 	if !tsk.IsFailed() {
 		tsk.RepeatAvailableAfter(r.GenerateNextTime(config.Interval))
 	}
-
-	if taskDuration := time.Since(now); taskDuration > UpdateTaskDurationMaximum {
-		r.logger.WithField("taskDuration", taskDuration.Truncate(time.Millisecond).Seconds()).Warn("Task duration exceeds maximum")
-	}
-
-	return true
 }
 
 type UpdateTaskRunner struct {

--- a/task/task.go
+++ b/task/task.go
@@ -306,6 +306,13 @@ func (t *Task) HasError() bool {
 	return t.Error != nil && t.Error.Error != nil
 }
 
+func (t *Task) GetError() error {
+	if t.Error != nil {
+		return t.Error.Error
+	}
+	return nil
+}
+
 func (t *Task) AppendError(err error) {
 	if err != nil {
 		if t.Error == nil {


### PR DESCRIPTION
- Use context deadline to forcibly cancel tasks at extended timeout
- Allow task queue shutdown to fully process any outstanding tasks
- Separate task queue shutdown into worker and manager groups
- Ensure critical database updates are not affected by context cancel
- Fix task service termination
- Fix pending iterator usage and error handling
- Use platform errors
- Minor logging updates
- Update test runner

The existing code that detected a long running tasks (at 2 times the runner maximum duration) would simple update the task in the database to `pending` and available. This inadvertently caused the same task to be run again while the long running task was still running. This yielded a number of errors. The code was updated to cancel the context on long running tasks, which would force long running task to actually stop cleanly.

When the current task queue implementation was signaled to shutdown it would cancel the common context for the worker routines and the manager routine. The manager routine is responsible for taking finished tasks and storing the task in the database. Upon shutdown, however, many times the manager routine would exit before one or more of the work routines and so those tasks would not be updated in the database (and, thus, left permanently in the `running` state - this was why the "unstick tasks" code was written). The code was updated to separate out two cancel functions and two wait groups (one for workers, one for manager) and allow the manager to fully handle all of the worker tasks (saving them to the database) before itself shutdown. Unless there is a crash, there should no longer be forever `running` tasks.

The task manager did not protect critical database operations (such as saving the final state of a canceled task) from a context cancel. The code was updated to protect those critical database operations from a cancel.

Also, some smaller changes to the task-related code.
 
NOTE: This is a part of the overall Dexcom work which will be collected into a final PR for final approval. However, since the work covers a number of different issues, I broke up the development into multiple smaller and more focused PRs. Once all of the smaller PRs are approved, I'll create a final overall PR for approval that will eventually be tested and deployed. (The smaller PRs will not be tested nor deployed.)