### PR TITLE
[BACK-3442] Prevent panics if ehr sync tasks don't have a cadence set

### DIFF
--- a/ehr/sync/task.go
+++ b/ehr/sync/task.go
@@ -57,7 +57,13 @@ func ScheduleNextExecution(tsk *task.Task) {
 }
 
 func GetCadence(data map[string]interface{}) *time.Duration {
-	cadence := data["cadence"].(string)
+	if data == nil {
+		return nil
+	}
+	cadence, ok := data["cadence"].(string)
+	if !ok {
+		return nil
+	}
 	parsed, err := time.ParseDuration(cadence)
 	if err != nil {
 		return nil

--- a/ehr/sync/task_test.go
+++ b/ehr/sync/task_test.go
@@ -1,6 +1,8 @@
 package sync_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -28,6 +30,29 @@ var _ = Describe("Task", func() {
 			extracted, err := sync.GetClinicId(create.Data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(extracted).To(Equal(*clinic.Id))
+		})
+	})
+
+	Describe("GetCadence", func() {
+		It("returns nil if data is nil", func() {
+			result := sync.GetCadence(nil)
+			Expect(result).To(BeNil())
+		})
+
+		It("returns nil if data doesn't have cadence", func() {
+			result := sync.GetCadence(map[string]interface{}{})
+			Expect(result).To(BeNil())
+		})
+
+		It("returns nil if cadence is invalid", func() {
+			result := sync.GetCadence(map[string]interface{}{"cadence": "invalid"})
+			Expect(result).To(BeNil())
+		})
+
+		It("returns the parses cadence correctly", func() {
+			period := time.Duration(14) * time.Hour * 24
+			result := sync.GetCadence(map[string]interface{}{"cadence": period.String()})
+			Expect(result).To(PointTo(Equal(period)))
 		})
 	})
 })


### PR DESCRIPTION
EHR sync tasks fail if they don't have an explicitly set cadence because of a panic due to a nil pointer dereferencing. The intention in the original implementation was to use the default 14 days. 