### PR TITLE
[BACK-2773/3474/3475] Updates to data model for twiist integration

### DIFF
--- a/data/types/bolus/bolus.go
+++ b/data/types/bolus/bolus.go
@@ -10,13 +10,32 @@ import (
 
 const (
 	Type = "bolus"
+
+	DeliveryContextAlgorithm    = "algorithm"
+	DeliveryContextDevice       = "device"
+	DeliveryContextOneButton    = "oneButton"
+	DeliveryContextRemote       = "remote"
+	DeliveryContextUndetermined = "undetermined"
+	DeliveryContextWatch        = "watch"
 )
+
+func DeliveryContexts() []string {
+	return []string{
+		DeliveryContextAlgorithm,
+		DeliveryContextDevice,
+		DeliveryContextOneButton,
+		DeliveryContextRemote,
+		DeliveryContextUndetermined,
+		DeliveryContextWatch,
+	}
+}
 
 type Bolus struct {
 	types.Base `bson:",inline"`
 
 	SubType string `json:"subType,omitempty" bson:"subType,omitempty"`
 
+	DeliveryContext    *string              `json:"deliveryContext,omitempty" bson:"deliveryContext,omitempty"`
 	InsulinFormulation *insulin.Formulation `json:"insulinFormulation,omitempty" bson:"insulinFormulation,omitempty"`
 }
 
@@ -42,6 +61,7 @@ func (b *Bolus) Meta() interface{} {
 func (b *Bolus) Parse(parser structure.ObjectParser) {
 	b.Base.Parse(parser)
 
+	b.DeliveryContext = parser.String("deliveryContext")
 	b.InsulinFormulation = insulin.ParseFormulation(parser.WithReferenceObjectParser("insulinFormulation"))
 }
 
@@ -54,6 +74,7 @@ func (b *Bolus) Validate(validator structure.Validator) {
 
 	validator.String("subType", &b.SubType).Exists().NotEmpty()
 
+	validator.String("deliveryContext", b.DeliveryContext).OneOf(DeliveryContexts()...)
 	if b.InsulinFormulation != nil {
 		b.InsulinFormulation.Validate(validator.WithReference("insulinFormulation"))
 	}

--- a/data/types/device/override/settings/pump/pump.go
+++ b/data/types/device/override/settings/pump/pump.go
@@ -15,7 +15,7 @@ const (
 	BasalRateScaleFactorMinimum          = 0.1
 	CarbohydrateRatioScaleFactorMaximum  = 10.0
 	CarbohydrateRatioScaleFactorMinimum  = 0.1
-	DurationMaximum                      = 604800 // 7 days in seconds
+	DurationMaximum                      = 604800000 // 7 days in milliseconds
 	DurationMinimum                      = 0
 	InsulinSensitivityScaleFactorMaximum = 10.0
 	InsulinSensitivityScaleFactorMinimum = 0.1
@@ -130,10 +130,6 @@ func (p *Pump) Validate(validator structure.Validator) {
 		}
 	} else if p.BloodGlucoseTarget != nil {
 		unitsValidator.ReportError(structureValidator.ErrorValueNotExists())
-	}
-
-	if p.BloodGlucoseTarget == nil && p.BasalRateScaleFactor == nil && p.CarbohydrateRatioScaleFactor == nil && p.InsulinSensitivityScaleFactor == nil {
-		validator.ReportError(structureValidator.ErrorValuesNotExistForAny("bgTarget", "basalRateScaleFactor", "carbRatioScaleFactor", "insulinSensitivityScaleFactor"))
 	}
 }
 

--- a/data/types/device/override/settings/pump/pump_test.go
+++ b/data/types/device/override/settings/pump/pump_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Pump", func() {
 	})
 
 	It("DurationMaximum is expected", func() {
-		Expect(dataTypesDeviceOverrideSettingsPump.DurationMaximum).To(Equal(604800))
+		Expect(dataTypesDeviceOverrideSettingsPump.DurationMaximum).To(Equal(604800000))
 	})
 
 	It("DurationMinimum is expected", func() {
@@ -370,7 +370,7 @@ var _ = Describe("Pump", func() {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = nil
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/duration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration; in range (lower)",
 					pointer.FromString("mmol/L"),
@@ -382,22 +382,22 @@ var _ = Describe("Pump", func() {
 				Entry("duration; in range (upper)",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
-						datum.Duration = pointer.FromInt(604800)
+						datum.Duration = pointer.FromInt(604800000)
 						datum.DurationExpected = nil
 					},
 				),
 				Entry("duration; out of range (upper)",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
-						datum.Duration = pointer.FromInt(604801)
+						datum.Duration = pointer.FromInt(604800001)
 						datum.DurationExpected = nil
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604801, 0, 604800), "/duration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration expected missing",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
-						datum.Duration = pointer.FromInt(test.RandomIntFromRange(0, 604800))
+						datum.Duration = pointer.FromInt(test.RandomIntFromRange(0, 604800000))
 						datum.DurationExpected = nil
 					},
 				),
@@ -407,7 +407,7 @@ var _ = Describe("Pump", func() {
 						datum.Duration = nil
 						datum.DurationExpected = pointer.FromInt(-1)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/expectedDuration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration expected; duration missing; in range (lower)",
 					pointer.FromString("mmol/L"),
@@ -420,16 +420,16 @@ var _ = Describe("Pump", func() {
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
 						datum.Duration = nil
-						datum.DurationExpected = pointer.FromInt(604800)
+						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 				),
 				Entry("duration expected; duration missing; out of range (upper)",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
 						datum.Duration = nil
-						datum.DurationExpected = pointer.FromInt(604801)
+						datum.DurationExpected = pointer.FromInt(604800001)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604801, 0, 604800), "/expectedDuration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration expected; duration out of range; out of range (lower)",
 					pointer.FromString("mmol/L"),
@@ -437,8 +437,8 @@ var _ = Describe("Pump", func() {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = pointer.FromInt(-1)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/duration", NewMeta()),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/expectedDuration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration expected; duration out of range; in range (lower)",
 					pointer.FromString("mmol/L"),
@@ -446,7 +446,7 @@ var _ = Describe("Pump", func() {
 						datum.Duration = pointer.FromInt(-1)
 						datum.DurationExpected = pointer.FromInt(0)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/duration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", NewMeta()),
 				),
 				Entry("duration expected; out of range (lower)",
 					pointer.FromString("mmol/L"),
@@ -454,7 +454,7 @@ var _ = Describe("Pump", func() {
 						datum.Duration = pointer.FromInt(3600)
 						datum.DurationExpected = pointer.FromInt(3599)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(3599, 3600, 604800), "/expectedDuration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(3599, 3600, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("duration expected; in range (lower)",
 					pointer.FromString("mmol/L"),
@@ -467,16 +467,16 @@ var _ = Describe("Pump", func() {
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
 						datum.Duration = pointer.FromInt(3600)
-						datum.DurationExpected = pointer.FromInt(604800)
+						datum.DurationExpected = pointer.FromInt(604800000)
 					},
 				),
 				Entry("duration expected; out of range (upper)",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
 						datum.Duration = pointer.FromInt(3600)
-						datum.DurationExpected = pointer.FromInt(604801)
+						datum.DurationExpected = pointer.FromInt(604800001)
 					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604801, 3600, 604800), "/expectedDuration", NewMeta()),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(604800001, 3600, 604800000), "/expectedDuration", NewMeta()),
 				),
 				Entry("units mmol/L; blood glucose target missing",
 					pointer.FromString("mmol/L"),
@@ -679,17 +679,6 @@ var _ = Describe("Pump", func() {
 						datum.BloodGlucoseTarget = dataBloodGlucoseTest.RandomTarget(unitsBloodGlucose)
 					},
 				),
-				Entry("one of required missing",
-					pointer.FromString("mmol/L"),
-					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
-						datum.BloodGlucoseTarget = nil
-						datum.BasalRateScaleFactor = nil
-						datum.CarbohydrateRatioScaleFactor = nil
-						datum.InsulinSensitivityScaleFactor = nil
-						datum.Units = nil
-					},
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValuesNotExistForAny("bgTarget", "basalRateScaleFactor", "carbRatioScaleFactor", "insulinSensitivityScaleFactor"), "", NewMeta()),
-				),
 				Entry("multiple errors",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesDeviceOverrideSettingsPump.Pump, unitsBloodGlucose *string) {
@@ -708,8 +697,8 @@ var _ = Describe("Pump", func() {
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotExists(), "/overrideType", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueExists(), "/overridePreset", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueStringNotOneOf("invalid", []string{"automatic", "manual"}), "/method", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/duration", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
-					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/expectedDuration", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
+					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/expectedDuration", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(0.09, 0.1, 10.0), "/basalRateScaleFactor", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(0.09, 0.1, 10.0), "/carbRatioScaleFactor", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),
 					errorsTest.WithPointerSourceAndMeta(structureValidator.ErrorValueNotInRange(0.09, 0.1, 10.0), "/insulinSensitivityScaleFactor", &dataTypesDevice.Meta{Type: "deviceEvent", SubType: "invalidSubType"}),

--- a/data/types/settings/pump/override_preset.go
+++ b/data/types/settings/pump/override_preset.go
@@ -15,7 +15,7 @@ const (
 	BasalRateScaleFactorMinimum          = 0.1
 	CarbohydrateRatioScaleFactorMaximum  = 10.0
 	CarbohydrateRatioScaleFactorMinimum  = 0.1
-	DurationMaximum                      = 604800 // 7 days in seconds
+	DurationMaximum                      = 604800000 // 7 days in milliseconds
 	DurationMinimum                      = 0
 	InsulinSensitivityScaleFactorMaximum = 10.0
 	InsulinSensitivityScaleFactorMinimum = 0.1

--- a/data/types/settings/pump/override_preset_test.go
+++ b/data/types/settings/pump/override_preset_test.go
@@ -41,7 +41,7 @@ var _ = Describe("OverridePreset", func() {
 	})
 
 	It("DurationMaximum is expected", func() {
-		Expect(dataTypesSettingsPump.DurationMaximum).To(Equal(604800))
+		Expect(dataTypesSettingsPump.DurationMaximum).To(Equal(604800000))
 	})
 
 	It("DurationMinimum is expected", func() {
@@ -193,7 +193,7 @@ var _ = Describe("OverridePreset", func() {
 					func(datum *dataTypesSettingsPump.OverridePreset, unitsBloodGlucose *string) {
 						datum.Duration = pointer.FromInt(-1)
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/duration"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration"),
 				),
 				Entry("duration; in range (lower)",
 					pointer.FromString("mmol/L"),
@@ -204,15 +204,15 @@ var _ = Describe("OverridePreset", func() {
 				Entry("duration; in range (upper)",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesSettingsPump.OverridePreset, unitsBloodGlucose *string) {
-						datum.Duration = pointer.FromInt(604800)
+						datum.Duration = pointer.FromInt(604800000)
 					},
 				),
 				Entry("duration; out of range (upper)",
 					pointer.FromString("mmol/L"),
 					func(datum *dataTypesSettingsPump.OverridePreset, unitsBloodGlucose *string) {
-						datum.Duration = pointer.FromInt(604801)
+						datum.Duration = pointer.FromInt(604800001)
 					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(604801, 0, 604800), "/duration"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(604800001, 0, 604800000), "/duration"),
 				),
 				Entry("units mmol/L; blood glucose target missing",
 					pointer.FromString("mmol/L"),
@@ -389,7 +389,7 @@ var _ = Describe("OverridePreset", func() {
 						datum.InsulinSensitivityScaleFactor = pointer.FromFloat64(0.09)
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/abbreviation"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(-1, 0, 604800), "/duration"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(-1, 0, 604800000), "/duration"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(0.09, 0.1, 10.0), "/basalRateScaleFactor"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(0.09, 0.1, 10.0), "/carbRatioScaleFactor"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(0.09, 0.1, 10.0), "/insulinSensitivityScaleFactor"),


### PR DESCRIPTION
- Use milliseconds for duration in pumpSettingsOverride
- Use milliseconds for duration in pumpSettings.overridePresets
- Add deliveryContext property to all bolus types
- Remove pumpSettingsOverride validation of required properties
- https://tidepool.atlassian.net/browse/BACK-2773
- https://tidepool.atlassian.net/browse/BACK-3474
- https://tidepool.atlassian.net/browse/BACK-3475