### PR TITLE
use a shared MongoDB client/store in data/summary tests

### DIFF
--- a/data/store/mongo/mongo.go
+++ b/data/store/mongo/mongo.go
@@ -12,9 +12,13 @@ func NewStore(config *storeStructuredMongo.Config) (*Store, error) {
 		return nil, err
 	}
 
+	return NewStoreFromBase(baseStore), nil
+}
+
+func NewStoreFromBase(base *storeStructuredMongo.Store) *Store {
 	return &Store{
-		Store: baseStore,
-	}, nil
+		Store: base,
+	}
 }
 
 type Store struct {

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -242,14 +242,9 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 	var alertsRepository alerts.Repository
 	var logger = logTest.NewLogger()
 	var store *dataStoreMongo.Store
-	var ensureIndexesOnce sync.Once
 
 	BeforeEach(func() {
-		store = dataStoreMongo.NewStoreFromBase(storeStructuredMongoTest.GetSuiteStore())
-		ensureIndexesOnce.Do(func() {
-			// EnsureIndexes is slow, but only needs to be executed once.
-			Expect(store.EnsureIndexes()).To(Succeed())
-		})
+		store = GetSuiteStore()
 	})
 
 	Context("New", func() {

--- a/data/store/mongo/suite_store_test.go
+++ b/data/store/mongo/suite_store_test.go
@@ -1,0 +1,24 @@
+package mongo_test
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/data/store/mongo"
+	"github.com/tidepool-org/platform/store/structured/mongo/test"
+)
+
+var suiteStore *mongo.Store
+var suiteStoreOnce sync.Once
+
+func GetSuiteStore() *mongo.Store {
+	GinkgoHelper()
+	suiteStoreOnce.Do(func() {
+		base := test.GetSuiteStore()
+		suiteStore = mongo.NewStoreFromBase(base)
+		Expect(suiteStore.EnsureIndexes()).To(Succeed())
+	})
+	return suiteStore
+}

--- a/data/summary/store/store_suite_test.go
+++ b/data/summary/store/store_suite_test.go
@@ -1,13 +1,30 @@
 package store_test
 
 import (
+	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	dataStoreMongo "github.com/tidepool-org/platform/data/store/mongo"
+	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 )
 
 func TestSummaryStore(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "data/summary/store")
+}
+
+var suiteStore *dataStoreMongo.Store
+var suiteStoreOnce sync.Once
+
+func GetSuiteStore() *dataStoreMongo.Store {
+	GinkgoHelper()
+	suiteStoreOnce.Do(func() {
+		base := storeStructuredMongoTest.GetSuiteStore()
+		suiteStore = dataStoreMongo.NewStoreFromBase(base)
+		Expect(suiteStore.EnsureIndexes()).To(Succeed())
+	})
+	return suiteStore
 }

--- a/data/summary/store/store_test.go
+++ b/data/summary/store/store_test.go
@@ -26,29 +26,35 @@ var _ = Describe("Summary Stats Mongo", Label("mongodb", "slow", "integration"),
 	var logger *logTest.Logger
 	var err error
 	var ctx context.Context
-	var config *storeStructuredMongo.Config
+
 	var store *dataStoreMongo.Store
 	var summaryRepository *storeStructuredMongo.Repository
 
 	BeforeEach(func() {
 		logger = logTest.NewLogger()
 		ctx = log.NewContextWithLogger(context.Background(), logger)
-		config = storeStructuredMongoTest.NewConfig()
-	})
-
-	AfterEach(func() {
-		if store != nil {
-			_ = store.Terminate(context.Background())
-		}
 	})
 
 	Context("Create Stores", func() {
-		It("CGM Repo", func() {
-			store, err = dataStoreMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
+		var config *storeStructuredMongo.Config
+		var createStore *dataStoreMongo.Store
 
-			summaryRepository = store.NewSummaryRepository().GetStore()
+		BeforeEach(func() {
+			config = storeStructuredMongoTest.NewConfig()
+		})
+
+		AfterEach(func() {
+			if createStore != nil {
+				_ = createStore.Terminate(context.Background())
+			}
+		})
+
+		It("CGM Repo", func() {
+			createStore, err := dataStoreMongo.NewStore(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createStore).ToNot(BeNil())
+
+			summaryRepository = createStore.NewSummaryRepository().GetStore()
 			Expect(summaryRepository).ToNot(BeNil())
 
 			cgmStore := dataStoreSummary.New[*types.CGMStats](summaryRepository)
@@ -56,11 +62,11 @@ var _ = Describe("Summary Stats Mongo", Label("mongodb", "slow", "integration"),
 		})
 
 		It("BGM Repo", func() {
-			store, err = dataStoreMongo.NewStore(config)
+			createStore, err := dataStoreMongo.NewStore(config)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
+			Expect(createStore).ToNot(BeNil())
 
-			summaryRepository = store.NewSummaryRepository().GetStore()
+			summaryRepository = createStore.NewSummaryRepository().GetStore()
 			Expect(summaryRepository).ToNot(BeNil())
 
 			bgmStore := dataStoreSummary.New[*types.BGMStats](summaryRepository)
@@ -68,11 +74,11 @@ var _ = Describe("Summary Stats Mongo", Label("mongodb", "slow", "integration"),
 		})
 
 		It("Continuous Repo", func() {
-			store, err = dataStoreMongo.NewStore(config)
+			createStore, err := dataStoreMongo.NewStore(config)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
+			Expect(createStore).ToNot(BeNil())
 
-			summaryRepository = store.NewSummaryRepository().GetStore()
+			summaryRepository = createStore.NewSummaryRepository().GetStore()
 			Expect(summaryRepository).ToNot(BeNil())
 
 			continuousStore := dataStoreSummary.New[*types.ContinuousStats](summaryRepository)
@@ -84,17 +90,14 @@ var _ = Describe("Summary Stats Mongo", Label("mongodb", "slow", "integration"),
 		var summaryCollection *mongo.Collection
 
 		BeforeEach(func() {
-			store, err = dataStoreMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
-
+			store = GetSuiteStore()
 			summaryCollection = store.GetCollection("summary")
-			Expect(store.EnsureIndexes()).To(Succeed())
 		})
 
 		AfterEach(func() {
 			if summaryCollection != nil {
-				_ = summaryCollection.Database().Drop(context.Background())
+				_, err = summaryCollection.DeleteMany(context.Background(), bson.D{})
+				Expect(err).To(Succeed())
 			}
 		})
 

--- a/data/summary/summary_suite_test.go
+++ b/data/summary/summary_suite_test.go
@@ -1,13 +1,30 @@
 package summary_test
 
 import (
+	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	dataStoreMongo "github.com/tidepool-org/platform/data/store/mongo"
+	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 )
 
 func TestSummary(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "data/summary")
+}
+
+var suiteStore *dataStoreMongo.Store
+var suiteStoreOnce sync.Once
+
+func GetSuiteStore() *dataStoreMongo.Store {
+	GinkgoHelper()
+	suiteStoreOnce.Do(func() {
+		base := storeStructuredMongoTest.GetSuiteStore()
+		suiteStore = dataStoreMongo.NewStoreFromBase(base)
+		Expect(suiteStore.EnsureIndexes()).To(Succeed())
+	})
+	return suiteStore
 }

--- a/data/summary/summary_test.go
+++ b/data/summary/summary_test.go
@@ -29,7 +29,6 @@ import (
 	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/pointer"
 	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
-	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 	userTest "github.com/tidepool-org/platform/user/test"
 )
 
@@ -144,12 +143,10 @@ func NewGlucose(typ string, units string, datumTime *time.Time, deviceID string,
 
 var _ = Describe("Summary", func() {
 	Context("MaybeUpdateSummary", func() {
-		var err error
 		var empty struct{}
 		var logger log.Logger
 		var ctx context.Context
 		var registry *summary.SummarizerRegistry
-		var config *storeStructuredMongo.Config
 		var store *dataStoreMongo.Store
 		var summaryRepository *storeStructuredMongo.Repository
 		var dataStore dataStore.DataRepository
@@ -161,11 +158,8 @@ var _ = Describe("Summary", func() {
 		BeforeEach(func() {
 			logger = logTest.NewLogger()
 			ctx = log.NewContextWithLogger(context.Background(), logger)
-			config = storeStructuredMongoTest.NewConfig()
 
-			store, err = dataStoreMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store.EnsureIndexes()).To(Succeed())
+			store = GetSuiteStore()
 
 			summaryRepository = store.NewSummaryRepository().GetStore()
 			dataStore = store.NewDataRepository()
@@ -347,7 +341,6 @@ var _ = Describe("Summary", func() {
 		var err error
 		var logger log.Logger
 		var ctx context.Context
-		var config *storeStructuredMongo.Config
 		var store *dataStoreMongo.Store
 		var dataCollection *mongo.Collection
 		var datumTime time.Time
@@ -361,10 +354,8 @@ var _ = Describe("Summary", func() {
 		BeforeEach(func() {
 			logger = logTest.NewLogger()
 			ctx = log.NewContextWithLogger(context.Background(), logger)
-			config = storeStructuredMongoTest.NewConfig()
-			store, err = dataStoreMongo.NewStore(config)
+			store = GetSuiteStore()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(store.EnsureIndexes()).To(Succeed())
 
 			dataCollection = store.GetCollection("deviceData")
 			datumTime = time.Now().UTC().Truncate(time.Hour)
@@ -416,7 +407,6 @@ var _ = Describe("Summary", func() {
 		var logger log.Logger
 		var ctx context.Context
 		var registry *summary.SummarizerRegistry
-		var config *storeStructuredMongo.Config
 		var store *dataStoreMongo.Store
 		var summaryRepository *storeStructuredMongo.Repository
 		var dataStore dataStore.DataRepository
@@ -433,11 +423,8 @@ var _ = Describe("Summary", func() {
 		BeforeEach(func() {
 			logger = logTest.NewLogger()
 			ctx = log.NewContextWithLogger(context.Background(), logger)
-			config = storeStructuredMongoTest.NewConfig()
 
-			store, err = dataStoreMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store.EnsureIndexes()).To(Succeed())
+			store = GetSuiteStore()
 
 			summaryRepository = store.NewSummaryRepository().GetStore()
 			dataCollection = store.GetCollection("deviceData")
@@ -832,7 +819,6 @@ var _ = Describe("Summary", func() {
 		var logger log.Logger
 		var ctx context.Context
 		var registry *summary.SummarizerRegistry
-		var config *storeStructuredMongo.Config
 		var store *dataStoreMongo.Store
 		var summaryRepository *storeStructuredMongo.Repository
 		var dataStore dataStore.DataRepository
@@ -845,11 +831,8 @@ var _ = Describe("Summary", func() {
 		BeforeEach(func() {
 			logger = logTest.NewLogger()
 			ctx = log.NewContextWithLogger(context.Background(), logger)
-			config = storeStructuredMongoTest.NewConfig()
 
-			store, err = dataStoreMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store.EnsureIndexes()).To(Succeed())
+			store = GetSuiteStore()
 
 			summaryRepository = store.NewSummaryRepository().GetStore()
 			dataCollection = store.GetCollection("deviceData")

--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -27,18 +27,18 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 			"203.0.113.2", "203.0.113.3",
 		}
 
-		BeforeEach(func() {
-			config = storeStructuredMongoTest.NewConfig()
-		})
-
-		AfterEach(func() {
-			if store != nil {
-				err := store.Terminate(context.Background())
-				Expect(err).ToNot(HaveOccurred())
-			}
-		})
-
 		Context("NewStore", func() {
+			BeforeEach(func() {
+				config = storeStructuredMongoTest.NewConfig()
+			})
+
+			AfterEach(func() {
+				if store != nil {
+					err := store.Terminate(context.Background())
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+
 			It("returns an error if the config is missing", func() {
 				var err error
 				store, err = storeStructuredMongo.NewStore(nil)
@@ -97,10 +97,7 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 
 		Context("with a new store", func() {
 			BeforeEach(func() {
-				var err error
-				store, err = storeStructuredMongo.NewStore(config)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(store).ToNot(BeNil())
+				store = storeStructuredMongoTest.GetSuiteStore()
 			})
 
 			Context("Status", func() {


### PR DESCRIPTION
A quick test showed an reduction in runtime from 1m34s to 4.7s.