### PR TITLE
update to match changed mongodb version scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ cache:
     - $HOME/.cache/go-build
 
 before_install:
-  - sudo apt update
-  - sudo apt install -y docker-buildx mongodb-org=${MONGODB} mongodb-org-database=${MONGODB} mongodb-org-server=${MONGODB} mongodb-mongosh=${MONGOSH} mongodb-org-mongos=${MONGODB} mongodb-org-tools=${MONGODB}
+  - sudo apt-get update
+  - sudo apt-get install --allow-downgrades -y docker-buildx-plugin mongodb-org=${MONGODB} mongodb-org-database=${MONGODB} mongodb-org-server=${MONGODB} mongodb-mongosh=${MONGOSH} mongodb-org-mongos=${MONGODB} mongodb-org-tools
   - mkdir /tmp/data
   - /usr/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --replSet rs0 --logpath ${PWD}/mongod.log &> /dev/null &
   - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
@@ -28,8 +28,8 @@ before_install:
 addons:
   apt:
     sources:
-      - sourceline: 'deb https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse'
-        key_url: 'https://pgp.mongodb.com/server-7.0.asc'
+      - sourceline: 'deb https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse'
+        key_url: 'https://pgp.mongodb.com/server-6.0.asc'
   artifacts:
     s3_region: us-west-2
     paths:


### PR DESCRIPTION
As far as we can tell, travis has updated some of the packages in their jammy
image. Notably mongodb's version got bumped up (we actually have to downgrade
now), and their version of docker was bumped, which causes us to have to
install the buildx plugin via a different package (seems they have both the
ubuntu apt sources and the docker.com apt sources which somehow used to play
nice until now?)

In addition we were using the mongo 7.x repo despite installing 6.x. I'm not
sure how that ever worked, but they've been put back into sync.
