### PR TITLE
Makefile changes to support private repository builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ TIMESTAMP ?= $(shell date +%s)
 # these can vary by 1 second
 export TIMESTAMP
 
+ifeq ($(PRIVATE),true)
+  REPOSITORY_SUFFIX:=-private
+endif
+
 ROOT_DIRECTORY:=$(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 
 REPOSITORY_GOPATH:=$(word 1, $(subst :, ,$(GOPATH)))
 REPOSITORY_PACKAGE:=github.com/tidepool-org/platform
-REPOSITORY_NAME:=$(notdir $(REPOSITORY_PACKAGE))
+REPOSITORY_NAME:=$(notdir $(REPOSITORY_PACKAGE))$(REPOSITORY_SUFFIX)
 
 BIN_DIRECTORY := ${ROOT_DIRECTORY}/_bin
 PATH := ${PATH}:${BIN_DIRECTORY}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ ifeq ($(PRIVATE),true)
   REPOSITORY_SUFFIX:=-private
 endif
 
+SERVICES_SEPARATOR=,
+BUILD_SERVICES?=auth,blob,data,migrations,prescription,task,tools
+BUILD_SERVICES:=$(subst $(SERVICES_SEPARATOR), ,$(BUILD_SERVICES))
+
 ROOT_DIRECTORY:=$(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 
 REPOSITORY_GOPATH:=$(word 1, $(subst :, ,$(GOPATH)))
@@ -52,7 +56,11 @@ else ifdef TRAVIS_TAG
 	DOCKER:=true
 endif
 ifdef DOCKER_FILE
-	DOCKER_REPOSITORY:=tidepool/$(REPOSITORY_NAME)-$(patsubst .%,%,$(suffix $(DOCKER_FILE)))
+	SERVICE_NAME:=$(patsubst .%,%,$(suffix $(DOCKER_FILE)))
+	ifneq ($(filter $(SERVICE_NAME),$(BUILD_SERVICES)),)
+		BUILD_SERVICE:=true
+	endif
+	DOCKER_REPOSITORY:=tidepool/$(REPOSITORY_NAME)-$(SERVICE_NAME)
 endif
 
 default: test
@@ -273,6 +281,7 @@ endif
 docker-build:
 ifdef DOCKER
 ifdef DOCKER_FILE
+ifdef BUILD_SERVICE
 	docker build --tag $(DOCKER_REPOSITORY):development --target=development --file "$(DOCKER_FILE)" .
 	docker build --tag $(DOCKER_REPOSITORY) --file "$(DOCKER_FILE)" .
 ifdef TRAVIS_BRANCH
@@ -290,11 +299,15 @@ endif
 ifdef TRAVIS_TAG
 	docker tag $(DOCKER_REPOSITORY) $(DOCKER_REPOSITORY):$(TRAVIS_TAG:v%=%)
 endif
+else
+	@echo skipping $(DOCKER_FILE)
+endif
 endif
 endif
 
 docker-push:
 ifdef DOCKER
+ifdef BUILD_SERVICE:
 	@echo "DOCKER_REPOSITORY = $(DOCKER_REPOSITORY)"
 	@echo "TRAVIS_BRANCH = $(TRAVIS_BRANCH)"
 	@echo "TRAVIS_PULL_REQUEST_BRANCH = $(TRAVIS_PULL_REQUEST_BRANCH)"
@@ -320,6 +333,7 @@ endif
 endif
 ifdef TRAVIS_TAG
 	docker push $(DOCKER_REPOSITORY):$(TRAVIS_TAG:v%=%)
+endif
 endif
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ TIMESTAMP ?= $(shell date +%s)
 # these can vary by 1 second
 export TIMESTAMP
 
-ifeq ($(PRIVATE),true)
+ifneq ($(PRIVATE),)
   REPOSITORY_SUFFIX:=-private
 endif
 
 SERVICES_SEPARATOR=,
-BUILD_SERVICES?=auth,blob,data,migrations,prescription,task,tools
-BUILD_SERVICES:=$(subst $(SERVICES_SEPARATOR), ,$(BUILD_SERVICES))
+SERVICES_TO_BUILD?=auth,blob,data,migrations,prescription,task,tools
+SERVICES_TO_BUILD:=$(subst $(SERVICES_SEPARATOR), ,$(SERVICES_TO_BUILD))
 
 ROOT_DIRECTORY:=$(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 
@@ -57,7 +57,7 @@ else ifdef TRAVIS_TAG
 endif
 ifdef DOCKER_FILE
 	SERVICE_NAME:=$(patsubst .%,%,$(suffix $(DOCKER_FILE)))
-	ifneq ($(filter $(SERVICE_NAME),$(BUILD_SERVICES)),)
+	ifneq ($(filter $(SERVICE_NAME),$(SERVICES_TO_BUILD)),)
 		BUILD_SERVICE:=true
 	endif
 	DOCKER_REPOSITORY:=tidepool/$(REPOSITORY_NAME)-$(SERVICE_NAME)
@@ -307,7 +307,7 @@ endif
 
 docker-push:
 ifdef DOCKER
-ifdef BUILD_SERVICE:
+ifdef BUILD_SERVICE
 	@echo "DOCKER_REPOSITORY = $(DOCKER_REPOSITORY)"
 	@echo "TRAVIS_BRANCH = $(TRAVIS_BRANCH)"
 	@echo "TRAVIS_PULL_REQUEST_BRANCH = $(TRAVIS_PULL_REQUEST_BRANCH)"


### PR DESCRIPTION
- Conditionally add `-private` suffix to repository name by passing `$PRIVATE=true` environment variable
- Allow specifying a subset of services to be built (we'll only need to build `data` and `auth` services in the private repository