### PR TITLE
[BACK-3720] Remove unnecessary deploy targets in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,6 @@ addons:
     sources:
       - sourceline: 'deb https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse'
         key_url: 'https://pgp.mongodb.com/server-6.0.asc'
-  artifacts:
-    s3_region: us-west-2
-    paths:
-      - $(git ls-files -o deploy/*/*-*.tar.gz | tr "\n" ":")
-    target_paths:
-      - /
 
 script:
-  - make ci-generate ci-build go-ci-test ci-deploy ci-docker TIMING_CMD="time -p"
+  - make ci-generate ci-build go-ci-test ci-docker TIMING_CMD="time -p"

--- a/migrations/start.sh
+++ b/migrations/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/migrations/migrations

--- a/services/auth/start.sh
+++ b/services/auth/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/services/auth/auth

--- a/services/blob/start.sh
+++ b/services/blob/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/services/blob/blob

--- a/services/data/start.sh
+++ b/services/data/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/services/data/data

--- a/services/prescription/start.sh
+++ b/services/prescription/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/services/prescription/prescription

--- a/services/task/start.sh
+++ b/services/task/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/services/task/task

--- a/tools/start.sh
+++ b/tools/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh -eu
-
-. ./env.sh
-exec _bin/tools/tools


### PR DESCRIPTION
- Remove unnecessary deploy targets in Makefile
- Remove unnecessary gopath-implode target in Makefile
- Update .travis.yml
- https://tidepool.atlassian.net/browse/BACK-3720