### PR TITLE
fixes a few flappy tests

### DIFF
--- a/request/mutator_test.go
+++ b/request/mutator_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the header even if there are already headers", func() {
-					existingKey := testHttp.NewHeaderKey()
+					existingKey := generateNewUniqueKey(testHttp.NewHeaderKey, map[string]any{key: struct{}{}})
 					existingValue := testHttp.NewHeaderValue()
 					request.Header.Add(existingKey, existingValue)
 					Expect(mutator.MutateRequest(request)).To(Succeed())
@@ -140,7 +140,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the parameter even if there are already parameters", func() {
-					existingKey := testHttp.NewParameterKey()
+					existingKey := generateNewUniqueKey(testHttp.NewParameterKey, map[string]any{key: struct{}{}})
 					existingValue := testHttp.NewParameterValue()
 					query := request.URL.Query()
 					query.Add(existingKey, existingValue)
@@ -217,7 +217,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the parameters even if there are already parameters", func() {
-					existingKey := testHttp.NewParameterKey()
+					existingKey := generateNewUniqueKey(testHttp.NewParameterKey, parameters)
 					existingValue := testHttp.NewParameterValue()
 					query := request.URL.Query()
 					query.Add(existingKey, existingValue)
@@ -306,7 +306,7 @@ var _ = Describe("Mutator", func() {
 				})
 
 				It("adds the parameters even if there are already parameters", func() {
-					existingKey := testHttp.NewParameterKey()
+					existingKey := generateNewUniqueKey(testHttp.NewParameterKey, parameters)
 					existingValue := test.RandomStringArrayFromRangeAndGeneratorWithDuplicates(1, 3, testHttp.NewParameterValue)
 					query := request.URL.Query()
 					query[existingKey] = existingValue

--- a/request/parser_test.go
+++ b/request/parser_test.go
@@ -16,6 +16,18 @@ import (
 	testHttp "github.com/tidepool-org/platform/test/http"
 )
 
+func generateNewUniqueKey[A any](f func() string, existingKeys map[string]A) string {
+	maxLoops := 1000
+	for loops := 0; loops < maxLoops; loops++ {
+		gen := f()
+		if _, found := existingKeys[gen]; !found {
+			return gen
+		}
+	}
+	Fail(fmt.Sprintf("unable to generate a unique key after %d tries", maxLoops), 1)
+	return ""
+}
+
 var _ = Describe("Parser", func() {
 	Context("with header", func() {
 		var header http.Header
@@ -23,7 +35,7 @@ var _ = Describe("Parser", func() {
 
 		BeforeEach(func() {
 			header = testHttp.RandomHeader()
-			key = testHttp.NewHeaderKey()
+			key = generateNewUniqueKey(testHttp.NewHeaderKey, header)
 		})
 
 		Context("ParseSingletonHeader", func() {


### PR DESCRIPTION
A few of these tests assumed that their generated keys were unique, when they weren't, which lead to flappy tests.

I'm not sure I've found them all, but I was able to run them with --repeat 20000 without a failure.