### PR TITLE
[BACK-3392] Add OpenID sector for Abbott OAuth

### DIFF
--- a/data/service/api/v1/partners.go
+++ b/data/service/api/v1/partners.go
@@ -1,0 +1,46 @@
+package v1
+
+import (
+	"net/http"
+	"os"
+
+	dataService "github.com/tidepool-org/platform/data/service"
+	"github.com/tidepool-org/platform/request"
+)
+
+// TODO: https://tidepool.atlassian.net/browse/BACK-3394 - This implementation is a
+// temporary placeholder to allow bootstrapping of the Abbott OAuth client workflow.
+// Will need to migrate this to environment variables and add minimal authorization.
+// For now, though, this is acceptable since it isn't revealing anything that is not
+// already available in other locations (i.e. other public repos).
+
+func PartnersSector(dataServiceContext dataService.Context) {
+	res := dataServiceContext.Response()
+	req := dataServiceContext.Request()
+	responder := request.MustNewResponder(res, req)
+
+	if partnerSectorIdentifers, ok := namespacePartnerSectorIdentifers[os.Getenv("POD_NAMESPACE")]; ok {
+		if sectorIdentifier, ok := partnerSectorIdentifers[req.PathParam("partner")]; ok {
+			responder.Data(http.StatusOK, sectorIdentifier)
+			return
+		}
+	}
+
+	responder.Data(http.StatusOK, []string{})
+}
+
+var namespacePartnerSectorIdentifers = map[string]map[string][]string{
+	"external": {
+		"abbott": {
+			"https://external.integration.tidepool.org/v1/oauth/abbott/redirect",
+			"https://external.integration.tidepool.org/v1/oauth/abbott-private-1/redirect",
+			"https://external.integration.tidepool.org/v1/oauth/abbott-private-2/redirect",
+			"https://qa1.development.tidepool.org/v1/oauth/abbott/redirect",
+			"https://qa2.development.tidepool.org/v1/oauth/abbott/redirect",
+			"https://qa3.development.tidepool.org/v1/oauth/abbott/redirect",
+			"https://qa4.development.tidepool.org/v1/oauth/abbott/redirect",
+			"https://qa5.development.tidepool.org/v1/oauth/abbott/redirect",
+			"https://dev1.dev.tidepool.org/v1/oauth/abbott/redirect",
+		},
+	},
+}

--- a/data/service/api/v1/v1.go
+++ b/data/service/api/v1/v1.go
@@ -20,6 +20,8 @@ func Routes() []service.Route {
 		service.Put("/v1/data_sets/:dataSetId", DataSetsUpdate, api.RequireAuth),
 		service.Get("/v1/time", TimeGet),
 		service.Post("/v1/users/:userId/data_sets", UsersDataSetsCreate, api.RequireAuth),
+
+		service.Get("/v1/partners/:partner/sector", PartnersSector),
 	}
 
 	routes = append(routes, DataSetsRoutes()...)


### PR DESCRIPTION
Note: This implementation is a temporary placeholder to allow bootstrapping of the Abbott OAuth client workflow. Will need to migrate this to environment variables and add minimal authorization. For now, though, this is acceptable since it isn't revealing anything that is not already available in other locations (i.e. other public repos).

TODO: https://tidepool.atlassian.net/browse/BACK-3394
