### PR TITLE
[BACK-3461] Add trend rate units to cbg data type

### DIFF
--- a/data/blood/glucose/glucose.go
+++ b/data/blood/glucose/glucose.go
@@ -10,14 +10,24 @@ const (
 	MmolL = "mmol/L"
 	Mmoll = "mmol/l"
 
+	MmolLMinute = "mmol/L/minute"
+
 	MgdL = "mg/dL"
 	Mgdl = "mg/dl"
+
+	MgdLMinute = "mg/dL/minute"
 
 	MmolLMinimum float64 = 0.0
 	MmolLMaximum float64 = 55.0
 
+	MmolLMinuteMinimum float64 = -5.5
+	MmolLMinuteMaximum float64 = 5.5
+
 	MgdLMinimum float64 = 0.0
 	MgdLMaximum float64 = 1000.0
+
+	MgdLMinuteMinimum float64 = -100.0
+	MgdLMinuteMaximum float64 = 100.0
 
 	// MmolLToMgdLConversionFactor is MgdL Per MmolL.
 	//
@@ -32,6 +42,10 @@ const (
 
 func Units() []string {
 	return []string{MmolL, Mmoll, MgdL, Mgdl}
+}
+
+func RateUnits() []string {
+	return []string{MmolLMinute, MgdLMinute}
 }
 
 func ValueRangeForUnits(units *string) (float64, float64) {
@@ -60,7 +74,41 @@ func NormalizeValueForUnits(value *float64, units *string) *float64 {
 	if value != nil && units != nil {
 		switch *units {
 		case MgdL, Mgdl:
-			intValue := int(*value/MmolLToMgdLConversionFactor*MmolLToMgdLPrecisionFactor + 0.5)
+			intValue := int(*value/MmolLToMgdLConversionFactor*MmolLToMgdLPrecisionFactor + math.Copysign(0.5, *value))
+			floatValue := float64(intValue) / MmolLToMgdLPrecisionFactor
+			return &floatValue
+		}
+	}
+	return value
+}
+
+func ValueRangeForRateUnits(rateUnits *string) (float64, float64) {
+	if rateUnits != nil {
+		switch *rateUnits {
+		case MmolLMinute:
+			return MmolLMinuteMinimum, MmolLMinuteMaximum
+		case MgdLMinute:
+			return MgdLMinuteMinimum, MgdLMinuteMaximum
+		}
+	}
+	return -math.MaxFloat64, math.MaxFloat64
+}
+
+func NormalizeRateUnits(rateUnits *string) *string {
+	if rateUnits != nil {
+		switch *rateUnits {
+		case MmolLMinute, MgdLMinute:
+			return pointer.FromString(MmolLMinute)
+		}
+	}
+	return rateUnits
+}
+
+func NormalizeValueForRateUnits(value *float64, rateUnits *string) *float64 {
+	if value != nil && rateUnits != nil {
+		switch *rateUnits {
+		case MgdLMinute:
+			intValue := int(*value/MmolLToMgdLConversionFactor*MmolLToMgdLPrecisionFactor + math.Copysign(0.5, *value))
 			floatValue := float64(intValue) / MmolLToMgdLPrecisionFactor
 			return &floatValue
 		}

--- a/data/blood/glucose/glucose_test.go
+++ b/data/blood/glucose/glucose_test.go
@@ -19,12 +19,20 @@ var _ = Describe("Glucose", func() {
 		Expect(glucose.Mmoll).To(Equal("mmol/l"))
 	})
 
+	It("has MmolLMinute", func() {
+		Expect(glucose.MmolLMinute).To(Equal("mmol/L/minute"))
+	})
+
 	It("has MgdL", func() {
 		Expect(glucose.MgdL).To(Equal("mg/dL"))
 	})
 
 	It("has Mgdl", func() {
 		Expect(glucose.Mgdl).To(Equal("mg/dl"))
+	})
+
+	It("has MgdLMinute", func() {
+		Expect(glucose.MgdLMinute).To(Equal("mg/dL/minute"))
 	})
 
 	It("has MmolLMinimum", func() {
@@ -35,12 +43,28 @@ var _ = Describe("Glucose", func() {
 		Expect(glucose.MmolLMaximum).To(Equal(55.0))
 	})
 
+	It("has MmolLMinuteMinimum", func() {
+		Expect(glucose.MmolLMinuteMinimum).To(Equal(-5.5))
+	})
+
+	It("has MmolLMinuteMaximum", func() {
+		Expect(glucose.MmolLMinuteMaximum).To(Equal(5.5))
+	})
+
 	It("has MgdLMinimum", func() {
 		Expect(glucose.MgdLMinimum).To(Equal(0.0))
 	})
 
 	It("has MgdLMaximum", func() {
 		Expect(glucose.MgdLMaximum).To(Equal(1000.0))
+	})
+
+	It("has MgdLMinuteMinimum", func() {
+		Expect(glucose.MgdLMinuteMinimum).To(Equal(-100.0))
+	})
+
+	It("has MgdLMinuteMaximum", func() {
+		Expect(glucose.MgdLMinuteMaximum).To(Equal(100.0))
 	})
 
 	It("has MmolLToMgdLConversionFactor", func() {
@@ -54,6 +78,12 @@ var _ = Describe("Glucose", func() {
 	Context("Units", func() {
 		It("returns the expected units", func() {
 			Expect(glucose.Units()).To(ConsistOf("mmol/L", "mmol/l", "mg/dL", "mg/dl"))
+		})
+	})
+
+	Context("RateUnits", func() {
+		It("returns the expected units", func() {
+			Expect(glucose.RateUnits()).To(ConsistOf("mmol/L/minute", "mg/dL/minute"))
 		})
 	})
 
@@ -122,6 +152,69 @@ var _ = Describe("Glucose", func() {
 				normalizedValue := glucose.NormalizeValueForUnits(pointer.FromFloat64(float64(value)), pointer.FromString("mg/dL"))
 				Expect(normalizedValue).ToNot(BeNil())
 				Expect(int(*normalizedValue*18.01559 + 0.5)).To(Equal(value))
+			}
+		})
+	})
+
+	DescribeTable("ValueRangeForRateUnits",
+		func(rateUnits *string, expectedLower float64, expectedUpper float64) {
+			actualLower, actualUpper := glucose.ValueRangeForRateUnits(rateUnits)
+			Expect(actualLower).To(Equal(expectedLower))
+			Expect(actualUpper).To(Equal(expectedUpper))
+		},
+		Entry("returns no range for nil", nil, -math.MaxFloat64, math.MaxFloat64),
+		Entry("returns no range for unknown units", pointer.FromString("unknown"), -math.MaxFloat64, math.MaxFloat64),
+		Entry("returns expected range for mmol/L/minute units", pointer.FromString("mmol/L/minute"), -5.5, 5.5),
+		Entry("returns expected range for mg/dL/minute units", pointer.FromString("mg/dL/minute"), -100.0, 100.0),
+	)
+
+	DescribeTable("NormalizeRateUnits",
+		func(rateUnits *string, expectedRateUnits *string) {
+			actualRateUnits := glucose.NormalizeRateUnits(rateUnits)
+			if expectedRateUnits == nil {
+				Expect(actualRateUnits).To(BeNil())
+			} else {
+				Expect(actualRateUnits).ToNot(BeNil())
+				Expect(*actualRateUnits).To(Equal(*expectedRateUnits))
+			}
+		},
+		Entry("returns nil for nil", nil, nil),
+		Entry("returns unchanged units for unknown units", pointer.FromString("unknown"), pointer.FromString("unknown")),
+		Entry("returns mmol/L/minute for mmol/L/minute", pointer.FromString("mmol/L/minute"), pointer.FromString("mmol/L/minute")),
+		Entry("returns mmol/L/minute for mg/dL/minute", pointer.FromString("mg/dL/minute"), pointer.FromString("mmol/L/minute")),
+	)
+
+	Context("NormalizeValueForRateUnits", func() {
+		DescribeTable("given value and units",
+			func(value *float64, rateUnits *string, expectedValue *float64) {
+				actualValue := glucose.NormalizeValueForRateUnits(value, rateUnits)
+				if expectedValue == nil {
+					Expect(actualValue).To(BeNil())
+				} else {
+					Expect(actualValue).ToNot(BeNil())
+					Expect(*actualValue).To(Equal(*expectedValue))
+				}
+			},
+			Entry("returns nil for nil value", nil, pointer.FromString("mmol/L/minute"), nil),
+			Entry("returns unchanged value for nil units", pointer.FromFloat64(1.0), nil, pointer.FromFloat64(1.0)),
+			Entry("returns unchanged value for unknown units", pointer.FromFloat64(1.0), pointer.FromString("unknown"), pointer.FromFloat64(1.0)),
+			Entry("returns unchanged value for mmol/L/minute units", pointer.FromFloat64(1.0), pointer.FromString("mmol/L/minute"), pointer.FromFloat64(1.0)),
+			Entry("returns converted value for mg/dL/minute units", pointer.FromFloat64(18.0), pointer.FromString("mg/dL/minute"), pointer.FromFloat64(0.99913)),
+		)
+
+		It("properly normalizes a range of mmol/L/minute values", func() {
+			for value := glucose.MmolLMinuteMinimum; value <= glucose.MmolLMinuteMaximum; value += 0.1 {
+				normalizedValue := glucose.NormalizeValueForRateUnits(pointer.FromFloat64(float64(value)), pointer.FromString("mmol/L/minute"))
+				Expect(normalizedValue).ToNot(BeNil())
+				Expect(*normalizedValue).To(Equal(value))
+			}
+		})
+
+		It("properly normalizes a range of mg/dL/minute values", func() {
+			for value := int(glucose.MgdLMinuteMinimum); value <= int(glucose.MgdLMinuteMaximum); value++ {
+				normalizedValue := glucose.NormalizeValueForRateUnits(pointer.FromFloat64(float64(value)), pointer.FromString("mg/dL/minute"))
+				Expect(normalizedValue).ToNot(BeNil())
+				Expect(int(*normalizedValue*18.01559 + math.Copysign(0.5, float64(value)))).To(Equal(value))
 			}
 		})
 	})

--- a/data/blood/glucose/test/target.go
+++ b/data/blood/glucose/test/target.go
@@ -84,6 +84,26 @@ func ExpectNormalizedValue(value *float64, expectedValue *float64, units *string
 	}
 }
 
+func ExpectNormalizedRateUnits(value *string, expectedValue *string) {
+	if expectedValue != nil {
+		gomega.Expect(value).ToNot(gomega.BeNil())
+		gomega.Expect(*value).To(gomega.Equal(*dataBloodGlucose.NormalizeRateUnits(expectedValue)))
+		*expectedValue = *value
+	} else {
+		gomega.Expect(value).To(gomega.BeNil())
+	}
+}
+
+func ExpectNormalizedRateValue(value *float64, expectedValue *float64, units *string) {
+	if expectedValue != nil {
+		gomega.Expect(value).ToNot(gomega.BeNil())
+		gomega.Expect(*value).To(gomega.Equal(*dataBloodGlucose.NormalizeValueForRateUnits(expectedValue, units)))
+		*expectedValue = *value
+	} else {
+		gomega.Expect(value).To(gomega.BeNil())
+	}
+}
+
 func ExpectNormalizedTarget(datum *dataBloodGlucose.Target, expectedDatum *dataBloodGlucose.Target, units *string) {
 	gomega.Expect(datum).ToNot(gomega.BeNil())
 	gomega.Expect(expectedDatum).ToNot(gomega.BeNil())

--- a/data/types/blood/glucose/continuous/continuous.go
+++ b/data/types/blood/glucose/continuous/continuous.go
@@ -2,7 +2,8 @@ package continuous
 
 import (
 	"github.com/tidepool-org/platform/data"
-	"github.com/tidepool-org/platform/data/types/blood/glucose"
+	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
+	dataTypesBloodGlucose "github.com/tidepool-org/platform/data/types/blood/glucose"
 	"github.com/tidepool-org/platform/structure"
 )
 
@@ -17,27 +18,34 @@ const (
 	RapidFall    = "rapidFall"
 	RapidRise    = "rapidRise"
 
-	TrendRateMaximum      = 100
-	TrendRateMinimum      = -100
 	SampleIntervalMinimum = 0
 	SampleIntervalMaximum = 24 * 60 * 60 * 1000
 )
 
 func Trends() []string {
-	return []string{ConstantRate, SlowFall, SlowRise, ModerateFall, ModerateRise, RapidFall, RapidRise}
+	return []string{
+		ConstantRate,
+		SlowFall,
+		SlowRise,
+		ModerateFall,
+		ModerateRise,
+		RapidFall,
+		RapidRise,
+	}
 }
 
 type Continuous struct {
-	glucose.Glucose `bson:",inline"`
-	Trend           *string  `json:"trend,omitempty" bson:"trend,omitempty"`
-	TrendRate       *float64 `json:"trendRate,omitempty" bson:"trendRate,omitempty"`
-	SampleInterval  *int     `json:"sampleInterval,omitempty" bson:"sampleInterval,omitempty"`
-	Backfilled      *bool    `json:"backfilled,omitempty" bson:"backfilled,omitempty"`
+	dataTypesBloodGlucose.Glucose `bson:",inline"`
+	Trend                         *string  `json:"trend,omitempty" bson:"trend,omitempty"`
+	TrendRateUnits                *string  `json:"trendRateUnits,omitempty" bson:"trendRateUnits,omitempty"`
+	TrendRate                     *float64 `json:"trendRate,omitempty" bson:"trendRate,omitempty"`
+	SampleInterval                *int     `json:"sampleInterval,omitempty" bson:"sampleInterval,omitempty"`
+	Backfilled                    *bool    `json:"backfilled,omitempty" bson:"backfilled,omitempty"`
 }
 
 func New() *Continuous {
 	return &Continuous{
-		Glucose: glucose.New(Type),
+		Glucose: dataTypesBloodGlucose.New(Type),
 	}
 }
 
@@ -49,6 +57,7 @@ func (c *Continuous) Parse(parser structure.ObjectParser) {
 	c.Glucose.Parse(parser)
 
 	c.Trend = parser.String("trend")
+	c.TrendRateUnits = parser.String("trendRateUnits")
 	c.TrendRate = parser.Float64("trendRate")
 	c.SampleInterval = parser.Int("sampleInterval")
 	c.Backfilled = parser.Bool("backfilled")
@@ -66,7 +75,12 @@ func (c *Continuous) Validate(validator structure.Validator) {
 	}
 
 	validator.String("trend", c.Trend).OneOf(Trends()...)
-	validator.Float64("trendRate", c.TrendRate).InRange(TrendRateMinimum, TrendRateMaximum)
+	if trendRateUnitsValidator := validator.String("trendRateUnits", c.TrendRateUnits); c.TrendRate != nil {
+		trendRateUnitsValidator.Exists().OneOf(dataBloodGlucose.RateUnits()...)
+	} else {
+		trendRateUnitsValidator.NotExists()
+	}
+	validator.Float64("trendRate", c.TrendRate).InRange(dataBloodGlucose.ValueRangeForRateUnits(c.TrendRateUnits))
 	validator.Int("sampleInterval", c.SampleInterval).InRange(SampleIntervalMinimum, SampleIntervalMaximum)
 }
 
@@ -76,4 +90,10 @@ func (c *Continuous) Normalize(normalizer data.Normalizer) {
 	}
 
 	c.Glucose.Normalize(normalizer)
+
+	if normalizer.Origin() == structure.OriginExternal {
+		rateUnits := c.TrendRateUnits
+		c.TrendRateUnits = dataBloodGlucose.NormalizeRateUnits(rateUnits)
+		c.TrendRate = dataBloodGlucose.NormalizeValueForRateUnits(c.TrendRate, rateUnits)
+	}
 }

--- a/data/types/blood/glucose/continuous/continuous_test.go
+++ b/data/types/blood/glucose/continuous/continuous_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	dataBloodGlucoseTest "github.com/tidepool-org/platform/data/blood/glucose/test"
 	dataNormalizer "github.com/tidepool-org/platform/data/normalizer"
 	"github.com/tidepool-org/platform/data/types"
@@ -18,18 +19,21 @@ import (
 	"github.com/tidepool-org/platform/test"
 )
 
-func NewMeta() interface{} {
+func NewMeta() any {
 	return &types.Meta{
 		Type: "cbg",
 	}
 }
 
-func NewContinuous(units *string) *continuous.Continuous {
+func RandomContinuous(units *string, rateUnits *string) *continuous.Continuous {
 	datum := continuous.New()
 	datum.Glucose = *dataTypesBloodGlucoseTest.NewGlucose(units)
 	datum.Type = "cbg"
 	datum.Trend = pointer.FromString(test.RandomStringFromArray(continuous.Trends()))
-	datum.TrendRate = pointer.FromFloat64(test.RandomFloat64FromRange(continuous.TrendRateMinimum, continuous.TrendRateMaximum))
+	datum.TrendRateUnits = rateUnits
+	if datum.TrendRateUnits != nil {
+		datum.TrendRate = pointer.FromFloat64(test.RandomFloat64FromRange(dataBloodGlucose.ValueRangeForRateUnits(datum.TrendRateUnits)))
+	}
 	datum.SampleInterval = pointer.FromInt(test.RandomIntFromRange(continuous.SampleIntervalMinimum, continuous.SampleIntervalMaximum))
 	datum.Backfilled = pointer.FromBool(test.RandomBool())
 	return datum
@@ -42,6 +46,7 @@ func CloneContinuous(datum *continuous.Continuous) *continuous.Continuous {
 	clone := continuous.New()
 	clone.Glucose = *dataTypesBloodGlucoseTest.CloneGlucose(&datum.Glucose)
 	clone.Trend = pointer.CloneString(datum.Trend)
+	clone.TrendRateUnits = pointer.CloneString(datum.TrendRateUnits)
 	clone.TrendRate = pointer.CloneFloat64(datum.TrendRate)
 	clone.SampleInterval = pointer.CloneInt(datum.SampleInterval)
 	clone.Backfilled = pointer.CloneBool(datum.Backfilled)
@@ -61,6 +66,7 @@ var _ = Describe("Continuous", func() {
 			Expect(datum.Units).To(BeNil())
 			Expect(datum.Value).To(BeNil())
 			Expect(datum.Trend).To(BeNil())
+			Expect(datum.TrendRateUnits).To(BeNil())
 			Expect(datum.TrendRate).To(BeNil())
 			Expect(datum.SampleInterval).To(BeNil())
 			Expect(datum.Backfilled).To(BeNil())
@@ -69,262 +75,525 @@ var _ = Describe("Continuous", func() {
 
 	Context("Validate", func() {
 		DescribeTable("validates the datum",
-			func(units *string, mutator func(datum *continuous.Continuous, units *string), expectedErrors ...error) {
-				datum := NewContinuous(units)
-				mutator(datum, units)
+			func(units *string, rateUnits *string, mutator func(datum *continuous.Continuous, units *string, rateUnits *string), expectedErrors ...error) {
+				datum := RandomContinuous(units, rateUnits)
+				mutator(datum, units, rateUnits)
 				dataTypesTest.ValidateWithExpectedOrigins(datum, structure.Origins(), expectedErrors...)
 			},
 			Entry("succeeds",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 			),
 			Entry("type missing",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Type = "" },
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Type = "" },
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &types.Meta{}),
 			),
 			Entry("type invalid",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Type = "invalidType" },
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Type = "invalidType" },
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotEqualTo("invalidType", "cbg"), "/type", &types.Meta{Type: "invalidType"}),
 			),
 			Entry("type cbg",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Type = "cbg" },
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Type = "cbg" },
 			),
 			Entry("units missing; value missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Value = nil },
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", NewMeta()),
 			),
 			Entry("units missing; value out of range (lower)",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(-0.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(-0.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 			),
 			Entry("units missing; value in range (lower)",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(0.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(0.0)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 			),
 			Entry("units missing; value in range (upper)",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(55.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(55.0)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 			),
 			Entry("units missing; value out of range (upper)",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(1000.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(1000.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", NewMeta()),
 			),
 			Entry("units invalid; value missing",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Value = nil },
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", NewMeta()),
 			),
 			Entry("units invalid; value out of range (lower)",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(-0.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(-0.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 			),
 			Entry("units invalid; value in range (lower)",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(0.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(0.0)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 			),
 			Entry("units invalid; value in range (upper)",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(55.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(55.0)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 			),
 			Entry("units invalid; value out of range (upper)",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(1000.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(1000.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L", "mmol/l", "mg/dL", "mg/dl"}), "/units", NewMeta()),
 			),
 			Entry("units mmol/L; value missing",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", NewMeta()),
 			),
 			Entry("units mmol/L; value out of range (lower)",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(-0.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(-0.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
 			),
 			Entry("units mmol/L; value in range (lower)",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(0.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(0.0)
+				},
 			),
 			Entry("units mmol/L; value in range (upper)",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(55.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(55.0)
+				},
 			),
 			Entry("units mmol/L; value out of range (upper)",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(55.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(55.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
 			),
 			Entry("units mmol/l; value missing",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", NewMeta()),
 			),
 			Entry("units mmol/l; value out of range (lower)",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(-0.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(-0.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 55.0), "/value", NewMeta()),
 			),
 			Entry("units mmol/l; value in range (lower)",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(0.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(0.0)
+				},
 			),
 			Entry("units mmol/l; value in range (upper)",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(55.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(55.0)
+				},
 			),
 			Entry("units mmol/l; value out of range (upper)",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(55.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(55.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(55.1, 0.0, 55.0), "/value", NewMeta()),
 			),
 			Entry("units mg/dL; value missing",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", NewMeta()),
 			),
 			Entry("units mg/dL; value out of range (lower)",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(-0.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(-0.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
 			),
 			Entry("units mg/dL; value in range (lower)",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(0.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(0.0)
+				},
 			),
 			Entry("units mg/dL; value in range (upper)",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(1000.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(1000.0)
+				},
 			),
 			Entry("units mg/dL; value out of range (upper)",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(1000.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(1000.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
 			),
 			Entry("units mg/dl; value missing",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", NewMeta()),
 			),
 			Entry("units mg/dl; value out of range (lower)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(-0.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(-0.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-0.1, 0.0, 1000.0), "/value", NewMeta()),
 			),
 			Entry("units mg/dl; value in range (lower)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(0.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(0.0)
+				},
 			),
 			Entry("units mg/dl; value in range (upper)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(1000.0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(1000.0)
+				},
 			),
 			Entry("units mg/dl; value out of range (upper)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = pointer.FromFloat64(1000.1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = pointer.FromFloat64(1000.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(1000.1, 0.0, 1000.0), "/value", NewMeta()),
 			),
 			Entry("trend missing",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Trend = nil },
 			),
 			Entry("trend empty",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("")
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("", continuous.Trends()), "/trend", NewMeta()),
 			),
 			Entry("trend invalid",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("invalid") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("invalid")
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", continuous.Trends()), "/trend", NewMeta()),
 			),
 			Entry("trend constant",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("constant") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("constant")
+				},
 			),
 			Entry("trend slowFall",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("slowFall") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("slowFall")
+				},
 			),
 			Entry("trend slowRise",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("slowRise") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("slowRise")
+				},
 			),
 			Entry("trend moderateFall",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("moderateFall") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("moderateFall")
+				},
 			),
 			Entry("trend moderateRise",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("moderateRise") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("moderateRise")
+				},
 			),
 			Entry("trend rapidFall",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("rapidFall") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("rapidFall")
+				},
 			),
 			Entry("trend rapidRise",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Trend = pointer.FromString("rapidRise") },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Trend = pointer.FromString("rapidRise")
+				},
 			),
-			Entry("trend rate missing",
-				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.TrendRate = nil },
+			Entry("trend rate units missing; trend rate missing",
+				pointer.FromString("mmol/L"),
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.TrendRate = nil },
 			),
-			Entry("trend rate out of range (lower)",
-				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.TrendRate = pointer.FromFloat64(-100.1) },
+			Entry("trend rate units missing; trend rate out of range (lower)",
+				pointer.FromString("mmol/L"),
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-5.51)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units missing; trend rate in range (lower)",
+				pointer.FromString("mmol/L"),
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-5.5)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units missing; trend rate in range (upper)",
+				pointer.FromString("mmol/L"),
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(5.5)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units missing; trend rate out of range (upper)",
+				pointer.FromString("mmol/L"),
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(5.51)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units invalid; trend rate missing",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = nil
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units invalid; trend rate out of range (lower)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-5.51)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units invalid; trend rate in range (lower)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-5.5)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units invalid; trend rate in range (upper)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(5.5)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units invalid; trend rate out of range (upper)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(5.51)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units mmol/L/minute; trend rate missing",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = nil
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units mmol/L/minute; trend rate out of range (lower)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-5.51)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-5.51, -5.5, 5.5), "/trendRate", NewMeta()),
+			),
+			Entry("trend rate units mmol/L/minute; trend rate in range (lower)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-5.5)
+				},
+			),
+			Entry("trend rate units mmol/L/minute; trend rate in range (upper)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(5.5)
+				},
+			),
+			Entry("trend rate units mmol/L/minute; trend rate out of range (upper)",
+				pointer.FromString("mmol/L"),
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(5.51)
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(5.51, -5.5, 5.5), "/trendRate", NewMeta()),
+			),
+			Entry("trend rate units mg/dL/minute; trend rate missing",
+				pointer.FromString("mg/dL"),
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = nil
+				},
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/trendRateUnits", NewMeta()),
+			),
+			Entry("trend rate units mg/dL/minute; trend rate out of range (lower)",
+				pointer.FromString("mg/dL"),
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-100.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-100.1, -100.0, 100.0), "/trendRate", NewMeta()),
 			),
-			Entry("trend rate in range (lower)",
-				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.TrendRate = pointer.FromFloat64(-100.0) },
+			Entry("trend rate units mg/dL/minute; trend rate in range (lower)",
+				pointer.FromString("mg/dL"),
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(-100.0)
+				},
 			),
-			Entry("trend rate in range (upper)",
-				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.TrendRate = pointer.FromFloat64(100.0) },
+			Entry("trend rate units mg/dL/minute; trend rate in range (upper)",
+				pointer.FromString("mg/dL"),
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(100.0)
+				},
 			),
-			Entry("trend rate out of range (upper)",
-				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.TrendRate = pointer.FromFloat64(100.1) },
+			Entry("trend rate units mg/dL/minute; trend rate out of range (upper)",
+				pointer.FromString("mg/dL"),
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRate = pointer.FromFloat64(100.1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(100.1, -100.0, 100.0), "/trendRate", NewMeta()),
 			),
 			Entry("sample interval missing",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.SampleInterval = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.SampleInterval = nil },
 			),
 			Entry("sample interval out of range (lower)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.SampleInterval = pointer.FromInt(-1) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.SampleInterval = pointer.FromInt(-1)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 86400000), "/sampleInterval", NewMeta()),
 			),
 			Entry("sample interval in range (lower)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.SampleInterval = pointer.FromInt(0) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.SampleInterval = pointer.FromInt(0)
+				},
 			),
 			Entry("sample interval in range (upper)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.SampleInterval = pointer.FromInt(86400000) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.SampleInterval = pointer.FromInt(86400000)
+				},
 			),
 			Entry("sample interval out of range (upper)",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.SampleInterval = pointer.FromInt(86400001) },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.SampleInterval = pointer.FromInt(86400001)
+				},
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(86400001, 0, 86400000), "/sampleInterval", NewMeta()),
 			),
 			Entry("multiple errors",
 				nil,
-				func(datum *continuous.Continuous, units *string) {
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
 					datum.Type = ""
 					datum.Value = nil
 					datum.Trend = nil
@@ -334,7 +603,7 @@ var _ = Describe("Continuous", func() {
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &types.Meta{}),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", &types.Meta{}),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", &types.Meta{}),
-				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-100.1, -100.0, 100.0), "/trendRate", &types.Meta{}),
+				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", &types.Meta{}),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 86400000), "/sampleInterval", &types.Meta{}),
 			),
 		)
@@ -342,10 +611,10 @@ var _ = Describe("Continuous", func() {
 
 	Context("Normalize", func() {
 		DescribeTable("normalizes the datum",
-			func(units *string, mutator func(datum *continuous.Continuous, units *string), expectator func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string)) {
+			func(units *string, rateUnits *string, mutator func(datum *continuous.Continuous, units *string, rateUnits *string), expectator func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string)) {
 				for _, origin := range structure.Origins() {
-					datum := NewContinuous(units)
-					mutator(datum, units)
+					datum := RandomContinuous(units, rateUnits)
+					mutator(datum, units, rateUnits)
 					expectedDatum := CloneContinuous(datum)
 					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
@@ -353,47 +622,70 @@ var _ = Describe("Continuous", func() {
 					Expect(normalizer.Error()).To(BeNil())
 					Expect(normalizer.Data()).To(BeEmpty())
 					if expectator != nil {
-						expectator(datum, expectedDatum, units)
+						expectator(datum, expectedDatum, units, rateUnits)
 					}
 					Expect(datum).To(Equal(expectedDatum))
 				}
 			},
 			Entry("does not modify the datum; units missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) {},
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units missing; value missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Value = nil },
 				nil,
 			),
 			Entry("does not modify the datum; units invalid",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units invalid; value missing",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Value = nil },
 				nil,
 			),
 			Entry("does not modify the datum; trend missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Trend = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.Trend = nil },
+				nil,
+			),
+			Entry("does not modify the datum; trend rate units invalid",
+				nil,
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRateUnits = pointer.FromString("invalid")
+				},
+				nil,
+			),
+			Entry("does not modify the datum; trend rate units invalid; trend rate missing",
+				nil,
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.TrendRateUnits = pointer.FromString("invalid")
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; trend rate missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.TrendRate = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.TrendRate = nil },
 				nil,
 			),
 		)
 
 		DescribeTable("normalizes the datum with origin external",
-			func(units *string, mutator func(datum *continuous.Continuous, units *string), expectator func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string)) {
-				datum := NewContinuous(units)
-				mutator(datum, units)
+			func(units *string, rateUnits *string, mutator func(datum *continuous.Continuous, units *string, rateUnits *string), expectator func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string)) {
+				datum := RandomContinuous(units, rateUnits)
+				mutator(datum, units, rateUnits)
 				expectedDatum := CloneContinuous(datum)
 				normalizer := dataNormalizer.New(logTest.NewLogger())
 				Expect(normalizer).ToNot(BeNil())
@@ -401,76 +693,106 @@ var _ = Describe("Continuous", func() {
 				Expect(normalizer.Error()).To(BeNil())
 				Expect(normalizer.Data()).To(BeEmpty())
 				if expectator != nil {
-					expectator(datum, expectedDatum, units)
+					expectator(datum, expectedDatum, units, rateUnits)
 				}
 				Expect(datum).To(Equal(expectedDatum))
 			},
 			Entry("does not modify the datum; units invalid; value missing",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; units mmol/L",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units mmol/L; value missing",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("modifies the datum; units mmol/l",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) {},
-				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string) {
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
+				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string) {
 					dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
 				},
 			),
 			Entry("modifies the datum; units mmol/l; value missing",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
-				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string) {
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
+				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string) {
 					dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
 				},
 			),
 			Entry("modifies the datum; units mg/dL",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) {},
-				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string) {
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
+				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string) {
 					dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
 					dataBloodGlucoseTest.ExpectNormalizedValue(datum.Value, expectedDatum.Value, units)
+					dataBloodGlucoseTest.ExpectNormalizedRateUnits(datum.TrendRateUnits, expectedDatum.TrendRateUnits)
+					dataBloodGlucoseTest.ExpectNormalizedRateValue(datum.TrendRate, expectedDatum.TrendRate, rateUnits)
 				},
 			),
 			Entry("modifies the datum; units mg/dL; value missing",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
-				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string) {
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
+				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string) {
 					dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
+					dataBloodGlucoseTest.ExpectNormalizedRateUnits(datum.TrendRateUnits, expectedDatum.TrendRateUnits)
 				},
 			),
 			Entry("modifies the datum; units mg/dl",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) {},
-				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string) {
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
+				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string) {
 					dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
 					dataBloodGlucoseTest.ExpectNormalizedValue(datum.Value, expectedDatum.Value, units)
+					dataBloodGlucoseTest.ExpectNormalizedRateUnits(datum.TrendRateUnits, expectedDatum.TrendRateUnits)
+					dataBloodGlucoseTest.ExpectNormalizedRateValue(datum.TrendRate, expectedDatum.TrendRate, rateUnits)
 				},
 			),
 			Entry("modifies the datum; units mg/dl; value missing",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
-				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string) {
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
+				func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string) {
 					dataBloodGlucoseTest.ExpectNormalizedUnits(datum.Units, expectedDatum.Units)
+					dataBloodGlucoseTest.ExpectNormalizedRateUnits(datum.TrendRateUnits, expectedDatum.TrendRateUnits)
 				},
 			),
 		)
 
 		DescribeTable("normalizes the datum with origin internal/store",
-			func(units *string, mutator func(datum *continuous.Continuous, units *string), expectator func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string)) {
+			func(units *string, rateUnits *string, mutator func(datum *continuous.Continuous, units *string, rateUnits *string), expectator func(datum *continuous.Continuous, expectedDatum *continuous.Continuous, units *string, rateUnits *string)) {
 				for _, origin := range []structure.Origin{structure.OriginInternal, structure.OriginStore} {
-					datum := NewContinuous(units)
-					mutator(datum, units)
+					datum := RandomContinuous(units, rateUnits)
+					mutator(datum, units, rateUnits)
 					expectedDatum := CloneContinuous(datum)
 					normalizer := dataNormalizer.New(logTest.NewLogger())
 					Expect(normalizer).ToNot(BeNil())
@@ -478,69 +800,99 @@ var _ = Describe("Continuous", func() {
 					Expect(normalizer.Error()).To(BeNil())
 					Expect(normalizer.Data()).To(BeEmpty())
 					if expectator != nil {
-						expectator(datum, expectedDatum, units)
+						expectator(datum, expectedDatum, units, rateUnits)
 					}
 					Expect(datum).To(Equal(expectedDatum))
 				}
 			},
 			Entry("does not modify the datum; units missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) {},
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units missing; value missing",
 				nil,
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				nil,
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; units invalid",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units invalid; value missing",
 				pointer.FromString("invalid"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("invalid"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; units mmol/L",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units mmol/L; value missing",
 				pointer.FromString("mmol/L"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; units mmol/l",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units mmol/l; value missing",
 				pointer.FromString("mmol/l"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("mmol/L/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; units mg/dL",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units mg/dL; value missing",
 				pointer.FromString("mg/dL"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 			Entry("does not modify the datum; units mg/dl",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) {},
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {},
 				nil,
 			),
 			Entry("does not modify the datum; units mg/dl; value missing",
 				pointer.FromString("mg/dl"),
-				func(datum *continuous.Continuous, units *string) { datum.Value = nil },
+				pointer.FromString("mg/dL/minute"),
+				func(datum *continuous.Continuous, units *string, rateUnits *string) {
+					datum.Value = nil
+					datum.TrendRate = nil
+				},
 				nil,
 			),
 		)

--- a/data/types/settings/cgm/rate_alert.go
+++ b/data/types/settings/cgm/rate_alert.go
@@ -3,13 +3,11 @@ package cgm
 import (
 	"math"
 
+	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	"github.com/tidepool-org/platform/structure"
 )
 
 const (
-	RateAlertUnitsMgdLMinute  = "mg/dL/minute"
-	RateAlertUnitsMmolLMinute = "mmol/L/minute"
-
 	FallAlertRateMgdLMinuteMaximum  = 10.0
 	FallAlertRateMgdLMinuteMinimum  = 0.0
 	FallAlertRateMmolLMinuteMaximum = 0.55507
@@ -19,13 +17,6 @@ const (
 	RiseAlertRateMmolLMinuteMaximum = 0.55507
 	RiseAlertRateMmolLMinuteMinimum = 0.05551
 )
-
-func RateAlertUnits() []string {
-	return []string{
-		RateAlertUnitsMgdLMinute,
-		RateAlertUnitsMmolLMinute,
-	}
-}
 
 type RateAlert struct {
 	Alert `bson:",inline"`
@@ -42,7 +33,7 @@ func (r *RateAlert) Parse(parser structure.ObjectParser) {
 func (r *RateAlert) Validate(validator structure.Validator) {
 	r.Alert.Validate(validator)
 	if unitsValidator := validator.String("units", r.Units); r.Rate != nil {
-		unitsValidator.Exists().OneOf(RateAlertUnits()...)
+		unitsValidator.Exists().OneOf(dataBloodGlucose.RateUnits()...)
 	} else {
 		unitsValidator.NotExists()
 	}
@@ -73,9 +64,9 @@ func (f *FallAlert) Validate(validator structure.Validator) {
 func FallAlertRateRangeForUnits(units *string) (float64, float64) {
 	if units != nil {
 		switch *units {
-		case RateAlertUnitsMgdLMinute:
+		case dataBloodGlucose.MgdLMinute:
 			return FallAlertRateMgdLMinuteMinimum, FallAlertRateMgdLMinuteMaximum
-		case RateAlertUnitsMmolLMinute:
+		case dataBloodGlucose.MmolLMinute:
 			return FallAlertRateMmolLMinuteMinimum, FallAlertRateMmolLMinuteMaximum
 		}
 	}
@@ -107,9 +98,9 @@ func (r *RiseAlert) Validate(validator structure.Validator) {
 func RiseAlertRateRangeForUnits(units *string) (float64, float64) {
 	if units != nil {
 		switch *units {
-		case RateAlertUnitsMgdLMinute:
+		case dataBloodGlucose.MgdLMinute:
 			return RiseAlertRateMgdLMinuteMinimum, RiseAlertRateMgdLMinuteMaximum
-		case RateAlertUnitsMmolLMinute:
+		case dataBloodGlucose.MmolLMinute:
 			return RiseAlertRateMmolLMinuteMinimum, RiseAlertRateMmolLMinuteMaximum
 		}
 	}

--- a/data/types/settings/cgm/rate_alert_test.go
+++ b/data/types/settings/cgm/rate_alert_test.go
@@ -16,14 +16,6 @@ import (
 )
 
 var _ = Describe("RateAlert", func() {
-	It("RateAlertUnitsMgdLMinute is expected", func() {
-		Expect(dataTypesSettingsCgm.RateAlertUnitsMgdLMinute).To(Equal("mg/dL/minute"))
-	})
-
-	It("RateAlertUnitsMmolLMinute is expected", func() {
-		Expect(dataTypesSettingsCgm.RateAlertUnitsMmolLMinute).To(Equal("mmol/L/minute"))
-	})
-
 	It("FallAlertRateMgdLMinuteMaximum is expected", func() {
 		Expect(dataTypesSettingsCgm.FallAlertRateMgdLMinuteMaximum).To(Equal(10.0))
 	})
@@ -54,10 +46,6 @@ var _ = Describe("RateAlert", func() {
 
 	It("RiseAlertRateMmolLMinuteMinimum is expected", func() {
 		Expect(dataTypesSettingsCgm.RiseAlertRateMmolLMinuteMinimum).To(Equal(0.05551))
-	})
-
-	It("RateAlertUnits returns expected", func() {
-		Expect(dataTypesSettingsCgm.RateAlertUnits()).To(Equal([]string{"mg/dL/minute", "mmol/L/minute"}))
 	})
 
 	Context("RateAlert", func() {
@@ -135,7 +123,7 @@ var _ = Describe("RateAlert", func() {
 						datum.Units = pointer.FromString("invalid")
 						datum.Rate = pointer.FromFloat64(test.RandomFloat64())
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mg/dL/minute", "mmol/L/minute"}), "/units"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/units"),
 				),
 				Entry("units mg/dL/minute; rate missing",
 					func(datum *dataTypesSettingsCgm.RateAlert) {
@@ -268,7 +256,7 @@ var _ = Describe("RateAlert", func() {
 						datum.Units = pointer.FromString("invalid")
 						datum.Rate = pointer.FromFloat64(test.RandomFloat64())
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mg/dL/minute", "mmol/L/minute"}), "/units"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/units"),
 				),
 				Entry("units mg/dL/minute; rate missing",
 					func(datum *dataTypesSettingsCgm.FallAlert) {
@@ -467,7 +455,7 @@ var _ = Describe("RateAlert", func() {
 						datum.Units = pointer.FromString("invalid")
 						datum.Rate = pointer.FromFloat64(test.RandomFloat64())
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mg/dL/minute", "mmol/L/minute"}), "/units"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"mmol/L/minute", "mg/dL/minute"}), "/units"),
 				),
 				Entry("units mg/dL/minute; rate missing",
 					func(datum *dataTypesSettingsCgm.RiseAlert) {

--- a/data/types/settings/cgm/test/rate_alert.go
+++ b/data/types/settings/cgm/test/rate_alert.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	dataBloodGlucose "github.com/tidepool-org/platform/data/blood/glucose"
 	dataTypesSettingsCgm "github.com/tidepool-org/platform/data/types/settings/cgm"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
@@ -10,7 +11,7 @@ func RandomRateAlert() *dataTypesSettingsCgm.RateAlert {
 	datum := &dataTypesSettingsCgm.RateAlert{}
 	datum.Alert = *RandomAlert()
 	datum.Rate = pointer.FromFloat64(test.RandomFloat64())
-	datum.Units = pointer.FromString(test.RandomStringFromArray(dataTypesSettingsCgm.RateAlertUnits()))
+	datum.Units = pointer.FromString(test.RandomStringFromArray(dataBloodGlucose.RateUnits()))
 	return datum
 }
 


### PR DESCRIPTION
- Add trend rate units to cbg data type
- Update general blood glucose functionality
- Use trend rate in Dexcom data
- https://tidepool.atlassian.net/browse/BACK-3461