### PR TITLE
run only go-ci-test for CI testing needs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,4 @@ addons:
     repo_token: 91ded9b66924acbe830541ab3593daf535f05f7c6db91b5cbd2d26dcf37da0b8
 
 script:
-  - make ci-generate ci-build ci-test ci-deploy ci-docker TIMING_CMD="time -p"
-  # Testing to see if go-ci-test catches the same failures as ci-test. If I
-  # understand how travis works, this means that go-ci-test will run even if
-  # ci-test fails, so we can see if they're catching the same
-  # things. Likewise, if go-ci-test fails, we can compare that to ci-test.
-  - make go-ci-test TIMING_CMD="time -p"
+  - make ci-generate ci-build go-ci-test ci-deploy ci-docker TIMING_CMD="time -p"

--- a/Makefile
+++ b/Makefile
@@ -372,4 +372,4 @@ gopath-implode:
 	deploy deploy-services deploy-migrations deploy-tools ci-deploy bundle-deploy \
 	docker docker-build docker-push ci-docker \
 	clean clean-bin clean-cover clean-debug clean-deploy clean-all pre-commit \
-	gopath-implode go-test
+	gopath-implode go-test go-ci-test


### PR DESCRIPTION
Running ci tests via ginkgo is slower, and our tests[1] indicate that the results are identical, so just run the faster one.

[1]: https://tidepoolteam.slack.com/archives/CF59ADWLB/p1732571354736099