### PR TITLE
strip kc: token if present before parsing token claims

### DIFF
--- a/data/service/api/v1/datasets_data_create.go
+++ b/data/service/api/v1/datasets_data_create.go
@@ -144,6 +144,7 @@ func CollectProvenanceInfo(ctx context.Context, req *rest.Request, authDetails r
 	if strings.HasPrefix(strings.ToLower(token), "bearer ") {
 		token = token[len("bearer "):]
 	}
+	token, _ = strings.CutPrefix(token, "kc:")
 
 	if token != "" && shouldHaveJWT(authDetails) {
 		claims := &TokenClaims{}


### PR DESCRIPTION
Intended to prevent egregious log entries.