### PR TITLE
use a shared MongoDB client/store in blob tests

### DIFF
--- a/blob/store/structured/mongo/blob_repository_test.go
+++ b/blob/store/structured/mongo/blob_repository_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	requestTest "github.com/tidepool-org/platform/request/test"
-	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
-	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 	"github.com/tidepool-org/platform/test"
 	userTest "github.com/tidepool-org/platform/user/test"
 )
@@ -75,30 +73,25 @@ func AsInterfaceArray(blobs blob.BlobArray) []interface{} {
 }
 
 var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
-	var config *storeStructuredMongo.Config
 	var logger *logTest.Logger
 	var store *blobStoreStructuredMongo.Store
 
 	BeforeEach(func() {
-		config = storeStructuredMongoTest.NewConfig()
 		logger = logTest.NewLogger()
-	})
-
-	AfterEach(func() {
-		if store != nil {
-			store.Terminate(context.Background())
-		}
 	})
 
 	Context("with a new store", func() {
 		var blobsCollection *mongo.Collection
 
 		BeforeEach(func() {
-			var err error
-			store, err = blobStoreStructuredMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
+			store = GetSuiteStore()
 			blobsCollection = store.GetCollection("blobs")
+		})
+
+		AfterEach(func() {
+			if blobsCollection != nil {
+				blobsCollection.DeleteMany(context.Background(), bson.D{})
+			}
 		})
 
 		Context("NewBlobRepository", func() {

--- a/blob/store/structured/mongo/devicelogs_repository_test.go
+++ b/blob/store/structured/mongo/devicelogs_repository_test.go
@@ -23,36 +23,29 @@ import (
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
 	requestTest "github.com/tidepool-org/platform/request/test"
-	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
-	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 	userTest "github.com/tidepool-org/platform/user/test"
 )
 
 var _ = Describe("Mongo", func() {
-	var config *storeStructuredMongo.Config
 	var logger *logTest.Logger
 	var store *blobStoreStructuredMongo.Store
 
 	BeforeEach(func() {
-		config = storeStructuredMongoTest.NewConfig()
 		logger = logTest.NewLogger()
-	})
-
-	AfterEach(func() {
-		if store != nil {
-			store.Terminate(context.Background())
-		}
 	})
 
 	Context("with a new store", func() {
 		var deviceLogsCollection *mongo.Collection
 
 		BeforeEach(func() {
-			var err error
-			store, err = blobStoreStructuredMongo.NewStore(config)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
+			store = GetSuiteStore()
 			deviceLogsCollection = store.GetCollection("deviceLogs")
+		})
+
+		AfterEach(func() {
+			if deviceLogsCollection != nil {
+				deviceLogsCollection.DeleteMany(context.Background(), bson.D{})
+			}
 		})
 
 		Context("NewDeviceLogsRepository", func() {

--- a/blob/store/structured/mongo/mongo.go
+++ b/blob/store/structured/mongo/mongo.go
@@ -14,10 +14,11 @@ func NewStore(config *storeStructuredMongo.Config) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewStoreFromBase(store), nil
+}
 
-	return &Store{
-		Store: store,
-	}, nil
+func NewStoreFromBase(base *storeStructuredMongo.Store) *Store {
+	return &Store{Store: base}
 }
 
 func (s *Store) EnsureIndexes() error {

--- a/blob/store/structured/mongo/mongo_test.go
+++ b/blob/store/structured/mongo/mongo_test.go
@@ -2,127 +2,141 @@ package mongo_test
 
 import (
 	"context"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	blobStoreStructuredMongo "github.com/tidepool-org/platform/blob/store/structured/mongo"
 	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
-	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
 	storeStructuredMongoTest "github.com/tidepool-org/platform/store/structured/mongo/test"
 )
 
 var _ = Describe("Mongo", func() {
-	var config *storeStructuredMongo.Config
-	var store *blobStoreStructuredMongo.Store
-
-	BeforeEach(func() {
-		config = storeStructuredMongoTest.NewConfig()
-	})
-
-	AfterEach(func() {
-		if store != nil {
-			store.Terminate(context.Background())
-		}
-	})
-
 	Context("NewStore", func() {
+		var createStore *blobStoreStructuredMongo.Store
+
+		AfterEach(func() {
+			if createStore != nil {
+				createStore.Terminate(context.Background())
+			}
+		})
+
 		It("returns an error when unsuccessful", func() {
-			var err error
-			store, err = blobStoreStructuredMongo.NewStore(nil)
+			createStore, err := blobStoreStructuredMongo.NewStore(nil)
 			errorsTest.ExpectEqual(err, errors.New("database config is empty"))
-			Expect(store).To(BeNil())
+			Expect(createStore).To(BeNil())
 		})
 
 		It("returns a new store and no error when successful", func() {
-			var err error
-			store, err = blobStoreStructuredMongo.NewStore(config)
+			config := storeStructuredMongoTest.NewConfig()
+			createStore, err := blobStoreStructuredMongo.NewStore(config)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(store).ToNot(BeNil())
-		})
-
-		Context("EnsureIndexes", func() {
-
-			var deviceLogsCollection *mongo.Collection
-			var blobsCollection *mongo.Collection
-
-			BeforeEach(func() {
-				var err error
-				store, err = blobStoreStructuredMongo.NewStore(config)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(store).ToNot(BeNil())
-				deviceLogsCollection = store.GetCollection("deviceLogs")
-				blobsCollection = store.GetCollection("blobs")
-			})
-
-			It("deviceLogs returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				cursor, err := deviceLogsCollection.Indexes().List(context.Background())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cursor).ToNot(BeNil())
-				var indexes []storeStructuredMongoTest.MongoIndex
-				err = cursor.All(context.Background(), &indexes)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Key": Equal(storeStructuredMongoTest.MakeKeySlice("_id")),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key":    Equal(storeStructuredMongoTest.MakeKeySlice("id")),
-						"Unique": Equal(true),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key": Equal(storeStructuredMongoTest.MakeKeySlice("userId", "startAtTime")),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key": Equal(storeStructuredMongoTest.MakeKeySlice("userId", "endAtTime")),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key": Equal(storeStructuredMongoTest.MakeKeySlice("startAtTime")),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key": Equal(storeStructuredMongoTest.MakeKeySlice("endAtTime")),
-					}),
-				))
-			})
-
-			It("blobs returns successfully", func() {
-				Expect(store.EnsureIndexes()).To(Succeed())
-				cursor, err := blobsCollection.Indexes().List(context.Background())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cursor).ToNot(BeNil())
-				var indexes []storeStructuredMongoTest.MongoIndex
-				err = cursor.All(context.Background(), &indexes)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(indexes).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Key": Equal(storeStructuredMongoTest.MakeKeySlice("_id")),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("id")),
-						"Background": Equal(true),
-						"Unique":     Equal(true),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("userId")),
-						"Background": Equal(true),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("mediaType")),
-						"Background": Equal(true),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("status")),
-						"Background": Equal(true),
-					}),
-				))
-			})
+			Expect(createStore).ToNot(BeNil())
 		})
 	})
 
+	Context("EnsureIndexes", func() {
+		var store *blobStoreStructuredMongo.Store
+		var deviceLogsCollection *mongo.Collection
+		var blobsCollection *mongo.Collection
+
+		BeforeEach(func() {
+			store = GetSuiteStore()
+			deviceLogsCollection = store.GetCollection("deviceLogs")
+			blobsCollection = store.GetCollection("blobs")
+		})
+
+		AfterEach(func() {
+			ctx := context.Background()
+			if deviceLogsCollection != nil {
+				deviceLogsCollection.DeleteMany(ctx, bson.D{})
+			}
+			if blobsCollection != nil {
+				blobsCollection.DeleteMany(ctx, bson.D{})
+			}
+		})
+
+		It("deviceLogs returns successfully", func() {
+			//Expect(store.EnsureIndexes()).To(Succeed())
+			cursor, err := deviceLogsCollection.Indexes().List(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cursor).ToNot(BeNil())
+			var indexes []storeStructuredMongoTest.MongoIndex
+			err = cursor.All(context.Background(), &indexes)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(indexes).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Key": Equal(storeStructuredMongoTest.MakeKeySlice("_id")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key":    Equal(storeStructuredMongoTest.MakeKeySlice("id")),
+					"Unique": Equal(true),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key": Equal(storeStructuredMongoTest.MakeKeySlice("userId", "startAtTime")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key": Equal(storeStructuredMongoTest.MakeKeySlice("userId", "endAtTime")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key": Equal(storeStructuredMongoTest.MakeKeySlice("startAtTime")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key": Equal(storeStructuredMongoTest.MakeKeySlice("endAtTime")),
+				}),
+			))
+		})
+
+		It("blobs returns successfully", func() {
+			//Expect(store.EnsureIndexes()).To(Succeed())
+			cursor, err := blobsCollection.Indexes().List(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cursor).ToNot(BeNil())
+			var indexes []storeStructuredMongoTest.MongoIndex
+			err = cursor.All(context.Background(), &indexes)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(indexes).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Key": Equal(storeStructuredMongoTest.MakeKeySlice("_id")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("id")),
+					"Background": Equal(true),
+					"Unique":     Equal(true),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("userId")),
+					"Background": Equal(true),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("mediaType")),
+					"Background": Equal(true),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Key":        Equal(storeStructuredMongoTest.MakeKeySlice("status")),
+					"Background": Equal(true),
+				}),
+			))
+		})
+	})
 })
+
+var suiteStore *blobStoreStructuredMongo.Store
+var suiteStoreOnce sync.Once
+
+func GetSuiteStore() *blobStoreStructuredMongo.Store {
+	GinkgoHelper()
+	suiteStoreOnce.Do(func() {
+		base := storeStructuredMongoTest.GetSuiteStore()
+		suiteStore = blobStoreStructuredMongo.NewStoreFromBase(base)
+		Expect(suiteStore.EnsureIndexes()).To(Succeed())
+	})
+	return suiteStore
+}

--- a/blob/store/structured/structured_test.go
+++ b/blob/store/structured/structured_test.go
@@ -1,6 +1,8 @@
 package structured_test
 
 import (
+	"sync"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -9,10 +11,12 @@ import (
 	blobStoreStructuredTest "github.com/tidepool-org/platform/blob/store/structured/test"
 	"github.com/tidepool-org/platform/crypto"
 	cryptoTest "github.com/tidepool-org/platform/crypto/test"
+	"github.com/tidepool-org/platform/data/store/mongo"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/net"
 	netTest "github.com/tidepool-org/platform/net/test"
 	"github.com/tidepool-org/platform/pointer"
+	mongotest "github.com/tidepool-org/platform/store/structured/mongo/test"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
 )
@@ -187,3 +191,16 @@ var _ = Describe("Structured", func() {
 		})
 	})
 })
+
+var suiteStore *mongo.Store
+var suiteStoreOnce sync.Once
+
+func GetSuiteStore() *mongo.Store {
+	GinkgoHelper()
+	suiteStoreOnce.Do(func() {
+		base := mongotest.GetSuiteStore()
+		suiteStore = mongo.NewStoreFromBase(base)
+		Expect(suiteStore.EnsureIndexes()).To(Succeed())
+	})
+	return suiteStore
+}


### PR DESCRIPTION
A quick test showed an reduction in runtime from 46s to 4.3s.