### PR TITLE
Make trend rate units optional

### DIFF
--- a/data/types/blood/glucose/continuous/continuous.go
+++ b/data/types/blood/glucose/continuous/continuous.go
@@ -76,7 +76,7 @@ func (c *Continuous) Validate(validator structure.Validator) {
 
 	validator.String("trend", c.Trend).OneOf(Trends()...)
 	if trendRateUnitsValidator := validator.String("trendRateUnits", c.TrendRateUnits); c.TrendRate != nil {
-		trendRateUnitsValidator.Exists().OneOf(dataBloodGlucose.RateUnits()...)
+		trendRateUnitsValidator.OneOf(dataBloodGlucose.RateUnits()...)
 	} else {
 		trendRateUnitsValidator.NotExists()
 	}

--- a/data/types/blood/glucose/continuous/continuous_test.go
+++ b/data/types/blood/glucose/continuous/continuous_test.go
@@ -407,38 +407,6 @@ var _ = Describe("Continuous", func() {
 				nil,
 				func(datum *continuous.Continuous, units *string, rateUnits *string) { datum.TrendRate = nil },
 			),
-			Entry("trend rate units missing; trend rate out of range (lower)",
-				pointer.FromString("mmol/L"),
-				nil,
-				func(datum *continuous.Continuous, units *string, rateUnits *string) {
-					datum.TrendRate = pointer.FromFloat64(-5.51)
-				},
-				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
-			),
-			Entry("trend rate units missing; trend rate in range (lower)",
-				pointer.FromString("mmol/L"),
-				nil,
-				func(datum *continuous.Continuous, units *string, rateUnits *string) {
-					datum.TrendRate = pointer.FromFloat64(-5.5)
-				},
-				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
-			),
-			Entry("trend rate units missing; trend rate in range (upper)",
-				pointer.FromString("mmol/L"),
-				nil,
-				func(datum *continuous.Continuous, units *string, rateUnits *string) {
-					datum.TrendRate = pointer.FromFloat64(5.5)
-				},
-				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
-			),
-			Entry("trend rate units missing; trend rate out of range (upper)",
-				pointer.FromString("mmol/L"),
-				nil,
-				func(datum *continuous.Continuous, units *string, rateUnits *string) {
-					datum.TrendRate = pointer.FromFloat64(5.51)
-				},
-				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", NewMeta()),
-			),
 			Entry("trend rate units invalid; trend rate missing",
 				pointer.FromString("mmol/L"),
 				pointer.FromString("invalid"),
@@ -603,7 +571,6 @@ var _ = Describe("Continuous", func() {
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueEmpty(), "/type", &types.Meta{}),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/units", &types.Meta{}),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/value", &types.Meta{}),
-				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/trendRateUnits", &types.Meta{}),
 				errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 86400000), "/sampleInterval", &types.Meta{}),
 			),
 		)


### PR DESCRIPTION
DIY Loop doesn't send trend rate units which prevents CBG data from being uploaded due to too stringent validation. We could potentially try to infer trend rate units from the blood glucose units, but that doesn't seem ideal.