### PR TITLE
have generic raw object for units and value

### DIFF
--- a/data/blood/glucose/glucose.go
+++ b/data/blood/glucose/glucose.go
@@ -67,3 +67,14 @@ func NormalizeValueForUnits(value *float64, units *string) *float64 {
 	}
 	return value
 }
+
+func NormalizeValueForUnitsWithFullPrecision(value *float64, units *string) *float64 {
+	if value != nil && units != nil {
+		switch *units {
+		case MgdL, Mgdl:
+			floatValue := *value / MmolLToMgdLConversionFactor
+			return &floatValue
+		}
+	}
+	return value
+}

--- a/data/blood/glucose/glucose_test.go
+++ b/data/blood/glucose/glucose_test.go
@@ -125,4 +125,28 @@ var _ = Describe("Glucose", func() {
 			}
 		})
 	})
+	Context("NormalizeValueForUnitsWithFullPrecision", func() {
+		DescribeTable("given value and units",
+			func(value *float64, units *string, expectedValue *float64) {
+				actualValue := glucose.NormalizeValueForUnitsWithFullPrecision(value, units)
+				if expectedValue == nil {
+					Expect(actualValue).To(BeNil())
+				} else {
+					Expect(actualValue).ToNot(BeNil())
+					Expect(*actualValue).To(Equal(*expectedValue))
+				}
+			},
+			Entry("returns nil for nil value", nil, pointer.FromString("mmol/L"), nil),
+			Entry("returns unchanged value for nil units", pointer.FromFloat64(10.0), nil, pointer.FromFloat64(10.0)),
+			Entry("returns unchanged value for unknown units", pointer.FromFloat64(10.0), pointer.FromString("unknown"), pointer.FromFloat64(10.0)),
+			Entry("returns unchanged value for mmol/L units", pointer.FromFloat64(10.0), pointer.FromString("mmol/L"), pointer.FromFloat64(10.0)),
+			Entry("returns unchanged value for mmol/l units", pointer.FromFloat64(10.0), pointer.FromString("mmol/l"), pointer.FromFloat64(10.0)),
+
+			Entry("returns converted value for mg/dL units", pointer.FromFloat64(140.0), pointer.FromString("mg/dL"), pointer.FromFloat64(7.771047187463747)),
+			Entry("returns converted value for mg/dL units", pointer.FromFloat64(100.0), pointer.FromString("mg/dL"), pointer.FromFloat64(5.550747991045533)),
+			Entry("returns converted value for mg/dl units", pointer.FromFloat64(80.0), pointer.FromString("mg/dl"), pointer.FromFloat64(4.440598392836427)),
+			Entry("returns converted value for mg/dl units", pointer.FromFloat64(69.0), pointer.FromString("mg/dl"), pointer.FromFloat64(3.830016113821418)),
+			Entry("returns converted value for mg/dl units", pointer.FromFloat64(50.0), pointer.FromString("mg/dl"), pointer.FromFloat64(2.7753739955227665)),
+		)
+	})
 })

--- a/data/blood/glucose/test/glucose.go
+++ b/data/blood/glucose/test/glucose.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/onsi/gomega"
+
 	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/metadata"
 	"github.com/tidepool-org/platform/test"

--- a/data/blood/glucose/test/glucose.go
+++ b/data/blood/glucose/test/glucose.go
@@ -1,10 +1,30 @@
 package test
 
 import (
+	"github.com/onsi/gomega"
 	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
+	"github.com/tidepool-org/platform/metadata"
 	"github.com/tidepool-org/platform/test"
 )
 
 func RandomUnits() string {
 	return test.RandomStringFromArray(dataBloodGlucose.Units())
+}
+
+func ExpectRaw(raw *metadata.Metadata, expectedRaw *metadata.Metadata) {
+	if expectedRaw != nil {
+		gomega.Expect(raw).ToNot(gomega.BeNil())
+		if expectedRaw.Get("units") == nil {
+			gomega.Expect(raw.Get("units")).To(gomega.BeNil())
+		} else {
+			gomega.Expect(raw.Get("units")).To(gomega.Equal(expectedRaw.Get("units")))
+		}
+		if expectedRaw.Get("value") == nil {
+			gomega.Expect(raw.Get("value")).To(gomega.BeNil())
+		} else {
+			gomega.Expect(raw.Get("value")).To(gomega.Equal(expectedRaw.Get("value")))
+		}
+	} else {
+		gomega.Expect(raw).To(gomega.BeNil())
+	}
 }

--- a/data/types/blood/blood.go
+++ b/data/types/blood/blood.go
@@ -54,7 +54,7 @@ func (b *Blood) LegacyIdentityFields() ([]string, error) {
 	)
 }
 
-func (b *Blood) GetRawUnitsAndValue() (*string, *float64, error) {
+func (b *Blood) GetRawValueAndUnits() (*float64, *string, error) {
 	if b.Raw == nil {
 		return nil, nil, errors.New("raw data is missing")
 	}
@@ -79,11 +79,11 @@ func (b *Blood) GetRawUnitsAndValue() (*string, *float64, error) {
 		return nil, nil, errors.New("raw value is invalid")
 	}
 
-	return &units, &value, nil
+	return &value, &units, nil
 
 }
 
-func (b *Blood) SetRawUnitsAndValue(units *string, value *float64) {
+func (b *Blood) SetRawValueAndUnits(value *float64, units *string) {
 	if b.Raw == nil {
 		b.Raw = metadata.NewMetadata()
 	}

--- a/data/types/blood/glucose/selfmonitored/selfmonitored.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored.go
@@ -6,7 +6,6 @@ import (
 	"github.com/tidepool-org/platform/data"
 	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/data/types/blood/glucose"
-	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 )
 
@@ -68,13 +67,9 @@ func (s *SelfMonitored) Normalize(normalizer data.Normalizer) {
 	}
 
 	if normalizer.Origin() == structure.OriginExternal {
-
-		rawUnits := pointer.CloneString(s.Units)
-		rawValue := pointer.CloneFloat64(s.Value)
-		s.SetRawUnitsAndValue(rawUnits, rawValue)
-
-		s.Units = dataBloodGlucose.NormalizeUnits(rawUnits)
-		s.Value = dataBloodGlucose.NormalizeValueForUnits(rawValue, rawUnits)
+		s.SetRawValueAndUnits(s.Value, s.Units)
+		s.Value = dataBloodGlucose.NormalizeValueForUnits(s.Value, s.Units)
+		s.Units = dataBloodGlucose.NormalizeUnits(s.Units)
 	}
 }
 
@@ -83,7 +78,7 @@ func (s *SelfMonitored) LegacyIdentityFields() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	units, value, err := s.GetRawUnitsAndValue()
+	value, units, err := s.GetRawValueAndUnits()
 	if err != nil {
 		return nil, err
 	}

--- a/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
@@ -559,7 +559,7 @@ var _ = Describe("SelfMonitored", func() {
 			It("returns the expected legacy identity fields", func() {
 				legacyIdentityFields, err := datum.LegacyIdentityFields()
 				Expect(err).ToNot(HaveOccurred())
-				units, value, err := datum.GetRawUnitsAndValue()
+				value, units, err := datum.GetRawValueAndUnits()
 				Expect(err).ToNot(HaveOccurred())
 				fullPrecisionValue := dataBloodGlucose.NormalizeValueForUnitsWithFullPrecision(value, units)
 				Expect(legacyIdentityFields).To(Equal([]string{datum.Type, *datum.DeviceID, (*datum.Time).Format(types.LegacyFieldTimeFormat), strconv.FormatFloat(*fullPrecisionValue, 'f', -1, 64)}))

--- a/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
+++ b/data/types/blood/glucose/selfmonitored/selfmonitored_test.go
@@ -7,13 +7,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	dataBloodGlucoseTest "github.com/tidepool-org/platform/data/blood/glucose/test"
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/data/types/blood/glucose/selfmonitored"
+	"github.com/tidepool-org/platform/metadata"
+
 	dataTypesBloodGlucoseTest "github.com/tidepool-org/platform/data/types/blood/glucose/test"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
+	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
@@ -73,6 +77,7 @@ var _ = Describe("SelfMonitored", func() {
 			Expect(datum.Units).To(BeNil())
 			Expect(datum.Value).To(BeNil())
 			Expect(datum.SubType).To(BeNil())
+			Expect(datum.Raw).To(BeNil())
 		})
 	})
 
@@ -298,6 +303,7 @@ var _ = Describe("SelfMonitored", func() {
 						datum.Normalize(normalizer.WithOrigin(origin))
 						Expect(normalizer.Error()).To(BeNil())
 						Expect(normalizer.Data()).To(BeEmpty())
+						expectedDatum.Raw = metadataTest.CloneMetadata(datum.Raw)
 						if expectator != nil {
 							expectator(datum, expectedDatum, units)
 						}
@@ -352,8 +358,9 @@ var _ = Describe("SelfMonitored", func() {
 			)
 
 			DescribeTable("normalizes the datum with origin external",
-				func(units *string, mutator func(datum *selfmonitored.SelfMonitored, units *string), expectator func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string)) {
+				func(units *string, mutator func(datum *selfmonitored.SelfMonitored, units *string), expectator func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64)) {
 					datum := NewSelfMonitored(units)
+					originalValue := pointer.CloneFloat64(datum.Value)
 					mutator(datum, units)
 					expectedDatum := CloneSelfMonitored(datum)
 					normalizer := dataNormalizer.New()
@@ -361,8 +368,9 @@ var _ = Describe("SelfMonitored", func() {
 					datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 					Expect(normalizer.Error()).To(BeNil())
 					Expect(normalizer.Data()).To(BeEmpty())
+					expectedDatum.Raw = metadataTest.CloneMetadata(datum.Raw)
 					if expectator != nil {
-						expectator(datum, expectedDatum, units)
+						expectator(datum, expectedDatum, units, originalValue)
 					}
 					Expect(datum).To(Equal(expectedDatum))
 				},
@@ -379,45 +387,52 @@ var _ = Describe("SelfMonitored", func() {
 				Entry("modifies the datum; units mmol/l",
 					pointer.FromString("mmol/l"),
 					func(datum *selfmonitored.SelfMonitored, units *string) {},
-					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string) {
+					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64) {
 						dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, &metadata.Metadata{"units": *units, "value": *value})
 					},
 				),
 				Entry("modifies the datum; units mmol/l; value missing",
 					pointer.FromString("mmol/l"),
 					func(datum *selfmonitored.SelfMonitored, units *string) { datum.Value = nil },
-					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string) {
+					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64) {
 						dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, &metadata.Metadata{"units": *units})
 					},
 				),
 				Entry("modifies the datum; units mg/dL",
 					pointer.FromString("mg/dL"),
 					func(datum *selfmonitored.SelfMonitored, units *string) {},
-					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string) {
+					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64) {
 						dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
 						dataBloodGlucoseTest.ExpectNormalizedValue(datum.Value, expectedDatum.Value, units)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, &metadata.Metadata{"units": *units, "value": *value})
 					},
 				),
 				Entry("modifies the datum; units mg/dL; value missing",
 					pointer.FromString("mg/dL"),
 					func(datum *selfmonitored.SelfMonitored, units *string) { datum.Value = nil },
-					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string) {
+					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64) {
 						dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, expectedDatum.Raw)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, &metadata.Metadata{"units": *units})
 					},
 				),
 				Entry("modifies the datum; units mg/dl",
 					pointer.FromString("mg/dl"),
 					func(datum *selfmonitored.SelfMonitored, units *string) {},
-					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string) {
+					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64) {
 						dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
 						dataBloodGlucoseTest.ExpectNormalizedValue(datum.Value, expectedDatum.Value, units)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, &metadata.Metadata{"units": *units, "value": *value})
 					},
 				),
 				Entry("modifies the datum; units mg/dl; value missing",
 					pointer.FromString("mg/dl"),
 					func(datum *selfmonitored.SelfMonitored, units *string) { datum.Value = nil },
-					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string) {
+					func(datum *selfmonitored.SelfMonitored, expectedDatum *selfmonitored.SelfMonitored, units *string, value *float64) {
 						dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
+						dataBloodGlucoseTest.ExpectRaw(datum.Raw, &metadata.Metadata{"units": *units, "value": nil})
 					},
 				),
 			)
@@ -486,7 +501,10 @@ var _ = Describe("SelfMonitored", func() {
 			var datum *selfmonitored.SelfMonitored
 
 			BeforeEach(func() {
-				datum = NewSelfMonitored(pointer.FromString("mmol/l"))
+				datum = NewSelfMonitored(pointer.FromString("mg/dl"))
+				normalizer := dataNormalizer.New()
+				Expect(normalizer).ToNot(BeNil())
+				datum.Normalize(normalizer.WithOrigin(structure.OriginExternal))
 			})
 
 			It("returns error if device id is missing", func() {
@@ -517,17 +535,34 @@ var _ = Describe("SelfMonitored", func() {
 				Expect(identityFields).To(BeEmpty())
 			})
 
-			It("returns error if value is missing", func() {
-				datum.Value = nil
+			It("returns error if raw is missing", func() {
+				datum.Raw = nil
 				identityFields, err := datum.LegacyIdentityFields()
-				Expect(err).To(MatchError("value is missing"))
+				Expect(err.Error()).To(Equal("raw data is missing"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if raw value is missing", func() {
+				datum.Raw.Delete("value")
+				identityFields, err := datum.LegacyIdentityFields()
+				Expect(err.Error()).To(Equal("raw value is missing"))
+				Expect(identityFields).To(BeEmpty())
+			})
+
+			It("returns error if raw units are missing", func() {
+				datum.Raw.Delete("units")
+				identityFields, err := datum.LegacyIdentityFields()
+				Expect(err.Error()).To(Equal("raw units are missing"))
 				Expect(identityFields).To(BeEmpty())
 			})
 
 			It("returns the expected legacy identity fields", func() {
 				legacyIdentityFields, err := datum.LegacyIdentityFields()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(legacyIdentityFields).To(Equal([]string{datum.Type, *datum.DeviceID, (*datum.Time).Format(types.LegacyFieldTimeFormat), strconv.FormatFloat(*datum.Value, 'f', -1, 64)}))
+				units, value, err := datum.GetRawUnitsAndValue()
+				Expect(err).ToNot(HaveOccurred())
+				fullPrecisionValue := dataBloodGlucose.NormalizeValueForUnitsWithFullPrecision(value, units)
+				Expect(legacyIdentityFields).To(Equal([]string{datum.Type, *datum.DeviceID, (*datum.Time).Format(types.LegacyFieldTimeFormat), strconv.FormatFloat(*fullPrecisionValue, 'f', -1, 64)}))
 			})
 		})
 	})

--- a/data/types/blood/test/blood.go
+++ b/data/types/blood/test/blood.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tidepool-org/platform/data/types/blood"
 	dataTypesTest "github.com/tidepool-org/platform/data/types/test"
+	metadataTest "github.com/tidepool-org/platform/metadata/test"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
@@ -25,5 +26,6 @@ func CloneBlood(datum *blood.Blood) *blood.Blood {
 	clone.Base = *dataTypesTest.CloneBase(&datum.Base)
 	clone.Units = pointer.CloneString(datum.Units)
 	clone.Value = pointer.CloneFloat64(datum.Value)
+	clone.Raw = metadataTest.CloneMetadata(datum.Raw)
 	return clone
 }


### PR DESCRIPTION
use a generic object to store raw units and value for SMBG. Use the raw details to generate the legacy identity 