### PR TITLE
allow an access token without a user id to authenticate as a service

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -89,7 +89,9 @@ func (d *authDetails) Method() Method {
 }
 
 func (d *authDetails) IsService() bool {
-	return d.method == MethodServiceSecret || (d.method == MethodSessionToken && d.userID == "")
+	return d.method == MethodServiceSecret ||
+		(d.method == MethodSessionToken && d.userID == "") ||
+		(d.method == MethodAccessToken && d.userID == "")
 }
 
 func (d *authDetails) IsUser() bool {


### PR DESCRIPTION
"MethodAccessToken" is a valid way for a service to authenticate, and
could happen for example, when someone uses a oauth library to perform
authentication, rather than using the internal platform client.