### PR TITLE
minimize database timeouts for tests

### DIFF
--- a/store/structured/mongo/mongo_test.go
+++ b/store/structured/mongo/mongo_test.go
@@ -2,6 +2,7 @@ package mongo_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,9 +56,14 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 			})
 
 			It("returns an error if the addresses are not reachable", func() {
-				config.Addresses = unusedIPs
 				var err error
-				store, err = storeStructuredMongo.NewStore(config)
+				clientOptions := options.Client()
+				clientOptions.SetTimeout(time.Millisecond)
+				clientOptions.SetSocketTimeout(time.Millisecond)
+				clientOptions.SetServerSelectionTimeout(time.Millisecond)
+				clientOptions.SetConnectTimeout(time.Millisecond)
+				config.Addresses = unusedIPs
+				store, err = storeStructuredMongo.NewStoreFromClient(config, clientOptions)
 				Expect(store).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				// We can't compare the exact error here, since different OSes display slightly different errors
@@ -66,9 +72,14 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 			})
 
 			It("returns the correct status if the addresses are not reachable", func() {
-				config.Addresses = unusedIPs
 				var err error
-				store, err = storeStructuredMongo.NewStore(config)
+				clientOptions := options.Client()
+				clientOptions.SetTimeout(time.Millisecond)
+				clientOptions.SetSocketTimeout(time.Millisecond)
+				clientOptions.SetServerSelectionTimeout(time.Millisecond)
+				clientOptions.SetConnectTimeout(time.Millisecond)
+				config.Addresses = unusedIPs
+				store, err = storeStructuredMongo.NewStoreFromClient(config, clientOptions)
 				Expect(store).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				status := store.Status(context.Background())

--- a/store/structured/mongo/store.go
+++ b/store/structured/mongo/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	mongoDriver "go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.uber.org/fx"
@@ -19,7 +19,7 @@ var StoreModule = fx.Options(
 )
 
 type Store struct {
-	client *mongoDriver.Client
+	client *mongo.Client
 	config *Config
 }
 
@@ -31,18 +31,22 @@ func NewStore(c *Config) (*Store, error) {
 	if c == nil {
 		return nil, errors.New("database config is empty")
 	}
+	return NewStoreFromClient(c, nil)
+}
 
+func NewStoreFromClient(c *Config, clientOptions *options.ClientOptions) (*Store, error) {
+	var err error
 	store := &Store{
 		config: c,
 	}
 
-	var err error
-	cs := c.AsConnectionString()
-	clientOptions := options.Client().
-		ApplyURI(cs).
+	if clientOptions == nil {
+		clientOptions = options.Client()
+	}
+	clientOptions.ApplyURI(c.AsConnectionString()).
 		SetConnectTimeout(store.config.Timeout).
 		SetServerSelectionTimeout(store.config.Timeout)
-	store.client, err = mongoDriver.Connect(context.Background(), clientOptions)
+	store.client, err = mongo.Connect(context.Background(), clientOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "connection options are invalid")
 	}
@@ -65,7 +69,7 @@ func (o *Store) GetRepository(collection string) *Repository {
 	return NewRepository(o.GetCollection(collection))
 }
 
-func (o *Store) GetCollection(collection string) *mongoDriver.Collection {
+func (o *Store) GetCollection(collection string) *mongo.Collection {
 	db := o.client.Database(o.config.Database)
 	prefixed := fmt.Sprintf("%s%s", o.config.CollectionPrefix, collection)
 	return db.Collection(prefixed)


### PR DESCRIPTION
These were the two tests that took the longest to run.

Each test was waiting five seconds for a timeout that we fully intended to happen. By shortening the timeout, we don't need to wait as long.

I'm not sure why we're really testing this, because I don't see how MongoDB will somehow in the future connect to hosts that don't exist.

This chops 10 seconds off from each run.