### PR TITLE
add a topic shifting retry mechanism for care partner alerts

### DIFF
--- a/alerts/client.go
+++ b/alerts/client.go
@@ -44,7 +44,7 @@ type PlatformClient interface {
 		requestBody interface{}, responseBody interface{}, inspectors ...request.ResponseInspector) error
 }
 
-// TokenProvider retrieves session tokens for calling the alerts API.
+// TokenProvider retrieves session tokens needed for calling the alerts API.
 //
 // client.External is one implementation
 type TokenProvider interface {

--- a/data/events/alerts.go
+++ b/data/events/alerts.go
@@ -52,9 +52,9 @@ func (c *Consumer) Consume(ctx context.Context,
 	}
 
 	switch {
-	case strings.HasSuffix(msg.Topic, ".data.alerts"):
+	case strings.Contains(msg.Topic, ".data.alerts"):
 		return c.consumeAlertsConfigs(ctx, session, msg)
-	case strings.HasSuffix(msg.Topic, ".data.deviceData.alerts"):
+	case strings.Contains(msg.Topic, ".data.deviceData.alerts"):
 		return c.consumeDeviceData(ctx, session, msg)
 	default:
 		c.logger(ctx).WithField("topic", msg.Topic).

--- a/data/events/events.go
+++ b/data/events/events.go
@@ -3,7 +3,7 @@ package events
 import (
 	"context"
 	"fmt"
-	"log/slog"
+	"os"
 	"sync"
 	"time"
 
@@ -17,6 +17,7 @@ import (
 	summaryStore "github.com/tidepool-org/platform/data/summary/store"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
+	logjson "github.com/tidepool-org/platform/log/json"
 )
 
 type userDeletionEventsHandler struct {
@@ -76,17 +77,25 @@ const AlertsEventRetries = 1000
 // AlertsEventConsumptionTimeout is the maximum time to process an alerts event.
 const AlertsEventConsumptionTimeout = 30 * time.Second
 
-// SaramaRunner interfaces between events.Runner and go-common's
-// asyncevents.SaramaEventsConsumer.
+// SaramaRunner interfaces between [events.Runner] and go-common's
+// [asyncevents.SaramaEventsConsumer].
+//
+// This means providing Initialize(), Run(), and Terminate() to satisfy events.Runner, while
+// under the hood calling SaramaEventConsumer's Run(), and canceling its Context as
+// appropriate.
 type SaramaRunner struct {
-	EventsRunner SaramaEventsRunner
-	Config       SaramaRunnerConfig
+	eventsRunner SaramaEventsRunner
 	cancelCtx    context.CancelFunc
 	cancelMu     sync.Mutex
 }
 
-// SaramaEventsRunner is implemented by go-common's
-// asyncevents.SaramaEventsRunner.
+func NewSaramaRunner(eventsRunner SaramaEventsRunner) *SaramaRunner {
+	return &SaramaRunner{
+		eventsRunner: eventsRunner,
+	}
+}
+
+// SaramaEventsRunner is implemented by go-common's [asyncevents.SaramaEventsRunner].
 type SaramaEventsRunner interface {
 	Run(ctx context.Context) error
 }
@@ -99,45 +108,19 @@ type SaramaEventsRunner interface {
 type SaramaRunnerConfig struct {
 	Brokers         []string
 	GroupID         string
-	Logger          log.Logger
 	Topics          []string
 	MessageConsumer asyncevents.SaramaMessageConsumer
 
 	Sarama *sarama.Config
 }
 
-func (r *SaramaRunner) Initialize() error {
-	group, err := sarama.NewConsumerGroup(r.Config.Brokers, r.Config.GroupID, r.Config.Sarama)
-	if err != nil {
-		return errors.Wrap(err, "Unable to build sarama consumer group")
-	}
-	handler := asyncevents.NewSaramaConsumerGroupHandler(&asyncevents.NTimesRetryingConsumer{
-		Consumer: r.Config.MessageConsumer,
-		Delay:    CappedExponentialBinaryDelay(AlertsEventRetryDelayMaximum),
-		Times:    AlertsEventRetries,
-		Logger:   r.logger,
-	}, AlertsEventConsumptionTimeout)
-	r.EventsRunner = asyncevents.NewSaramaEventsConsumer(group, handler, r.Config.Topics...)
-	return nil
-}
-
-func (r *SaramaRunner) logger(ctx context.Context) asyncevents.Logger {
-	// Prefer a logger from the context.
-	if ctxLogger := log.LoggerFromContext(ctx); ctxLogger != nil {
-		return &log.GoCommonAdapter{Logger: ctxLogger}
-	}
-	if r.Config.Logger != nil {
-		return &log.GoCommonAdapter{Logger: r.Config.Logger}
-	}
-	// No known log.Logger could be found, default to slog.
-	return slog.Default()
-}
+func (r *SaramaRunner) Initialize() error { return nil }
 
 // Run adapts platform's event.Runner to work with go-common's
 // asyncevents.SaramaEventsConsumer.
 func (r *SaramaRunner) Run() error {
-	if r.EventsRunner == nil {
-		return errors.New("Unable to run SaramaRunner, EventsRunner is nil")
+	if r.eventsRunner == nil {
+		return errors.New("Unable to run SaramaRunner, eventsRunner is nil")
 	}
 
 	r.cancelMu.Lock()
@@ -153,7 +136,7 @@ func (r *SaramaRunner) Run() error {
 	if err != nil {
 		return err
 	}
-	if err := r.EventsRunner.Run(ctx); err != nil {
+	if err := r.eventsRunner.Run(ctx); err != nil {
 		return errors.Wrap(err, "Unable to Run SaramaRunner")
 	}
 	return nil
@@ -195,4 +178,281 @@ func (c *AlertsEventsConsumer) Consume(ctx context.Context,
 		return err
 	}
 	return nil
+}
+
+// CascadingSaramaEventsRunner manages multiple sarama consumer groups to execute a
+// topic-cascading retry process.
+//
+// The topic names are generated from Config.Topics combined with Delays. If given a single
+// topic "updates", and delays: 0s, 1s, and 5s, then the following topics will be consumed:
+// updates, updates-retry-1s, updates-retry-5s. The consumer of the updates-retry-5s topic
+// will write failed messages to updates-dead.
+//
+// The inspiration for this system was drawn from
+// https://www.uber.com/blog/reliable-reprocessing/
+type CascadingSaramaEventsRunner struct {
+	Config         SaramaRunnerConfig
+	Delays         []time.Duration
+	Logger         log.Logger
+	SaramaBuilders SaramaBuilders
+}
+
+func NewCascadingSaramaEventsRunner(config SaramaRunnerConfig, logger log.Logger,
+	delays []time.Duration) *CascadingSaramaEventsRunner {
+
+	return &CascadingSaramaEventsRunner{
+		Config:         config,
+		Delays:         delays,
+		Logger:         logger,
+		SaramaBuilders: DefaultSaramaBuilders{},
+	}
+}
+
+// LimitedAsyncProducer restricts the [sarama.AsyncProducer] interface to ensure that its
+// recipient isn't able to call Close(), thereby opening the potential for a panic when
+// writing to a closed channel.
+type LimitedAsyncProducer interface {
+	AbortTxn() error
+	BeginTxn() error
+	CommitTxn() error
+	Input() chan<- *sarama.ProducerMessage
+}
+
+func (r *CascadingSaramaEventsRunner) Run(ctx context.Context) error {
+	if len(r.Config.Topics) == 0 {
+		return errors.New("no topics")
+	}
+	if len(r.Delays) == 0 {
+		return errors.New("no delays")
+	}
+
+	producersCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var wg sync.WaitGroup
+	errs := make(chan error, len(r.Config.Topics)*len(r.Delays))
+	defer func() {
+		r.logger(ctx).Debug("CascadingSaramaEventsRunner: waiting for consumers")
+		wg.Wait()
+		r.logger(ctx).Debug("CascadingSaramaEventsRunner: all consumers returned")
+		close(errs)
+	}()
+
+	for _, topic := range r.Config.Topics {
+		for idx, delay := range r.Delays {
+			producerCfg := r.producerConfig(idx, delay)
+			// The producer is built here rather than in buildConsumer() to control when
+			// producer is closed. Were the producer to be closed before consumer.Run()
+			// returns, it would be possible for consumer to write to the producer's
+			// Inputs() channel, which if closed, would cause a panic.
+			producer, err := r.SaramaBuilders.NewAsyncProducer(r.Config.Brokers, producerCfg)
+			if err != nil {
+				return errors.Wrapf(err, "Unable to build async producer: %s", r.Config.GroupID)
+			}
+
+			consumer, err := r.buildConsumer(producersCtx, idx, producer, delay, topic)
+			if err != nil {
+				return err
+			}
+
+			wg.Add(1)
+			go func(topic string) {
+				defer func() { wg.Done(); producer.Close() }()
+				if err := consumer.Run(producersCtx); err != nil {
+					errs <- fmt.Errorf("topics[%q]: %s", topic, err)
+				}
+				r.logger(ctx).WithField("topic", topic).
+					Debug("CascadingSaramaEventsRunner: consumer go proc returning")
+			}(topic)
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		r.logger(ctx).Debug("CascadingSaramaEventsRunner: context is done")
+		return nil
+	case err := <-errs:
+		r.logger(ctx).WithError(err).
+			Debug("CascadingSaramaEventsRunner: Run(): error from consumer")
+		return err
+	}
+}
+
+func (r *CascadingSaramaEventsRunner) producerConfig(idx int, delay time.Duration) *sarama.Config {
+	uniqueConfig := *r.Config.Sarama
+	hostID := os.Getenv("HOSTNAME") // set by default in kubernetes pods
+	if hostID == "" {
+		hostID = fmt.Sprintf("%d-%d", time.Now().UnixNano()/int64(time.Second), os.Getpid())
+	}
+	txnID := fmt.Sprintf("%s-%s-%d-%s", r.Config.GroupID, delay.String(), idx, hostID)
+	uniqueConfig.Producer.Transaction.ID = txnID
+	uniqueConfig.Producer.Idempotent = true
+	uniqueConfig.Producer.RequiredAcks = sarama.WaitForAll
+	uniqueConfig.Net.MaxOpenRequests = 1
+	uniqueConfig.Consumer.IsolationLevel = sarama.ReadCommitted
+	return &uniqueConfig
+}
+
+// SaramaBuilders allows tests to inject mock objects.
+type SaramaBuilders interface {
+	NewAsyncProducer([]string, *sarama.Config) (sarama.AsyncProducer, error)
+	NewConsumerGroup([]string, string, *sarama.Config) (sarama.ConsumerGroup, error)
+}
+
+// DefaultSaramaBuilders implements SaramaBuilders for normal, non-test use.
+type DefaultSaramaBuilders struct{}
+
+func (DefaultSaramaBuilders) NewAsyncProducer(brokers []string, config *sarama.Config) (
+	sarama.AsyncProducer, error) {
+
+	return sarama.NewAsyncProducer(brokers, config)
+}
+
+func (DefaultSaramaBuilders) NewConsumerGroup(brokers []string, groupID string,
+	config *sarama.Config) (sarama.ConsumerGroup, error) {
+
+	return sarama.NewConsumerGroup(brokers, groupID, config)
+}
+
+func (r *CascadingSaramaEventsRunner) buildConsumer(ctx context.Context, idx int,
+	producer LimitedAsyncProducer, delay time.Duration, baseTopic string) (
+	*asyncevents.SaramaEventsConsumer, error) {
+
+	groupID := r.Config.GroupID
+	if delay > 0 {
+		groupID += "-retry-" + delay.String()
+	}
+	group, err := r.SaramaBuilders.NewConsumerGroup(r.Config.Brokers, groupID,
+		r.Config.Sarama)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to build sarama consumer group: %s", groupID)
+	}
+
+	var consumer asyncevents.SaramaMessageConsumer = r.Config.MessageConsumer
+	if len(r.Delays) > 0 {
+		nextTopic := baseTopic + "-dead"
+		if idx+1 < len(r.Delays) {
+			nextTopic = baseTopic + "-retry-" + r.Delays[idx+1].String()
+		}
+		consumer = &CascadingConsumer{
+			Consumer:  consumer,
+			NextTopic: nextTopic,
+			Producer:  producer,
+			Logger:    r.Logger,
+		}
+	}
+	if delay > 0 {
+		consumer = &DelayingConsumer{
+			Consumer: consumer,
+			Delay:    delay,
+			Logger:   r.Logger,
+		}
+	}
+	handler := asyncevents.NewSaramaConsumerGroupHandler(consumer,
+		AlertsEventConsumptionTimeout)
+	topic := baseTopic
+	if delay > 0 {
+		topic += "-retry-" + delay.String()
+	}
+	r.logger(ctx).WithField("topic", topic).Debug("creating consumer")
+
+	return asyncevents.NewSaramaEventsConsumer(group, handler, topic), nil
+}
+
+func (r *CascadingSaramaEventsRunner) logger(ctx context.Context) log.Logger {
+	// A context logger might have more fields or ... context. So prefer that if availble.
+	if ctxLogger := log.LoggerFromContext(ctx); ctxLogger != nil {
+		return ctxLogger
+	}
+	if r.Logger == nil {
+		// logjson.NewLogger will only fail if an argument is missing.
+		r.Logger, _ = logjson.NewLogger(os.Stderr, log.DefaultLevelRanks(), log.DefaultLevel())
+	}
+	return r.Logger
+}
+
+// DelayingConsumer injects a delay before consuming a message.
+type DelayingConsumer struct {
+	Consumer asyncevents.SaramaMessageConsumer
+	Delay    time.Duration
+	Logger   log.Logger
+}
+
+func (c *DelayingConsumer) Consume(ctx context.Context, session sarama.ConsumerGroupSession,
+	msg *sarama.ConsumerMessage) error {
+
+	select {
+	case <-ctx.Done():
+		if ctxErr := ctx.Err(); ctxErr != context.Canceled {
+			return ctxErr
+		}
+		return nil
+	case <-time.After(c.Delay):
+		c.Logger.WithFields(log.Fields{"topic": msg.Topic, "delay": c.Delay}).Debugf("delayed")
+		return c.Consumer.Consume(ctx, session, msg)
+	}
+}
+
+// CascadingConsumer cascades messages that failed to be consumed to another topic.
+type CascadingConsumer struct {
+	Consumer  asyncevents.SaramaMessageConsumer
+	NextTopic string
+	Producer  LimitedAsyncProducer
+	Logger    log.Logger
+}
+
+func (c *CascadingConsumer) Consume(ctx context.Context, session sarama.ConsumerGroupSession,
+	msg *sarama.ConsumerMessage) (err error) {
+
+	if err := c.Consumer.Consume(ctx, session, msg); err != nil {
+		txnErr := c.withTxn(func() error {
+			select {
+			case <-ctx.Done():
+				if ctxErr := ctx.Err(); ctxErr != context.Canceled {
+					return ctxErr
+				}
+				return nil
+			case c.Producer.Input() <- c.cascadeMessage(msg):
+				fields := log.Fields{"from": msg.Topic, "to": c.NextTopic}
+				c.Logger.WithFields(fields).Debug("cascaded")
+				return nil
+			}
+		})
+		if txnErr != nil {
+			c.Logger.WithError(txnErr).Info("Unable to complete cascading transaction")
+			return err
+		}
+	}
+	return nil
+}
+
+// withTxn wraps a function with a transaction that is aborted if an error is returned.
+func (c *CascadingConsumer) withTxn(f func() error) (err error) {
+	if err := c.Producer.BeginTxn(); err != nil {
+		return errors.Wrap(err, "Unable to begin transaction")
+	}
+	defer func(err *error) {
+		if err != nil && *err != nil {
+			if abortErr := c.Producer.AbortTxn(); abortErr != nil {
+				c.Logger.WithError(abortErr).Info("Unable to abort transaction")
+			}
+			return
+		}
+		if commitErr := c.Producer.CommitTxn(); commitErr != nil {
+			c.Logger.WithError(commitErr).Info("Unable to commit transaction")
+		}
+	}(&err)
+	return f()
+}
+
+func (c *CascadingConsumer) cascadeMessage(msg *sarama.ConsumerMessage) *sarama.ProducerMessage {
+	pHeaders := make([]sarama.RecordHeader, len(msg.Headers))
+	for idx, header := range msg.Headers {
+		pHeaders[idx] = *header
+	}
+	return &sarama.ProducerMessage{
+		Key:     sarama.ByteEncoder(msg.Key),
+		Value:   sarama.ByteEncoder(msg.Value),
+		Topic:   c.NextTopic,
+		Headers: pHeaders,
+	}
 }

--- a/vendor/github.com/IBM/sarama/mocks/README.md
+++ b/vendor/github.com/IBM/sarama/mocks/README.md
@@ -1,0 +1,13 @@
+# sarama/mocks
+
+The `mocks` subpackage includes mock implementations that implement the interfaces of the major sarama types.
+You can use them to test your sarama applications using dependency injection.
+
+The following mock objects are available:
+
+- [Consumer](https://pkg.go.dev/github.com/IBM/sarama/mocks#Consumer), which will create [PartitionConsumer](https://pkg.go.dev/github.com/IBM/sarama/mocks#PartitionConsumer) mocks.
+- [AsyncProducer](https://pkg.go.dev/github.com/IBM/sarama/mocks#AsyncProducer)
+- [SyncProducer](https://pkg.go.dev/github.com/IBM/sarama/mocks#SyncProducer)
+
+The mocks allow you to set expectations on them. When you close the mocks, the expectations will be verified,
+and the results will be reported to the `*testing.T` object you provided when creating the mock.

--- a/vendor/github.com/IBM/sarama/mocks/async_producer.go
+++ b/vendor/github.com/IBM/sarama/mocks/async_producer.go
@@ -1,0 +1,272 @@
+package mocks
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/IBM/sarama"
+)
+
+// AsyncProducer implements sarama's Producer interface for testing purposes.
+// Before you can send messages to it's Input channel, you have to set expectations
+// so it knows how to handle the input; it returns an error if the number of messages
+// received is bigger then the number of expectations set. You can also set a
+// function in each expectation so that the message is checked by this function and
+// an error is returned if the match fails.
+type AsyncProducer struct {
+	l               sync.Mutex
+	t               ErrorReporter
+	expectations    []*producerExpectation
+	closed          chan struct{}
+	input           chan *sarama.ProducerMessage
+	successes       chan *sarama.ProducerMessage
+	errors          chan *sarama.ProducerError
+	isTransactional bool
+	txnLock         sync.Mutex
+	txnStatus       sarama.ProducerTxnStatusFlag
+	lastOffset      int64
+	*TopicConfig
+}
+
+// NewAsyncProducer instantiates a new Producer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is validated and used to determine
+// whether it should ack successes on the Successes channel and handle partitioning.
+func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Invalid mock configuration provided: %s", err.Error())
+	}
+	mp := &AsyncProducer{
+		t:               t,
+		closed:          make(chan struct{}),
+		expectations:    make([]*producerExpectation, 0),
+		input:           make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		successes:       make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		errors:          make(chan *sarama.ProducerError, config.ChannelBufferSize),
+		isTransactional: config.Producer.Transaction.ID != "",
+		txnStatus:       sarama.ProducerTxnFlagReady,
+		TopicConfig:     NewTopicConfig(),
+	}
+
+	go func() {
+		defer func() {
+			close(mp.successes)
+			close(mp.errors)
+			close(mp.closed)
+		}()
+
+		partitioners := make(map[string]sarama.Partitioner, 1)
+
+		for msg := range mp.input {
+			mp.txnLock.Lock()
+			if mp.IsTransactional() && mp.txnStatus&sarama.ProducerTxnFlagInTransaction == 0 {
+				mp.t.Errorf("attempt to send message when transaction is not started or is in ending state.")
+				mp.errors <- &sarama.ProducerError{Err: errors.New("attempt to send message when transaction is not started or is in ending state"), Msg: msg}
+				continue
+			}
+			mp.txnLock.Unlock()
+			partitioner := partitioners[msg.Topic]
+			if partitioner == nil {
+				partitioner = config.Producer.Partitioner(msg.Topic)
+				partitioners[msg.Topic] = partitioner
+			}
+			mp.l.Lock()
+			if mp.expectations == nil || len(mp.expectations) == 0 {
+				mp.expectations = nil
+				mp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+			} else {
+				expectation := mp.expectations[0]
+				mp.expectations = mp.expectations[1:]
+
+				partition, err := partitioner.Partition(msg, mp.partitions(msg.Topic))
+				if err != nil {
+					mp.t.Errorf("Partitioner returned an error: %s", err.Error())
+					mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+				} else {
+					msg.Partition = partition
+					if expectation.CheckFunction != nil {
+						err := expectation.CheckFunction(msg)
+						if err != nil {
+							mp.t.Errorf("Check function returned an error: %s", err.Error())
+							mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+						}
+					}
+					if errors.Is(expectation.Result, errProduceSuccess) {
+						mp.lastOffset++
+						if config.Producer.Return.Successes {
+							msg.Offset = mp.lastOffset
+							mp.successes <- msg
+						}
+					} else if config.Producer.Return.Errors {
+						mp.errors <- &sarama.ProducerError{Err: expectation.Result, Msg: msg}
+					}
+				}
+			}
+			mp.l.Unlock()
+		}
+
+		mp.l.Lock()
+		if len(mp.expectations) > 0 {
+			mp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(mp.expectations))
+		}
+		mp.l.Unlock()
+	}()
+
+	return mp
+}
+
+////////////////////////////////////////////////
+// Implement Producer interface
+////////////////////////////////////////////////
+
+// AsyncClose corresponds with the AsyncClose method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) AsyncClose() {
+	close(mp.input)
+}
+
+// Close corresponds with the Close method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) Close() error {
+	mp.AsyncClose()
+	<-mp.closed
+	return nil
+}
+
+// Input corresponds with the Input method of sarama's Producer implementation.
+// You have to set expectations on the mock producer before writing messages to the Input
+// channel, so it knows how to handle them. If there is no more remaining expectations and
+// a messages is written to the Input channel, the mock producer will write an error to the test
+// state object.
+func (mp *AsyncProducer) Input() chan<- *sarama.ProducerMessage {
+	return mp.input
+}
+
+// Successes corresponds with the Successes method of sarama's Producer implementation.
+func (mp *AsyncProducer) Successes() <-chan *sarama.ProducerMessage {
+	return mp.successes
+}
+
+// Errors corresponds with the Errors method of sarama's Producer implementation.
+func (mp *AsyncProducer) Errors() <-chan *sarama.ProducerError {
+	return mp.errors
+}
+
+func (mp *AsyncProducer) IsTransactional() bool {
+	return mp.isTransactional
+}
+
+func (mp *AsyncProducer) BeginTxn() error {
+	mp.txnLock.Lock()
+	defer mp.txnLock.Unlock()
+
+	mp.txnStatus = sarama.ProducerTxnFlagInTransaction
+	return nil
+}
+
+func (mp *AsyncProducer) CommitTxn() error {
+	mp.txnLock.Lock()
+	defer mp.txnLock.Unlock()
+
+	mp.txnStatus = sarama.ProducerTxnFlagReady
+	return nil
+}
+
+func (mp *AsyncProducer) AbortTxn() error {
+	mp.txnLock.Lock()
+	defer mp.txnLock.Unlock()
+
+	mp.txnStatus = sarama.ProducerTxnFlagReady
+	return nil
+}
+
+func (mp *AsyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	mp.txnLock.Lock()
+	defer mp.txnLock.Unlock()
+
+	return mp.txnStatus
+}
+
+func (mp *AsyncProducer) AddOffsetsToTxn(offsets map[string][]*sarama.PartitionOffsetMetadata, groupId string) error {
+	return nil
+}
+
+func (mp *AsyncProducer) AddMessageToTxn(msg *sarama.ConsumerMessage, groupId string, metadata *string) error {
+	return nil
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectInputWithMessageCheckerFunctionAndSucceed sets an expectation on the mock producer that a
+// message will be provided on the input channel. The mock producer will call the given function to
+// check the message. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it produced successfully, i.e. it will make it
+// available on the Successes channel if the Producer.Return.Successes setting is set to true.
+func (mp *AsyncProducer) ExpectInputWithMessageCheckerFunctionAndSucceed(cf MessageChecker) *AsyncProducer {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+
+	return mp
+}
+
+// ExpectInputWithMessageCheckerFunctionAndFail sets an expectation on the mock producer that a
+// message will be provided on the input channel. The mock producer will first call the given
+// function to check the message. If an error is returned it will be made available on the Errors
+// channel otherwise the mock will handle the message as if it failed to produce successfully. This
+// means it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputWithMessageCheckerFunctionAndFail(cf MessageChecker, err error) *AsyncProducer {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+
+	return mp
+}
+
+// ExpectInputWithCheckerFunctionAndSucceed sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will call the given function to check
+// the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it produced successfully, i.e. it will make
+// it available on the Successes channel if the Producer.Return.Successes setting is set to true.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndSucceed(cf ValueChecker) *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndSucceed(messageValueChecker(cf))
+
+	return mp
+}
+
+// ExpectInputWithCheckerFunctionAndFail sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will first call the given function to
+// check the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it failed to produce successfully. This means
+// it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndFail(cf ValueChecker, err error) *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndFail(messageValueChecker(cf), err)
+
+	return mp
+}
+
+// ExpectInputAndSucceed sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it is produced successfully,
+// i.e. it will make it available on the Successes channel if the Producer.Return.Successes setting
+// is set to true.
+func (mp *AsyncProducer) ExpectInputAndSucceed() *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndSucceed(nil)
+
+	return mp
+}
+
+// ExpectInputAndFail sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it failed to produce
+// successfully. This means it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputAndFail(err error) *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndFail(nil, err)
+
+	return mp
+}

--- a/vendor/github.com/IBM/sarama/mocks/consumer.go
+++ b/vendor/github.com/IBM/sarama/mocks/consumer.go
@@ -1,0 +1,441 @@
+package mocks
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/IBM/sarama"
+)
+
+// Consumer implements sarama's Consumer interface for testing purposes.
+// Before you can start consuming from this consumer, you have to register
+// topic/partitions using ExpectConsumePartition, and set expectations on them.
+type Consumer struct {
+	l                  sync.Mutex
+	t                  ErrorReporter
+	config             *sarama.Config
+	partitionConsumers map[string]map[int32]*PartitionConsumer
+	metadata           map[string][]int32
+}
+
+// NewConsumer returns a new mock Consumer instance. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument can be set to nil; if it is
+// non-nil it is validated.
+func NewConsumer(t ErrorReporter, config *sarama.Config) *Consumer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Invalid mock configuration provided: %s", err.Error())
+	}
+
+	c := &Consumer{
+		t:                  t,
+		config:             config,
+		partitionConsumers: make(map[string]map[int32]*PartitionConsumer),
+	}
+	return c
+}
+
+///////////////////////////////////////////////////
+// Consumer interface implementation
+///////////////////////////////////////////////////
+
+// ConsumePartition implements the ConsumePartition method from the sarama.Consumer interface.
+// Before you can start consuming a partition, you have to set expectations on it using
+// ExpectConsumePartition. You can only consume a partition once per consumer.
+func (c *Consumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil || c.partitionConsumers[topic][partition] == nil {
+		c.t.Errorf("No expectations set for %s/%d", topic, partition)
+		return nil, errOutOfExpectations
+	}
+
+	pc := c.partitionConsumers[topic][partition]
+	if pc.consumed {
+		return nil, sarama.ConfigurationError("The topic/partition is already being consumed")
+	}
+
+	if pc.offset != AnyOffset && pc.offset != offset {
+		c.t.Errorf("Unexpected offset when calling ConsumePartition for %s/%d. Expected %d, got %d.", topic, partition, pc.offset, offset)
+	}
+
+	pc.consumed = true
+	return pc, nil
+}
+
+// Topics returns a list of topics, as registered with SetTopicMetadata
+func (c *Consumer) Topics() ([]string, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Topics. Initialize the mock's topic metadata with SetTopicMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+
+	var result []string
+	for topic := range c.metadata {
+		result = append(result, topic)
+	}
+	return result, nil
+}
+
+// Partitions returns the list of parititons for the given topic, as registered with SetTopicMetadata
+func (c *Consumer) Partitions(topic string) ([]int32, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Partitions. Initialize the mock's topic metadata with SetTopicMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+	if c.metadata[topic] == nil {
+		return nil, sarama.ErrUnknownTopicOrPartition
+	}
+
+	return c.metadata[topic], nil
+}
+
+func (c *Consumer) HighWaterMarks() map[string]map[int32]int64 {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	hwms := make(map[string]map[int32]int64, len(c.partitionConsumers))
+	for topic, partitionConsumers := range c.partitionConsumers {
+		hwm := make(map[int32]int64, len(partitionConsumers))
+		for partition, pc := range partitionConsumers {
+			hwm[partition] = pc.HighWaterMarkOffset()
+		}
+		hwms[topic] = hwm
+	}
+
+	return hwms
+}
+
+// Close implements the Close method from the sarama.Consumer interface. It will close
+// all registered PartitionConsumer instances.
+func (c *Consumer) Close() error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			_ = partitionConsumer.Close()
+		}
+	}
+
+	return nil
+}
+
+// Pause implements Consumer.
+func (c *Consumer) Pause(topicPartitions map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for topic, partitions := range topicPartitions {
+		for _, partition := range partitions {
+			if topicConsumers, ok := c.partitionConsumers[topic]; ok {
+				if partitionConsumer, ok := topicConsumers[partition]; ok {
+					partitionConsumer.Pause()
+				}
+			}
+		}
+	}
+}
+
+// Resume implements Consumer.
+func (c *Consumer) Resume(topicPartitions map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for topic, partitions := range topicPartitions {
+		for _, partition := range partitions {
+			if topicConsumers, ok := c.partitionConsumers[topic]; ok {
+				if partitionConsumer, ok := topicConsumers[partition]; ok {
+					partitionConsumer.Resume()
+				}
+			}
+		}
+	}
+}
+
+// PauseAll implements Consumer.
+func (c *Consumer) PauseAll() {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			partitionConsumer.Pause()
+		}
+	}
+}
+
+// ResumeAll implements Consumer.
+func (c *Consumer) ResumeAll() {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			partitionConsumer.Resume()
+		}
+	}
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// SetTopicMetadata sets the clusters topic/partition metadata,
+// which will be returned by Topics() and Partitions().
+func (c *Consumer) SetTopicMetadata(metadata map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	c.metadata = metadata
+}
+
+// ExpectConsumePartition will register a topic/partition, so you can set expectations on it.
+// The registered PartitionConsumer will be returned, so you can set expectations
+// on it using method chaining. Once a topic/partition is registered, you are
+// expected to start consuming it using ConsumePartition. If that doesn't happen,
+// an error will be written to the error reporter once the mock consumer is closed. It also expects
+// that the message and error channels be written with YieldMessage and YieldError accordingly,
+// and be fully consumed once the mock consumer is closed if ExpectMessagesDrainedOnClose or
+// ExpectErrorsDrainedOnClose have been called.
+func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset int64) *PartitionConsumer {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil {
+		c.partitionConsumers[topic] = make(map[int32]*PartitionConsumer)
+	}
+
+	if c.partitionConsumers[topic][partition] == nil {
+		highWatermarkOffset := offset
+		if offset == sarama.OffsetOldest {
+			highWatermarkOffset = 0
+		}
+
+		c.partitionConsumers[topic][partition] = &PartitionConsumer{
+			highWaterMarkOffset: highWatermarkOffset,
+			t:                   c.t,
+			topic:               topic,
+			partition:           partition,
+			offset:              offset,
+			messages:            make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
+			suppressedMessages:  make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
+			errors:              make(chan *sarama.ConsumerError, c.config.ChannelBufferSize),
+		}
+	}
+
+	return c.partitionConsumers[topic][partition]
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer mock type
+///////////////////////////////////////////////////
+
+// PartitionConsumer implements sarama's PartitionConsumer interface for testing purposes.
+// It is returned by the mock Consumers ConsumePartitionMethod, but only if it is
+// registered first using the Consumer's ExpectConsumePartition method. Before consuming the
+// Errors and Messages channel, you should specify what values will be provided on these
+// channels using YieldMessage and YieldError.
+type PartitionConsumer struct {
+	highWaterMarkOffset           int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	suppressedHighWaterMarkOffset int64
+	l                             sync.Mutex
+	t                             ErrorReporter
+	topic                         string
+	partition                     int32
+	offset                        int64
+	messages                      chan *sarama.ConsumerMessage
+	suppressedMessages            chan *sarama.ConsumerMessage
+	errors                        chan *sarama.ConsumerError
+	singleClose                   sync.Once
+	consumed                      bool
+	errorsShouldBeDrained         bool
+	messagesShouldBeDrained       bool
+	paused                        bool
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer interface implementation
+///////////////////////////////////////////////////
+
+// AsyncClose implements the AsyncClose method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) AsyncClose() {
+	pc.singleClose.Do(func() {
+		close(pc.suppressedMessages)
+		close(pc.messages)
+		close(pc.errors)
+	})
+}
+
+// Close implements the Close method from the sarama.PartitionConsumer interface. It will
+// verify whether the partition consumer was actually started.
+func (pc *PartitionConsumer) Close() error {
+	if !pc.consumed {
+		pc.t.Errorf("Expectations set on %s/%d, but no partition consumer was started.", pc.topic, pc.partition)
+		return errPartitionConsumerNotStarted
+	}
+
+	if pc.errorsShouldBeDrained && len(pc.errors) > 0 {
+		pc.t.Errorf("Expected the errors channel for %s/%d to be drained on close, but found %d errors.", pc.topic, pc.partition, len(pc.errors))
+	}
+
+	if pc.messagesShouldBeDrained && len(pc.messages) > 0 {
+		pc.t.Errorf("Expected the messages channel for %s/%d to be drained on close, but found %d messages.", pc.topic, pc.partition, len(pc.messages))
+	}
+
+	pc.AsyncClose()
+
+	var (
+		closeErr error
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		errs := make(sarama.ConsumerErrors, 0)
+		for err := range pc.errors {
+			errs = append(errs, err)
+		}
+
+		if len(errs) > 0 {
+			closeErr = errs
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range pc.messages {
+			// drain
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range pc.suppressedMessages {
+			// drain
+		}
+	}()
+
+	wg.Wait()
+	return closeErr
+}
+
+// Errors implements the Errors method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	return pc.errors
+}
+
+// Messages implements the Messages method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return pc.messages
+}
+
+func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {
+	return atomic.LoadInt64(&pc.highWaterMarkOffset)
+}
+
+// Pause implements the Pause method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Pause() {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	pc.suppressedHighWaterMarkOffset = atomic.LoadInt64(&pc.highWaterMarkOffset)
+
+	pc.paused = true
+}
+
+// Resume implements the Resume method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Resume() {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	pc.highWaterMarkOffset = atomic.LoadInt64(&pc.suppressedHighWaterMarkOffset)
+	for len(pc.suppressedMessages) > 0 {
+		msg := <-pc.suppressedMessages
+		pc.messages <- msg
+	}
+
+	pc.paused = false
+}
+
+// IsPaused implements the IsPaused method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) IsPaused() bool {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	return pc.paused
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// YieldMessage will yield a messages Messages channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this
+// message was consumed from the Messages channel, because there are legitimate
+// reasons forthis not to happen. ou can call ExpectMessagesDrainedOnClose so it will
+// verify that the channel is empty on close.
+func (pc *PartitionConsumer) YieldMessage(msg *sarama.ConsumerMessage) *PartitionConsumer {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	msg.Topic = pc.topic
+	msg.Partition = pc.partition
+
+	if pc.paused {
+		msg.Offset = atomic.AddInt64(&pc.suppressedHighWaterMarkOffset, 1) - 1
+		pc.suppressedMessages <- msg
+	} else {
+		msg.Offset = atomic.AddInt64(&pc.highWaterMarkOffset, 1) - 1
+		pc.messages <- msg
+	}
+
+	return pc
+}
+
+// YieldError will yield an error on the Errors channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this error was
+// consumed from the Errors channel, because there are legitimate reasons for this
+// not to happen. You can call ExpectErrorsDrainedOnClose so it will verify that
+// the channel is empty on close.
+func (pc *PartitionConsumer) YieldError(err error) *PartitionConsumer {
+	pc.errors <- &sarama.ConsumerError{
+		Topic:     pc.topic,
+		Partition: pc.partition,
+		Err:       err,
+	}
+
+	return pc
+}
+
+// ExpectMessagesDrainedOnClose sets an expectation on the partition consumer
+// that the messages channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectMessagesDrainedOnClose() *PartitionConsumer {
+	pc.messagesShouldBeDrained = true
+
+	return pc
+}
+
+// ExpectErrorsDrainedOnClose sets an expectation on the partition consumer
+// that the errors channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectErrorsDrainedOnClose() *PartitionConsumer {
+	pc.errorsShouldBeDrained = true
+
+	return pc
+}

--- a/vendor/github.com/IBM/sarama/mocks/mocks.go
+++ b/vendor/github.com/IBM/sarama/mocks/mocks.go
@@ -1,0 +1,110 @@
+/*
+Package mocks provides mocks that can be used for testing applications
+that use Sarama. The mock types provided by this package implement the
+interfaces Sarama exports, so you can use them for dependency injection
+in your tests.
+
+All mock instances require you to set expectations on them before you
+can use them. It will determine how the mock will behave. If an
+expectation is not met, it will make your test fail.
+
+NOTE: this package currently does not fall under the API stability
+guarantee of Sarama as it is still considered experimental.
+*/
+package mocks
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/IBM/sarama"
+)
+
+// ErrorReporter is a simple interface that includes the testing.T methods we use to report
+// expectation violations when using the mock objects.
+type ErrorReporter interface {
+	Errorf(string, ...interface{})
+}
+
+// ValueChecker is a function type to be set in each expectation of the producer mocks
+// to check the value passed.
+type ValueChecker func(val []byte) error
+
+// MessageChecker is a function type to be set in each expectation of the producer mocks
+// to check the message passed.
+type MessageChecker func(*sarama.ProducerMessage) error
+
+// messageValueChecker wraps a ValueChecker into a MessageChecker.
+// Failure to encode the message value will return an error and not call
+// the wrapped ValueChecker.
+func messageValueChecker(f ValueChecker) MessageChecker {
+	if f == nil {
+		return nil
+	}
+	return func(msg *sarama.ProducerMessage) error {
+		val, err := msg.Value.Encode()
+		if err != nil {
+			return fmt.Errorf("Input message encoding failed: %w", err)
+		}
+		return f(val)
+	}
+}
+
+var (
+	errProduceSuccess              error = nil
+	errOutOfExpectations                 = errors.New("No more expectations set on mock")
+	errPartitionConsumerNotStarted       = errors.New("The partition consumer was never started")
+)
+
+const AnyOffset int64 = -1000
+
+type producerExpectation struct {
+	Result        error
+	CheckFunction MessageChecker
+}
+
+// TopicConfig describes a mock topic structure for the mock producers’ partitioning needs.
+type TopicConfig struct {
+	overridePartitions map[string]int32
+	defaultPartitions  int32
+}
+
+// NewTopicConfig makes a configuration which defaults to 32 partitions for every topic.
+func NewTopicConfig() *TopicConfig {
+	return &TopicConfig{
+		overridePartitions: make(map[string]int32, 0),
+		defaultPartitions:  32,
+	}
+}
+
+// SetDefaultPartitions sets the number of partitions any topic not explicitly configured otherwise
+// (by SetPartitions) will have from the perspective of created partitioners.
+func (pc *TopicConfig) SetDefaultPartitions(n int32) {
+	pc.defaultPartitions = n
+}
+
+// SetPartitions sets the number of partitions the partitioners will see for specific topics. This
+// only applies to messages produced after setting them.
+func (pc *TopicConfig) SetPartitions(partitions map[string]int32) {
+	for p, n := range partitions {
+		pc.overridePartitions[p] = n
+	}
+}
+
+func (pc *TopicConfig) partitions(topic string) int32 {
+	if n, found := pc.overridePartitions[topic]; found {
+		return n
+	}
+	return pc.defaultPartitions
+}
+
+// NewTestConfig returns a config meant to be used by tests.
+// Due to inconsistencies with the request versions the clients send using the default Kafka version
+// and the response versions our mocks use, we default to the minimum Kafka version in most tests
+func NewTestConfig() *sarama.Config {
+	config := sarama.NewConfig()
+	config.Consumer.Retry.Backoff = 0
+	config.Producer.Retry.Backoff = 0
+	config.Version = sarama.MinVersion
+	return config
+}

--- a/vendor/github.com/IBM/sarama/mocks/sync_producer.go
+++ b/vendor/github.com/IBM/sarama/mocks/sync_producer.go
@@ -1,0 +1,264 @@
+package mocks
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/IBM/sarama"
+)
+
+// SyncProducer implements sarama's SyncProducer interface for testing purposes.
+// Before you can use it, you have to set expectations on the mock SyncProducer
+// to tell it how to handle calls to SendMessage, so you can easily test success
+// and failure scenarios.
+type SyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	lastOffset   int64
+
+	*TopicConfig
+	newPartitioner sarama.PartitionerConstructor
+	partitioners   map[string]sarama.Partitioner
+
+	isTransactional bool
+	txnLock         sync.Mutex
+	txnStatus       sarama.ProducerTxnStatusFlag
+}
+
+// NewSyncProducer instantiates a new SyncProducer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is validated and used to handle
+// partitioning.
+func NewSyncProducer(t ErrorReporter, config *sarama.Config) *SyncProducer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Invalid mock configuration provided: %s", err.Error())
+	}
+	return &SyncProducer{
+		t:               t,
+		expectations:    make([]*producerExpectation, 0),
+		TopicConfig:     NewTopicConfig(),
+		newPartitioner:  config.Producer.Partitioner,
+		partitioners:    make(map[string]sarama.Partitioner, 1),
+		isTransactional: config.Producer.Transaction.ID != "",
+		txnStatus:       sarama.ProducerTxnFlagReady,
+	}
+}
+
+////////////////////////////////////////////////
+// Implement SyncProducer interface
+////////////////////////////////////////////////
+
+// SendMessage corresponds with the SendMessage method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessage, so it knows
+// how to handle them. You can set a function in each expectation so that the message value
+// checked by this function and an error is returned if the match fails.
+// If there is no more remaining expectation when SendMessage is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if sp.IsTransactional() && sp.txnStatus&sarama.ProducerTxnFlagInTransaction == 0 {
+		sp.t.Errorf("attempt to send message when transaction is not started or is in ending state.")
+		return -1, -1, errors.New("attempt to send message when transaction is not started or is in ending state")
+	}
+
+	if len(sp.expectations) > 0 {
+		expectation := sp.expectations[0]
+		sp.expectations = sp.expectations[1:]
+		topic := msg.Topic
+		partition, err := sp.partitioner(topic).Partition(msg, sp.partitions(topic))
+		if err != nil {
+			sp.t.Errorf("Partitioner returned an error: %s", err.Error())
+			return -1, -1, err
+		}
+		msg.Partition = partition
+		if expectation.CheckFunction != nil {
+			errCheck := expectation.CheckFunction(msg)
+			if errCheck != nil {
+				sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+				return -1, -1, errCheck
+			}
+		}
+		if errors.Is(expectation.Result, errProduceSuccess) {
+			sp.lastOffset++
+			msg.Offset = sp.lastOffset
+			return 0, msg.Offset, nil
+		}
+		return -1, -1, expectation.Result
+	}
+	sp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+	return -1, -1, errOutOfExpectations
+}
+
+// SendMessages corresponds with the SendMessages method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessages, so it knows
+// how to handle them. If there is no more remaining expectations when SendMessages is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) >= len(msgs) {
+		expectations := sp.expectations[0:len(msgs)]
+		sp.expectations = sp.expectations[len(msgs):]
+
+		for i, expectation := range expectations {
+			topic := msgs[i].Topic
+			partition, err := sp.partitioner(topic).Partition(msgs[i], sp.partitions(topic))
+			if err != nil {
+				sp.t.Errorf("Partitioner returned an error: %s", err.Error())
+				return err
+			}
+			msgs[i].Partition = partition
+			if expectation.CheckFunction != nil {
+				errCheck := expectation.CheckFunction(msgs[i])
+				if errCheck != nil {
+					sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+					return errCheck
+				}
+			}
+			if !errors.Is(expectation.Result, errProduceSuccess) {
+				return expectation.Result
+			}
+			sp.lastOffset++
+			msgs[i].Offset = sp.lastOffset
+		}
+		return nil
+	}
+	sp.t.Errorf("Insufficient expectations set on this mock producer to handle the input messages.")
+	return errOutOfExpectations
+}
+
+func (sp *SyncProducer) partitioner(topic string) sarama.Partitioner {
+	partitioner := sp.partitioners[topic]
+	if partitioner == nil {
+		partitioner = sp.newPartitioner(topic)
+		sp.partitioners[topic] = partitioner
+	}
+	return partitioner
+}
+
+// Close corresponds with the Close method of sarama's SyncProducer implementation.
+// By closing a mock syncproducer, you also tell it that no more SendMessage calls will follow,
+// so it will write an error to the test state if there's any remaining expectations.
+func (sp *SyncProducer) Close() error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		sp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(sp.expectations))
+	}
+
+	return nil
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectSendMessageWithMessageCheckerFunctionAndSucceed sets an expectation on the mock producer
+// that SendMessage will be called. The mock producer will first call the given function to check
+// the message. It will cascade the error of the function, if any, or handle the message as if it
+// produced successfully, i.e. by returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageWithMessageCheckerFunctionAndSucceed(cf MessageChecker) *SyncProducer {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+
+	return sp
+}
+
+// ExpectSendMessageWithMessageCheckerFunctionAndFail sets an expectation on the mock producer that
+// SendMessage will be called. The mock producer will first call the given function to check the
+// message. It will cascade the error of the function, if any, or handle the message as if it
+// failed to produce successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageWithMessageCheckerFunctionAndFail(cf MessageChecker, err error) *SyncProducer {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+
+	return sp
+}
+
+// ExpectSendMessageWithCheckerFunctionAndSucceed sets an expectation on the mock producer that SendMessage
+// will be called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it produced
+// successfully, i.e. by returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndSucceed(cf ValueChecker) *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(messageValueChecker(cf))
+
+	return sp
+}
+
+// ExpectSendMessageWithCheckerFunctionAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it failed
+// to produce successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndFail(cf ValueChecker, err error) *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndFail(messageValueChecker(cf), err)
+
+	return sp
+}
+
+// ExpectSendMessageAndSucceed sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it produced successfully, i.e. by
+// returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageAndSucceed() *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(nil)
+
+	return sp
+}
+
+// ExpectSendMessageAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it failed to produce
+// successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageAndFail(err error) *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndFail(nil, err)
+
+	return sp
+}
+
+func (sp *SyncProducer) IsTransactional() bool {
+	return sp.isTransactional
+}
+
+func (sp *SyncProducer) BeginTxn() error {
+	sp.txnLock.Lock()
+	defer sp.txnLock.Unlock()
+
+	sp.txnStatus = sarama.ProducerTxnFlagInTransaction
+	return nil
+}
+
+func (sp *SyncProducer) CommitTxn() error {
+	sp.txnLock.Lock()
+	defer sp.txnLock.Unlock()
+
+	sp.txnStatus = sarama.ProducerTxnFlagReady
+	return nil
+}
+
+func (sp *SyncProducer) AbortTxn() error {
+	sp.txnLock.Lock()
+	defer sp.txnLock.Unlock()
+
+	sp.txnStatus = sarama.ProducerTxnFlagReady
+	return nil
+}
+
+func (sp *SyncProducer) TxnStatus() sarama.ProducerTxnStatusFlag {
+	return sp.txnStatus
+}
+
+func (sp *SyncProducer) AddOffsetsToTxn(offsets map[string][]*sarama.PartitionOffsetMetadata, groupId string) error {
+	return nil
+}
+
+func (sp *SyncProducer) AddMessageToTxn(msg *sarama.ConsumerMessage, groupId string, metadata *string) error {
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,7 @@
 # github.com/IBM/sarama v1.43.2
 ## explicit; go 1.19
 github.com/IBM/sarama
+github.com/IBM/sarama/mocks
 # github.com/ant0ine/go-json-rest v3.3.2+incompatible
 ## explicit
 github.com/ant0ine/go-json-rest/rest


### PR DESCRIPTION
When a care partner alert encounters an error, the message is moved to a separate topic that will cause it to be retried after a delay. Any number of these topics can be configured.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"eric-cpa-alerts","parentHead":"eaa652e677b47c870b8cc0f8a7cf3ddcced2f8c0","parentPull":715,"trunk":"master"}
```
-->
