### PR TITLE
add a fallback for Makefile's git SHA checksum calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ else
 	VERSION_BASE:=$(shell git describe --abbrev=0 --tags 2> /dev/null || echo 'v0.0.0')
 endif
 VERSION_BASE:=$(VERSION_BASE:v%=%)
-VERSION_SHORT_COMMIT:=$(shell git rev-parse --short HEAD)
-VERSION_FULL_COMMIT:=$(shell git rev-parse HEAD)
+VERSION_SHORT_COMMIT:=$(shell git rev-parse --short HEAD || echo "dev")
+VERSION_FULL_COMMIT:=$(shell git rev-parse HEAD || echo "dev")
 VERSION_PACKAGE:=$(REPOSITORY_PACKAGE)/application
 
 GO_BUILD_FLAGS:=-buildvcs=false


### PR DESCRIPTION
Under certain conditions (my custom Tilt setup), when Tilt tries to build
platform services, it ignores the .git directory, which causes calculations of
the git SHA checksums to be empty. The data service refuses to start without
some value. This change provides a fallback in the event that no git
information is available.

This shouldn't affect any of our existing build/deployment processes, which
obviously do have git values included, so if you notice anything different,
let me know.