### PR TITLE
run both ci-test and go-ci-test via Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,8 @@ addons:
 
 script:
   - make ci-generate ci-build ci-test ci-deploy ci-docker
+  # Testing to see if go-ci-test catches the same failures as ci-test. If I
+  # understand how travis works, this means that go-ci-test will run even if
+  # ci-test fails, so we can see if they're catching the same
+  # things. Likewise, if go-ci-test fails, we can compare that to ci-test.
+  - make go-ci-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ addons:
     repo_token: 91ded9b66924acbe830541ab3593daf535f05f7c6db91b5cbd2d26dcf37da0b8
 
 script:
-  - make ci-generate ci-build ci-test ci-deploy ci-docker
+  - make ci-generate ci-build ci-test ci-deploy ci-docker TIMING_CMD="time -p"
   # Testing to see if go-ci-test catches the same failures as ci-test. If I
   # understand how travis works, this means that go-ci-test will run even if
   # ci-test fails, so we can see if they're catching the same
   # things. Likewise, if go-ci-test fails, we can compare that to ci-test.
-  - make go-ci-test
+  - make go-ci-test TIMING_CMD="time -p"

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ GINKGO_CI_FLAGS += $(GINKGO_CI_WATCH_FLAGS) --randomize-suites --keep-going
 GOTEST_PKGS ?= ./...
 GOTEST_FLAGS ?=
 
+TIMING_CMD ?=
+
 ifdef TRAVIS_BRANCH
 ifdef TRAVIS_COMMIT
     DOCKER:=true
@@ -212,7 +214,7 @@ test-watch: ginkgo
 
 ci-test: ginkgo
 	@echo "ginkgo $(GINKGO_FLAGS) $(GINKGO_CI_FLAGS) $(TEST)"
-	@cd $(ROOT_DIRECTORY) && . ./env.test.sh && ginkgo $(GINKGO_FLAGS) $(GINKGO_CI_FLAGS) $(TEST)
+	@cd $(ROOT_DIRECTORY) && . ./env.test.sh && $(TIMING_CMD) ginkgo $(GINKGO_FLAGS) $(GINKGO_CI_FLAGS) $(TEST)
 
 ci-test-until-failure: ginkgo
 	@echo "ginkgo $(GINKGO_FLAGS) $(GINKGO_CI_FLAGS) -untilItFails $(TEST)"
@@ -223,7 +225,7 @@ ci-test-watch: ginkgo
 	@cd $(ROOT_DIRECTORY) && . ./env.test.sh && ginkgo watch $(GINKGO_FLAGS) $(GINKGO_CI_WATCH_FLAGS) $(TEST)
 
 go-test:
-	. ./env.test.sh && go test $(GOTEST_FLAGS) $(GOTEST_PKGS)
+	. ./env.test.sh && $(TIMING_CMD) go test $(GOTEST_FLAGS) $(GOTEST_PKGS)
 
 go-ci-test: GOTEST_FLAGS += -count=1 -race -shuffle=on -cover
 go-ci-test: GOTEST_PKGS = ./...


### PR DESCRIPTION
This is intended as a trial to ensure that both make ci-test and make go-ci-test find the same errors. The latter is significantly faster, so it would be preferable to use it instead, but of course we need to ensure that we're not running things incorrectly or missing out on something provided by the current ginkgo-based solution.

For more info/discussion:
  - https://tidepoolteam.slack.com/archives/CF59ADWLB/p1727967169327199
  - https://github.com/tidepool-org/platform/pull/777