### PR TITLE
[BACK-3723] Refactor data deduplicator dependencies

### DIFF
--- a/data/deduplicator/deduplicator.go
+++ b/data/deduplicator/deduplicator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 )
 
 type Factory interface {
@@ -13,9 +12,9 @@ type Factory interface {
 }
 
 type Deduplicator interface {
-	Open(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) (*data.DataSet, error)
-	AddData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error
-	DeleteData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, selectors *data.Selectors) error
-	Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error
-	Delete(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error
+	Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error)
+	AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error
+	DeleteData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
+	Close(ctx context.Context, dataSet *data.DataSet) error
+	Delete(ctx context.Context, dataSet *data.DataSet) error
 }

--- a/data/deduplicator/deduplicator/base.go
+++ b/data/deduplicator/deduplicator/base.go
@@ -4,18 +4,55 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/net"
 	"github.com/tidepool-org/platform/pointer"
 )
 
+type DataSetStore interface {
+	UpdateDataSet(ctx context.Context, id string, update *data.DataSetUpdate) (*data.DataSet, error)
+	DeleteDataSet(ctx context.Context, dataSet *data.DataSet) error
+}
+
+type DataStore interface {
+	CreateDataSetData(ctx context.Context, dataSet *data.DataSet, dataSetData []data.Datum) error
+	NewerDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) (*data.Selectors, error)
+	ActivateDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
+	ArchiveDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
+	DeleteDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
+	DestroyDeletedDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
+	DestroyDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
+
+	ArchiveDeviceDataUsingHashesFromDataSet(ctx context.Context, dataSet *data.DataSet) error
+	UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.Context, dataSet *data.DataSet) error
+	DeleteOtherDataSetData(ctx context.Context, dataSet *data.DataSet) error
+}
+
+type Dependencies struct {
+	DataSetStore DataSetStore
+	DataStore    DataStore
+}
+
+func (d Dependencies) Validate() error {
+	if d.DataSetStore == nil {
+		return errors.New("data set store is missing")
+	}
+	if d.DataStore == nil {
+		return errors.New("data store is missing")
+	}
+	return nil
+}
+
 type Base struct {
+	Dependencies
 	name    string
 	version string
 }
 
-func NewBase(name string, version string) (*Base, error) {
+func NewBase(dependencies Dependencies, name string, version string) (*Base, error) {
+	if err := dependencies.Validate(); err != nil {
+		return nil, errors.Wrap(err, "dependencies is invalid")
+	}
 	if name == "" {
 		return nil, errors.New("name is missing")
 	} else if !net.IsValidReverseDomain(name) {
@@ -28,8 +65,9 @@ func NewBase(name string, version string) (*Base, error) {
 	}
 
 	return &Base{
-		name:    name,
-		version: version,
+		Dependencies: dependencies,
+		name:         name,
+		version:      version,
 	}, nil
 }
 
@@ -45,12 +83,9 @@ func (b *Base) Get(ctx context.Context, dataSet *data.DataSet) (bool, error) {
 	return dataSet.HasDeduplicatorNameMatch(b.name), nil
 }
 
-func (b *Base) Open(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) (*data.DataSet, error) {
+func (b *Base) Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")
-	}
-	if repository == nil {
-		return nil, errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return nil, errors.New("data set is missing")
@@ -61,15 +96,12 @@ func (b *Base) Open(ctx context.Context, repository dataStore.DataRepository, da
 	update.Deduplicator = data.NewDeduplicatorDescriptor()
 	update.Deduplicator.Name = pointer.FromString(b.name)
 	update.Deduplicator.Version = pointer.FromString(b.version)
-	return repository.UpdateDataSet(ctx, *dataSet.UploadID, update)
+	return b.DataSetStore.UpdateDataSet(ctx, *dataSet.UploadID, update)
 }
 
-func (b *Base) AddData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error {
+func (b *Base) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -78,15 +110,12 @@ func (b *Base) AddData(ctx context.Context, repository dataStore.DataRepository,
 		return errors.New("data set data is missing")
 	}
 
-	return repository.CreateDataSetData(ctx, dataSet, dataSetData)
+	return b.DataStore.CreateDataSetData(ctx, dataSet, dataSetData)
 }
 
-func (b *Base) DeleteData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, selectors *data.Selectors) error {
+func (b *Base) DeleteData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -95,15 +124,12 @@ func (b *Base) DeleteData(ctx context.Context, repository dataStore.DataReposito
 		return errors.New("selectors is missing")
 	}
 
-	return repository.DestroyDataSetData(ctx, dataSet, selectors)
+	return b.DataStore.DestroyDataSetData(ctx, dataSet, selectors)
 }
 
-func (b *Base) Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (b *Base) Close(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -111,23 +137,20 @@ func (b *Base) Close(ctx context.Context, repository dataStore.DataRepository, d
 
 	update := data.NewDataSetUpdate()
 	update.Active = pointer.FromBool(true)
-	if _, err := repository.UpdateDataSet(ctx, *dataSet.UploadID, update); err != nil {
+	if _, err := b.DataSetStore.UpdateDataSet(ctx, *dataSet.UploadID, update); err != nil {
 		return err
 	}
 
-	return repository.ActivateDataSetData(ctx, dataSet, nil)
+	return b.DataStore.ActivateDataSetData(ctx, dataSet, nil)
 }
 
-func (b *Base) Delete(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (b *Base) Delete(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
 	}
 
-	return repository.DeleteDataSet(ctx, dataSet)
+	return b.DataSetStore.DeleteDataSet(ctx, dataSet)
 }

--- a/data/deduplicator/deduplicator/data_set_delete_origin_base.go
+++ b/data/deduplicator/deduplicator/data_set_delete_origin_base.go
@@ -4,38 +4,53 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 )
 
-type DataSetDeleteOriginProvider interface {
-	FilterData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) (data.Data, error)
+type DataSetDeleteOriginDataFilter interface {
+	FilterData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) (data.Data, error)
 	GetDataSelectors(datum data.Data) *data.Selectors
+}
+
+type DataSetDeleteOriginDependencies struct {
+	Dependencies
+	DataFilter DataSetDeleteOriginDataFilter
+}
+
+func (d DataSetDeleteOriginDependencies) Validate() error {
+	if err := d.Dependencies.Validate(); err != nil {
+		return err
+	}
+	if d.DataFilter == nil {
+		return errors.New("data filter is missing")
+	}
+	return nil
 }
 
 type DataSetDeleteOriginBase struct {
 	*Base
-	provider DataSetDeleteOriginProvider
+	DataFilter DataSetDeleteOriginDataFilter
 }
 
-func NewDataSetDeleteOriginBase(name string, version string, provider DataSetDeleteOriginProvider) (*DataSetDeleteOriginBase, error) {
-	base, err := NewBase(name, version)
+func NewDataSetDeleteOriginBase(dependencies DataSetDeleteOriginDependencies, name string, version string) (*DataSetDeleteOriginBase, error) {
+	if err := dependencies.Validate(); err != nil {
+		return nil, errors.Wrap(err, "dependencies is invalid")
+	}
+
+	base, err := NewBase(dependencies.Dependencies, name, version)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DataSetDeleteOriginBase{
-		Base:     base,
-		provider: provider,
+		Base:       base,
+		DataFilter: dependencies.DataFilter,
 	}, nil
 }
 
-func (d *DataSetDeleteOriginBase) Open(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) (*data.DataSet, error) {
+func (d *DataSetDeleteOriginBase) Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")
-	}
-	if repository == nil {
-		return nil, errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return nil, errors.New("data set is missing")
@@ -45,15 +60,12 @@ func (d *DataSetDeleteOriginBase) Open(ctx context.Context, repository dataStore
 		dataSet.Active = true
 	}
 
-	return d.Base.Open(ctx, repository, dataSet)
+	return d.Base.Open(ctx, dataSet)
 }
 
-func (d *DataSetDeleteOriginBase) AddData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error {
+func (d *DataSetDeleteOriginBase) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -67,29 +79,26 @@ func (d *DataSetDeleteOriginBase) AddData(ctx context.Context, repository dataSt
 	}
 
 	var err error
-	if dataSetData, err = d.provider.FilterData(ctx, repository, dataSet, dataSetData); err != nil {
+	if dataSetData, err = d.DataFilter.FilterData(ctx, dataSet, dataSetData); err != nil {
 		return err
 	}
 
-	if selectors := d.provider.GetDataSelectors(dataSetData); selectors != nil {
-		if err := repository.DeleteDataSetData(ctx, dataSet, selectors); err != nil {
+	if selectors := d.DataFilter.GetDataSelectors(dataSetData); selectors != nil {
+		if err := d.DataStore.DeleteDataSetData(ctx, dataSet, selectors); err != nil {
 			return err
 		}
-		if err := d.Base.AddData(ctx, repository, dataSet, dataSetData); err != nil {
+		if err := d.Base.AddData(ctx, dataSet, dataSetData); err != nil {
 			return err
 		}
-		return repository.DestroyDeletedDataSetData(ctx, dataSet, selectors)
+		return d.DataStore.DestroyDeletedDataSetData(ctx, dataSet, selectors)
 	}
 
-	return d.Base.AddData(ctx, repository, dataSet, dataSetData)
+	return d.Base.AddData(ctx, dataSet, dataSetData)
 }
 
-func (d *DataSetDeleteOriginBase) DeleteData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, selectors *data.Selectors) error {
+func (d *DataSetDeleteOriginBase) DeleteData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -98,15 +107,12 @@ func (d *DataSetDeleteOriginBase) DeleteData(ctx context.Context, repository dat
 		return errors.New("selectors is missing")
 	}
 
-	return repository.ArchiveDataSetData(ctx, dataSet, selectors)
+	return d.DataStore.ArchiveDataSetData(ctx, dataSet, selectors)
 }
 
-func (d *DataSetDeleteOriginBase) Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (d *DataSetDeleteOriginBase) Close(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -116,5 +122,5 @@ func (d *DataSetDeleteOriginBase) Close(ctx context.Context, repository dataStor
 		return nil
 	}
 
-	return d.Base.Close(ctx, repository, dataSet)
+	return d.Base.Close(ctx, dataSet)
 }

--- a/data/deduplicator/deduplicator/data_set_delete_origin_older_test.go
+++ b/data/deduplicator/deduplicator/data_set_delete_origin_older_test.go
@@ -27,184 +27,382 @@ var _ = Describe("DataSetDeleteOriginOlder", func() {
 		Expect(dataDeduplicatorDeduplicator.DataSetDeleteOriginOlderVersion).To(Equal("1.0.0"))
 	})
 
-	Context("NewDataSetDeleteOriginOlder", func() {
-		It("returns successfully", func() {
-			Expect(dataDeduplicatorDeduplicator.NewDataSetDeleteOriginOlder()).ToNot(BeNil())
-		})
-	})
-
-	Context("with new deduplicator", func() {
-		var deduplicator *dataDeduplicatorDeduplicator.DataSetDeleteOriginOlder
-		var dataSet *data.DataSet
+	Context("with dependencies", func() {
+		var dataSetRepository *dataStoreTest.DataRepository
+		var dataRepository *dataStoreTest.DataRepository
+		var dependencies dataDeduplicatorDeduplicator.Dependencies
 
 		BeforeEach(func() {
-			var err error
-			deduplicator, err = dataDeduplicatorDeduplicator.NewDataSetDeleteOriginOlder()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(deduplicator).ToNot(BeNil())
-			dataSet = dataTest.RandomDataSet()
-			dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin.older")
+			dataSetRepository = dataStoreTest.NewDataRepository()
+			dataRepository = dataStoreTest.NewDataRepository()
+			dependencies = dataDeduplicatorDeduplicator.Dependencies{
+				DataSetStore: dataSetRepository,
+				DataStore:    dataRepository,
+			}
 		})
 
-		Context("New", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
+		AfterEach(func() {
+			dataRepository.AssertOutputsEmpty()
+			dataSetRepository.AssertOutputsEmpty()
+		})
 
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+		Context("NewDataSetDeleteOriginOlder", func() {
+			It("returns successfully", func() {
+				Expect(dataDeduplicatorDeduplicator.NewDataSetDeleteOriginOlder(dependencies)).ToNot(BeNil())
 			})
 		})
 
-		Context("Get", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-		})
-
-		Context("with context and repository", func() {
-			var ctx context.Context
-			var repository *dataStoreTest.DataRepository
+		Context("with new deduplicator", func() {
+			var deduplicator *dataDeduplicatorDeduplicator.DataSetDeleteOriginOlder
+			var dataSet *data.DataSet
 
 			BeforeEach(func() {
-				ctx = context.Background()
-				repository = dataStoreTest.NewDataRepository()
+				var err error
+				deduplicator, err = dataDeduplicatorDeduplicator.NewDataSetDeleteOriginOlder(dependencies)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deduplicator).ToNot(BeNil())
+				dataSet = dataTest.RandomDataSet()
+				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin.older")
 			})
 
-			AfterEach(func() {
-				repository.AssertOutputsEmpty()
-			})
-
-			Context("Open", func() {
-				It("returns an error when the context is missing", func() {
-					result, err := deduplicator.Open(nil, repository, dataSet)
-					Expect(err).To(MatchError("context is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the repository is missing", func() {
-					result, err := deduplicator.Open(ctx, nil, dataSet)
-					Expect(err).To(MatchError("repository is missing"))
-					Expect(result).To(BeNil())
-				})
-
+			Context("New", func() {
 				It("returns an error when the data set is missing", func() {
-					result, err := deduplicator.Open(ctx, repository, nil)
+					found, err := deduplicator.New(context.Background(), nil)
 					Expect(err).To(MatchError("data set is missing"))
-					Expect(result).To(BeNil())
+					Expect(found).To(BeFalse())
 				})
 
-				When("UpdateDataSet is invoked", func() {
-					var update *data.DataSetUpdate
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("Get", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.Get(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("with context", func() {
+				var ctx context.Context
+
+				BeforeEach(func() {
+					ctx = context.Background()
+				})
+
+				Context("Open", func() {
+					It("returns an error when the context is missing", func() {
+						result, err := deduplicator.Open(nil, dataSet)
+						Expect(err).To(MatchError("context is missing"))
+						Expect(result).To(BeNil())
+					})
+
+					It("returns an error when the data set is missing", func() {
+						result, err := deduplicator.Open(ctx, nil)
+						Expect(err).To(MatchError("data set is missing"))
+						Expect(result).To(BeNil())
+					})
+
+					When("UpdateDataSet is invoked", func() {
+						var update *data.DataSetUpdate
+
+						BeforeEach(func() {
+							update = data.NewDataSetUpdate()
+							update.Deduplicator = &data.DeduplicatorDescriptor{
+								Name:    pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin.older"),
+								Version: pointer.FromString("1.0.0"),
+							}
+						})
+
+						AfterEach(func() {
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
+						})
+
+						updateAssertions := func() {
+							When("the data set does not have a deduplicator", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator = nil
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+
+							When("the data set has a deduplicator with matching name and version does not exist", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator.Version = nil
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+
+							When("the data set has a deduplicator with matching name and version exists", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+						}
+
+						When("data set type is not specified", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = nil
+								update.Active = pointer.FromBool(false)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeFalse())
+							})
+
+							updateAssertions()
+						})
+
+						When("data set type is continuous", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("continuous")
+								update.Active = pointer.FromBool(true)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeTrue())
+							})
+
+							updateAssertions()
+						})
+
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+								update.Active = pointer.FromBool(false)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeFalse())
+							})
+
+							updateAssertions()
+						})
+					})
+				})
+
+				Context("AddData", func() {
+					var unfilteredDataSetData data.Data
+					var filteredDataSetData data.Data
+					var allDataSetData data.Data
+					var unfilteredSelectors *data.Selectors
+					var filteredSelectors *data.Selectors
 
 					BeforeEach(func() {
-						update = data.NewDataSetUpdate()
-						update.Deduplicator = &data.DeduplicatorDescriptor{
-							Name:    pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin.older"),
-							Version: pointer.FromString("1.0.0"),
+						unfilteredDataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
+						unfilteredSelectors = data.NewSelectors()
+						for index := range unfilteredDataSetData {
+							base := dataTypesTest.RandomBase()
+							unfilteredDataSetData[index] = base
+							*unfilteredSelectors = append(*unfilteredSelectors, &data.Selector{Origin: &data.SelectorOrigin{ID: pointer.CloneString(base.Origin.ID), Time: base.Origin.Time}})
 						}
+						filteredDataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
+						filteredSelectors = data.NewSelectors()
+						for index := range filteredDataSetData {
+							base := dataTypesTest.RandomBase()
+							base.Type = test.RandomStringFromArray([]string{"bolus", "food"})
+							filteredDataSetData[index] = base
+							*filteredSelectors = append(*filteredSelectors, &data.Selector{Origin: &data.SelectorOrigin{ID: pointer.CloneString(base.Origin.ID), Time: base.Origin.Time}})
+						}
+						allDataSetData = append(unfilteredDataSetData, filteredDataSetData...)
 					})
 
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.AddData(nil, dataSet, allDataSetData)).To(MatchError("context is missing"))
 					})
 
-					updateAssertions := func() {
-						When("the data set does not have a deduplicator", func() {
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.AddData(ctx, nil, allDataSetData)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the data set data is missing", func() {
+						Expect(deduplicator.AddData(ctx, dataSet, nil)).To(MatchError("data set data is missing"))
+					})
+
+					dataSetTypeAssertions := func() {
+						originAssertions := func() {
+							When("create data set data is invoked", func() {
+								AfterEach(func() {
+									Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: allDataSetData}}))
+								})
+
+								It("returns an error when create data set data returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Equal(responseErr))
+								})
+
+								It("returns successfully when create data set data returns successfully", func() {
+									dataRepository.CreateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Succeed())
+								})
+							})
+						}
+
+						When("data set data does not have an origin", func() {
 							BeforeEach(func() {
-								dataSet.Deduplicator = nil
+								for index := range allDataSetData {
+									base := dataTypesTest.RandomBase()
+									base.Origin = nil
+									allDataSetData[index] = base
+								}
 							})
 
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
+							originAssertions()
 						})
 
-						When("the data set has a deduplicator with matching name and version does not exist", func() {
+						When("data set data does not have an origin id", func() {
 							BeforeEach(func() {
-								dataSet.Deduplicator.Version = nil
+								for index := range allDataSetData {
+									base := dataTypesTest.RandomBase()
+									base.Origin.ID = nil
+									allDataSetData[index] = base
+								}
 							})
 
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
+							originAssertions()
 						})
 
-						When("the data set has a deduplicator with matching name and version exists", func() {
-							BeforeEach(func() {
-								dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
-							})
+						When("data set data has an origin id", func() {
+							When("newer data set data using origin ids is invoked", func() {
+								AfterEach(func() {
+									Expect(dataRepository.NewerDataSetDataInputs).To(Equal([]dataStoreTest.NewerDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: filteredSelectors}}))
+								})
 
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
+								It("returns an error when newer data set data using origin id returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.NewerDataSetDataOutputs = []dataStoreTest.NewerDataSetDataOutput{{Selectors: nil, Error: responseErr}}
+									Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Equal(responseErr))
+								})
 
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
+								When("delete data set data using origin ids is invoked", func() {
+									BeforeEach(func() {
+										dataRepository.NewerDataSetDataOutputs = []dataStoreTest.NewerDataSetDataOutput{{Selectors: filteredSelectors, Error: nil}}
+									})
+
+									AfterEach(func() {
+										Expect(dataRepository.DeleteDataSetDataInputs).To(Equal([]dataStoreTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: unfilteredSelectors}}))
+									})
+
+									It("returns an error when delete data set data using origin id returns an error", func() {
+										responseErr := errorsTest.RandomError()
+										dataRepository.DeleteDataSetDataOutputs = []error{responseErr}
+										Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Equal(responseErr))
+									})
+
+									When("create data set data is invoked", func() {
+										BeforeEach(func() {
+											dataRepository.DeleteDataSetDataOutputs = []error{nil}
+										})
+
+										AfterEach(func() {
+											Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: unfilteredDataSetData}}))
+										})
+
+										It("returns an error when create data set data returns an error", func() {
+											responseErr := errorsTest.RandomError()
+											dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+											Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Equal(responseErr))
+										})
+
+										When("destroy deleted data set data is invoked", func() {
+											BeforeEach(func() {
+												dataRepository.CreateDataSetDataOutputs = []error{nil}
+											})
+
+											AfterEach(func() {
+												Expect(dataRepository.DestroyDeletedDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDeletedDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: unfilteredSelectors}}))
+											})
+
+											It("returns an error when destroy deleted data set data returns an error", func() {
+												responseErr := errorsTest.RandomError()
+												dataRepository.DestroyDeletedDataSetDataOutputs = []error{responseErr}
+												Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Equal(responseErr))
+											})
+
+											It("returns successfully when destroy deleted data set data returns successfully", func() {
+												dataRepository.DestroyDeletedDataSetDataOutputs = []error{nil}
+												Expect(deduplicator.AddData(ctx, dataSet, allDataSetData)).To(Succeed())
+											})
+										})
+									})
+								})
 							})
 						})
 					}
@@ -212,393 +410,187 @@ var _ = Describe("DataSetDeleteOriginOlder", func() {
 					When("data set type is not specified", func() {
 						BeforeEach(func() {
 							dataSet.DataSetType = nil
-							update.Active = pointer.FromBool(false)
 						})
 
 						AfterEach(func() {
-							Expect(dataSet.Active).To(BeFalse())
+							for _, datum := range allDataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Active).To(BeFalse())
+							}
 						})
 
-						updateAssertions()
+						dataSetTypeAssertions()
 					})
 
 					When("data set type is continuous", func() {
 						BeforeEach(func() {
 							dataSet.DataSetType = pointer.FromString("continuous")
-							update.Active = pointer.FromBool(true)
 						})
 
 						AfterEach(func() {
-							Expect(dataSet.Active).To(BeTrue())
+							for _, datum := range allDataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Active).To(BeTrue())
+							}
 						})
 
-						updateAssertions()
+						dataSetTypeAssertions()
 					})
 
 					When("data set type is normal", func() {
 						BeforeEach(func() {
 							dataSet.DataSetType = pointer.FromString("normal")
-							update.Active = pointer.FromBool(false)
 						})
 
 						AfterEach(func() {
-							Expect(dataSet.Active).To(BeFalse())
-						})
-
-						updateAssertions()
-					})
-				})
-			})
-
-			Context("AddData", func() {
-				var unfilteredDataSetData data.Data
-				var filteredDataSetData data.Data
-				var allDataSetData data.Data
-				var unfilteredSelectors *data.Selectors
-				var filteredSelectors *data.Selectors
-
-				BeforeEach(func() {
-					unfilteredDataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
-					unfilteredSelectors = data.NewSelectors()
-					for index := range unfilteredDataSetData {
-						base := dataTypesTest.RandomBase()
-						unfilteredDataSetData[index] = base
-						*unfilteredSelectors = append(*unfilteredSelectors, &data.Selector{Origin: &data.SelectorOrigin{ID: pointer.CloneString(base.Origin.ID), Time: base.Origin.Time}})
-					}
-					filteredDataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
-					filteredSelectors = data.NewSelectors()
-					for index := range filteredDataSetData {
-						base := dataTypesTest.RandomBase()
-						base.Type = test.RandomStringFromArray([]string{"bolus", "food"})
-						filteredDataSetData[index] = base
-						*filteredSelectors = append(*filteredSelectors, &data.Selector{Origin: &data.SelectorOrigin{ID: pointer.CloneString(base.Origin.ID), Time: base.Origin.Time}})
-					}
-					allDataSetData = append(unfilteredDataSetData, filteredDataSetData...)
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.AddData(nil, repository, dataSet, allDataSetData)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.AddData(ctx, nil, dataSet, allDataSetData)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, nil, allDataSetData)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the data set data is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, dataSet, nil)).To(MatchError("data set data is missing"))
-				})
-
-				dataSetTypeAssertions := func() {
-					originAssertions := func() {
-						When("create data set data is invoked", func() {
-							AfterEach(func() {
-								Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: allDataSetData}}))
-							})
-
-							It("returns an error when create data set data returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.CreateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Equal(responseErr))
-							})
-
-							It("returns successfully when create data set data returns successfully", func() {
-								repository.CreateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Succeed())
-							})
-						})
-					}
-
-					When("data set data does not have an origin", func() {
-						BeforeEach(func() {
-							for index := range allDataSetData {
-								base := dataTypesTest.RandomBase()
-								base.Origin = nil
-								allDataSetData[index] = base
+							for _, datum := range allDataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Active).To(BeFalse())
 							}
 						})
 
-						originAssertions()
+						dataSetTypeAssertions()
+					})
+				})
+
+				Context("DeleteData", func() {
+					var selectors *data.Selectors
+
+					BeforeEach(func() {
+						selectors = dataTest.RandomSelectors()
 					})
 
-					When("data set data does not have an origin id", func() {
-						BeforeEach(func() {
-							for index := range allDataSetData {
-								base := dataTypesTest.RandomBase()
-								base.Origin.ID = nil
-								allDataSetData[index] = base
-							}
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.DeleteData(nil, dataSet, selectors)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, nil, selectors)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the selectors is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, dataSet, nil)).To(MatchError("selectors is missing"))
+					})
+
+					When("archive data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.ArchiveDataSetDataInputs).To(Equal([]dataStoreTest.ArchiveDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
 						})
 
-						originAssertions()
+						It("returns an error when archive data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.ArchiveDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when archive data set data returns successfully", func() {
+							dataRepository.ArchiveDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Succeed())
+						})
+					})
+				})
+
+				Context("Close", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Close(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					When("data set data has an origin id", func() {
-						When("newer data set data using origin ids is invoked", func() {
-							AfterEach(func() {
-								Expect(repository.NewerDataSetDataInputs).To(Equal([]dataStoreTest.NewerDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: filteredSelectors}}))
-							})
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Close(ctx, nil)).To(MatchError("data set is missing"))
+					})
 
-							It("returns an error when newer data set data using origin id returns an error", func() {
+					When("data set type is continuous", func() {
+						BeforeEach(func() {
+							dataSet.DataSetType = pointer.FromString("continuous")
+						})
+
+						It("returns successfully", func() {
+							Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
+						})
+					})
+
+					When("UpdateDataSet is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
+						})
+
+						updateAssertions := func() {
+							It("returns an error when update data set data returns an error", func() {
 								responseErr := errorsTest.RandomError()
-								repository.NewerDataSetDataOutputs = []dataStoreTest.NewerDataSetDataOutput{{Selectors: nil, Error: responseErr}}
-								Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Equal(responseErr))
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
 							})
 
-							When("delete data set data using origin ids is invoked", func() {
+							When("activate data set data is invoked", func() {
 								BeforeEach(func() {
-									repository.NewerDataSetDataOutputs = []dataStoreTest.NewerDataSetDataOutput{{Selectors: filteredSelectors, Error: nil}}
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
 								})
 
 								AfterEach(func() {
-									Expect(repository.DeleteDataSetDataInputs).To(Equal([]dataStoreTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: unfilteredSelectors}}))
+									Expect(dataRepository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
 								})
 
-								It("returns an error when delete data set data using origin id returns an error", func() {
+								It("returns an error when active data set data returns an error", func() {
 									responseErr := errorsTest.RandomError()
-									repository.DeleteDataSetDataOutputs = []error{responseErr}
-									Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Equal(responseErr))
+									dataRepository.ActivateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
 								})
 
-								When("create data set data is invoked", func() {
-									BeforeEach(func() {
-										repository.DeleteDataSetDataOutputs = []error{nil}
-									})
-
-									AfterEach(func() {
-										Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: unfilteredDataSetData}}))
-									})
-
-									It("returns an error when create data set data returns an error", func() {
-										responseErr := errorsTest.RandomError()
-										repository.CreateDataSetDataOutputs = []error{responseErr}
-										Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Equal(responseErr))
-									})
-
-									When("destroy deleted data set data is invoked", func() {
-										BeforeEach(func() {
-											repository.CreateDataSetDataOutputs = []error{nil}
-										})
-
-										AfterEach(func() {
-											Expect(repository.DestroyDeletedDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDeletedDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: unfilteredSelectors}}))
-										})
-
-										It("returns an error when destroy deleted data set data returns an error", func() {
-											responseErr := errorsTest.RandomError()
-											repository.DestroyDeletedDataSetDataOutputs = []error{responseErr}
-											Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Equal(responseErr))
-										})
-
-										It("returns successfully when destroy deleted data set data returns successfully", func() {
-											repository.DestroyDeletedDataSetDataOutputs = []error{nil}
-											Expect(deduplicator.AddData(ctx, repository, dataSet, allDataSetData)).To(Succeed())
-										})
-									})
+								It("returns successfully when active data set data returns successfully", func() {
+									dataRepository.ActivateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
 								})
 							})
-						})
-					})
-				}
-
-				When("data set type is not specified", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = nil
-					})
-
-					AfterEach(func() {
-						for _, datum := range allDataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Active).To(BeFalse())
 						}
-					})
 
-					dataSetTypeAssertions()
-				})
-
-				When("data set type is continuous", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("continuous")
-					})
-
-					AfterEach(func() {
-						for _, datum := range allDataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Active).To(BeTrue())
-						}
-					})
-
-					dataSetTypeAssertions()
-				})
-
-				When("data set type is normal", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("normal")
-					})
-
-					AfterEach(func() {
-						for _, datum := range allDataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Active).To(BeFalse())
-						}
-					})
-
-					dataSetTypeAssertions()
-				})
-			})
-
-			Context("DeleteData", func() {
-				var selectors *data.Selectors
-
-				BeforeEach(func() {
-					selectors = dataTest.RandomSelectors()
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.DeleteData(nil, repository, dataSet, selectors)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, nil, dataSet, selectors)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, nil, selectors)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the selectors is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, dataSet, nil)).To(MatchError("selectors is missing"))
-				})
-
-				When("archive data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.ArchiveDataSetDataInputs).To(Equal([]dataStoreTest.ArchiveDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-					})
-
-					It("returns an error when archive data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.ArchiveDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when archive data set data returns successfully", func() {
-						repository.ArchiveDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Succeed())
-					})
-				})
-			})
-
-			Context("Close", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Close(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Close(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Close(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("data set type is continuous", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("continuous")
-					})
-
-					It("returns successfully", func() {
-						Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
-					})
-				})
-
-				When("UpdateDataSet is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
-					})
-
-					updateAssertions := func() {
-						It("returns an error when update data set data returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-						})
-
-						When("activate data set data is invoked", func() {
+						When("data set type is not specified", func() {
 							BeforeEach(func() {
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								dataSet.DataSetType = nil
 							})
 
-							AfterEach(func() {
-								Expect(repository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
-							})
-
-							It("returns an error when active data set data returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.ActivateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-							})
-
-							It("returns successfully when active data set data returns successfully", func() {
-								repository.ActivateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
-							})
-						})
-					}
-
-					When("data set type is not specified", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = nil
+							updateAssertions()
 						})
 
-						updateAssertions()
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+							})
+
+							updateAssertions()
+						})
+					})
+				})
+
+				Context("Delete", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Delete(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					When("data set type is normal", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("normal")
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Delete(ctx, nil)).To(MatchError("data set is missing"))
+					})
+
+					When("delete data set is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
 						})
 
-						updateAssertions()
-					})
-				})
-			})
+						It("returns an error when delete data set returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataSetRepository.DeleteDataSetOutputs = []error{responseErr}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Equal(responseErr))
+						})
 
-			Context("Delete", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Delete(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Delete(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Delete(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("delete data set is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
-					})
-
-					It("returns an error when delete data set returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DeleteDataSetOutputs = []error{responseErr}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when delete data set returns successfully", func() {
-						repository.DeleteDataSetOutputs = []error{nil}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Succeed())
+						It("returns successfully when delete data set returns successfully", func() {
+							dataSetRepository.DeleteDataSetOutputs = []error{nil}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Succeed())
+						})
 					})
 				})
 			})

--- a/data/deduplicator/deduplicator/data_set_delete_origin_test.go
+++ b/data/deduplicator/deduplicator/data_set_delete_origin_test.go
@@ -23,194 +23,364 @@ var _ = Describe("DataSetDeleteOrigin", func() {
 		Expect(dataDeduplicatorDeduplicator.DataSetDeleteOriginName).To(Equal("org.tidepool.deduplicator.dataset.delete.origin"))
 	})
 
-	Context("NewDataSetDeleteOrigin", func() {
-		It("returns successfully", func() {
-			Expect(dataDeduplicatorDeduplicator.NewDataSetDeleteOrigin()).ToNot(BeNil())
-		})
-	})
-
-	Context("with new deduplicator", func() {
-		var deduplicator *dataDeduplicatorDeduplicator.DataSetDeleteOrigin
-		var dataSet *data.DataSet
+	Context("with dependencies", func() {
+		var dataSetRepository *dataStoreTest.DataRepository
+		var dataRepository *dataStoreTest.DataRepository
+		var dependencies dataDeduplicatorDeduplicator.Dependencies
 
 		BeforeEach(func() {
-			var err error
-			deduplicator, err = dataDeduplicatorDeduplicator.NewDataSetDeleteOrigin()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(deduplicator).ToNot(BeNil())
-			dataSet = dataTest.RandomDataSet()
-			dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin")
+			dataSetRepository = dataStoreTest.NewDataRepository()
+			dataRepository = dataStoreTest.NewDataRepository()
+			dependencies = dataDeduplicatorDeduplicator.Dependencies{
+				DataSetStore: dataSetRepository,
+				DataStore:    dataRepository,
+			}
 		})
 
-		Context("New", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
+		AfterEach(func() {
+			dataRepository.AssertOutputsEmpty()
+			dataSetRepository.AssertOutputsEmpty()
+		})
 
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
-			})
-
-			It("returns true when the deduplicator name matches deprecated", func() {
-				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous.origin")
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+		Context("NewDataSetDeleteOrigin", func() {
+			It("returns successfully", func() {
+				Expect(dataDeduplicatorDeduplicator.NewDataSetDeleteOrigin(dependencies)).ToNot(BeNil())
 			})
 		})
 
-		Context("Get", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-
-			It("returns true when the deduplicator name matches deprecated", func() {
-				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous.origin")
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-		})
-
-		Context("with context and repository", func() {
-			var ctx context.Context
-			var repository *dataStoreTest.DataRepository
+		Context("with new deduplicator", func() {
+			var deduplicator *dataDeduplicatorDeduplicator.DataSetDeleteOrigin
+			var dataSet *data.DataSet
 
 			BeforeEach(func() {
-				ctx = context.Background()
-				repository = dataStoreTest.NewDataRepository()
+				var err error
+				deduplicator, err = dataDeduplicatorDeduplicator.NewDataSetDeleteOrigin(dependencies)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deduplicator).ToNot(BeNil())
+				dataSet = dataTest.RandomDataSet()
+				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin")
 			})
 
-			AfterEach(func() {
-				repository.AssertOutputsEmpty()
-			})
-
-			Context("Open", func() {
-				It("returns an error when the context is missing", func() {
-					result, err := deduplicator.Open(nil, repository, dataSet)
-					Expect(err).To(MatchError("context is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the repository is missing", func() {
-					result, err := deduplicator.Open(ctx, nil, dataSet)
-					Expect(err).To(MatchError("repository is missing"))
-					Expect(result).To(BeNil())
-				})
-
+			Context("New", func() {
 				It("returns an error when the data set is missing", func() {
-					result, err := deduplicator.Open(ctx, repository, nil)
+					found, err := deduplicator.New(context.Background(), nil)
 					Expect(err).To(MatchError("data set is missing"))
-					Expect(result).To(BeNil())
+					Expect(found).To(BeFalse())
 				})
 
-				When("UpdateDataSet is invoked", func() {
-					var update *data.DataSetUpdate
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				})
+
+				It("returns true when the deduplicator name matches deprecated", func() {
+					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous.origin")
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("Get", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.Get(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+
+				It("returns true when the deduplicator name matches deprecated", func() {
+					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous.origin")
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("with context", func() {
+				var ctx context.Context
+
+				BeforeEach(func() {
+					ctx = context.Background()
+				})
+
+				Context("Open", func() {
+					It("returns an error when the context is missing", func() {
+						result, err := deduplicator.Open(nil, dataSet)
+						Expect(err).To(MatchError("context is missing"))
+						Expect(result).To(BeNil())
+					})
+
+					It("returns an error when the data set is missing", func() {
+						result, err := deduplicator.Open(ctx, nil)
+						Expect(err).To(MatchError("data set is missing"))
+						Expect(result).To(BeNil())
+					})
+
+					When("UpdateDataSet is invoked", func() {
+						var update *data.DataSetUpdate
+
+						BeforeEach(func() {
+							update = data.NewDataSetUpdate()
+							update.Deduplicator = &data.DeduplicatorDescriptor{
+								Name:    pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin"),
+								Version: pointer.FromString("1.0.0"),
+							}
+						})
+
+						AfterEach(func() {
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
+						})
+
+						updateAssertions := func() {
+							When("the data set does not have a deduplicator", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator = nil
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+
+							When("the data set has a deduplicator with matching name and version does not exist", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator.Version = nil
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+
+							When("the data set has a deduplicator with matching name and version exists", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+						}
+
+						When("data set type is not specified", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = nil
+								update.Active = pointer.FromBool(false)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeFalse())
+							})
+
+							updateAssertions()
+						})
+
+						When("data set type is continuous", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("continuous")
+								update.Active = pointer.FromBool(true)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeTrue())
+							})
+
+							updateAssertions()
+						})
+
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+								update.Active = pointer.FromBool(false)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeFalse())
+							})
+
+							updateAssertions()
+						})
+					})
+				})
+
+				Context("AddData", func() {
+					var dataSetData data.Data
+					var selectors *data.Selectors
 
 					BeforeEach(func() {
-						update = data.NewDataSetUpdate()
-						update.Deduplicator = &data.DeduplicatorDescriptor{
-							Name:    pointer.FromString("org.tidepool.deduplicator.dataset.delete.origin"),
-							Version: pointer.FromString("1.0.0"),
+						dataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
+						selectors = data.NewSelectors()
+						for index := range dataSetData {
+							base := dataTypesTest.RandomBase()
+							dataSetData[index] = base
+							*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: pointer.CloneString(base.Origin.ID)}})
 						}
 					})
 
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.AddData(nil, dataSet, dataSetData)).To(MatchError("context is missing"))
 					})
 
-					updateAssertions := func() {
-						When("the data set does not have a deduplicator", func() {
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.AddData(ctx, nil, dataSetData)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the data set data is missing", func() {
+						Expect(deduplicator.AddData(ctx, dataSet, nil)).To(MatchError("data set data is missing"))
+					})
+
+					dataSetTypeAssertions := func() {
+						originAssertions := func() {
+							When("create data set data is invoked", func() {
+								AfterEach(func() {
+									Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+								})
+
+								It("returns an error when create data set data returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
+								})
+
+								It("returns successfully when create data set data returns successfully", func() {
+									dataRepository.CreateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Succeed())
+								})
+							})
+						}
+
+						When("data set data does not have an origin", func() {
 							BeforeEach(func() {
-								dataSet.Deduplicator = nil
+								for index := range dataSetData {
+									base := dataTypesTest.RandomBase()
+									base.Origin = nil
+									dataSetData[index] = base
+								}
 							})
 
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
+							originAssertions()
 						})
 
-						When("the data set has a deduplicator with matching name and version does not exist", func() {
+						When("data set data does not have an origin id", func() {
 							BeforeEach(func() {
-								dataSet.Deduplicator.Version = nil
+								for index := range dataSetData {
+									base := dataTypesTest.RandomBase()
+									base.Origin.ID = nil
+									dataSetData[index] = base
+								}
 							})
 
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
+							originAssertions()
 						})
 
-						When("the data set has a deduplicator with matching name and version exists", func() {
-							BeforeEach(func() {
-								dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
-							})
+						When("data set data has an origin id", func() {
+							When("delete data set data using origin ids is invoked", func() {
+								AfterEach(func() {
+									Expect(dataRepository.DeleteDataSetDataInputs).To(Equal([]dataStoreTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+								})
 
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
+								It("returns an error when delete data set data using origin id returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.DeleteDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
+								})
 
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
+								When("create data set data is invoked", func() {
+									BeforeEach(func() {
+										dataRepository.DeleteDataSetDataOutputs = []error{nil}
+									})
+
+									AfterEach(func() {
+										Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+									})
+
+									It("returns an error when create data set data returns an error", func() {
+										responseErr := errorsTest.RandomError()
+										dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+										Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
+									})
+
+									When("destroy deleted data set data is invoked", func() {
+										BeforeEach(func() {
+											dataRepository.CreateDataSetDataOutputs = []error{nil}
+										})
+
+										AfterEach(func() {
+											Expect(dataRepository.DestroyDeletedDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDeletedDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+										})
+
+										It("returns an error when destroy deleted data set data returns an error", func() {
+											responseErr := errorsTest.RandomError()
+											dataRepository.DestroyDeletedDataSetDataOutputs = []error{responseErr}
+											Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
+										})
+
+										It("returns successfully when destroy deleted data set data returns successfully", func() {
+											dataRepository.DestroyDeletedDataSetDataOutputs = []error{nil}
+											Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Succeed())
+										})
+									})
+								})
 							})
 						})
 					}
@@ -218,365 +388,187 @@ var _ = Describe("DataSetDeleteOrigin", func() {
 					When("data set type is not specified", func() {
 						BeforeEach(func() {
 							dataSet.DataSetType = nil
-							update.Active = pointer.FromBool(false)
 						})
 
 						AfterEach(func() {
-							Expect(dataSet.Active).To(BeFalse())
+							for _, datum := range dataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Active).To(BeFalse())
+							}
 						})
 
-						updateAssertions()
+						dataSetTypeAssertions()
 					})
 
 					When("data set type is continuous", func() {
 						BeforeEach(func() {
 							dataSet.DataSetType = pointer.FromString("continuous")
-							update.Active = pointer.FromBool(true)
 						})
 
 						AfterEach(func() {
-							Expect(dataSet.Active).To(BeTrue())
+							for _, datum := range dataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Active).To(BeTrue())
+							}
 						})
 
-						updateAssertions()
+						dataSetTypeAssertions()
 					})
 
 					When("data set type is normal", func() {
 						BeforeEach(func() {
 							dataSet.DataSetType = pointer.FromString("normal")
-							update.Active = pointer.FromBool(false)
 						})
 
 						AfterEach(func() {
-							Expect(dataSet.Active).To(BeFalse())
-						})
-
-						updateAssertions()
-					})
-				})
-			})
-
-			Context("AddData", func() {
-				var dataSetData data.Data
-				var selectors *data.Selectors
-
-				BeforeEach(func() {
-					dataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
-					selectors = data.NewSelectors()
-					for index := range dataSetData {
-						base := dataTypesTest.RandomBase()
-						dataSetData[index] = base
-						*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: pointer.CloneString(base.Origin.ID)}})
-					}
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.AddData(nil, repository, dataSet, dataSetData)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.AddData(ctx, nil, dataSet, dataSetData)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, nil, dataSetData)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the data set data is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, dataSet, nil)).To(MatchError("data set data is missing"))
-				})
-
-				dataSetTypeAssertions := func() {
-					originAssertions := func() {
-						When("create data set data is invoked", func() {
-							AfterEach(func() {
-								Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
-							})
-
-							It("returns an error when create data set data returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.CreateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
-							})
-
-							It("returns successfully when create data set data returns successfully", func() {
-								repository.CreateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Succeed())
-							})
-						})
-					}
-
-					When("data set data does not have an origin", func() {
-						BeforeEach(func() {
-							for index := range dataSetData {
-								base := dataTypesTest.RandomBase()
-								base.Origin = nil
-								dataSetData[index] = base
+							for _, datum := range dataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Active).To(BeFalse())
 							}
 						})
 
-						originAssertions()
+						dataSetTypeAssertions()
+					})
+				})
+
+				Context("DeleteData", func() {
+					var selectors *data.Selectors
+
+					BeforeEach(func() {
+						selectors = dataTest.RandomSelectors()
 					})
 
-					When("data set data does not have an origin id", func() {
-						BeforeEach(func() {
-							for index := range dataSetData {
-								base := dataTypesTest.RandomBase()
-								base.Origin.ID = nil
-								dataSetData[index] = base
-							}
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.DeleteData(nil, dataSet, selectors)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, nil, selectors)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the selectors is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, dataSet, nil)).To(MatchError("selectors is missing"))
+					})
+
+					When("archive data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.ArchiveDataSetDataInputs).To(Equal([]dataStoreTest.ArchiveDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
 						})
 
-						originAssertions()
+						It("returns an error when archive data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.ArchiveDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when archive data set data returns successfully", func() {
+							dataRepository.ArchiveDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Succeed())
+						})
+					})
+				})
+
+				Context("Close", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Close(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					When("data set data has an origin id", func() {
-						When("delete data set data using origin ids is invoked", func() {
-							AfterEach(func() {
-								Expect(repository.DeleteDataSetDataInputs).To(Equal([]dataStoreTest.DeleteDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-							})
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Close(ctx, nil)).To(MatchError("data set is missing"))
+					})
 
-							It("returns an error when delete data set data using origin id returns an error", func() {
+					When("data set type is continuous", func() {
+						BeforeEach(func() {
+							dataSet.DataSetType = pointer.FromString("continuous")
+						})
+
+						It("returns successfully", func() {
+							Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
+						})
+					})
+
+					When("UpdateDataSet is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
+						})
+
+						updateAssertions := func() {
+							It("returns an error when update data set data returns an error", func() {
 								responseErr := errorsTest.RandomError()
-								repository.DeleteDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
 							})
 
-							When("create data set data is invoked", func() {
+							When("activate data set data is invoked", func() {
 								BeforeEach(func() {
-									repository.DeleteDataSetDataOutputs = []error{nil}
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
 								})
 
 								AfterEach(func() {
-									Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+									Expect(dataRepository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
 								})
 
-								It("returns an error when create data set data returns an error", func() {
+								It("returns an error when active data set data returns an error", func() {
 									responseErr := errorsTest.RandomError()
-									repository.CreateDataSetDataOutputs = []error{responseErr}
-									Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
+									dataRepository.ActivateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
 								})
 
-								When("destroy deleted data set data is invoked", func() {
-									BeforeEach(func() {
-										repository.CreateDataSetDataOutputs = []error{nil}
-									})
-
-									AfterEach(func() {
-										Expect(repository.DestroyDeletedDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDeletedDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-									})
-
-									It("returns an error when destroy deleted data set data returns an error", func() {
-										responseErr := errorsTest.RandomError()
-										repository.DestroyDeletedDataSetDataOutputs = []error{responseErr}
-										Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
-									})
-
-									It("returns successfully when destroy deleted data set data returns successfully", func() {
-										repository.DestroyDeletedDataSetDataOutputs = []error{nil}
-										Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Succeed())
-									})
+								It("returns successfully when active data set data returns successfully", func() {
+									dataRepository.ActivateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
 								})
 							})
-						})
-					})
-				}
-
-				When("data set type is not specified", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = nil
-					})
-
-					AfterEach(func() {
-						for _, datum := range dataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Active).To(BeFalse())
 						}
-					})
 
-					dataSetTypeAssertions()
-				})
-
-				When("data set type is continuous", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("continuous")
-					})
-
-					AfterEach(func() {
-						for _, datum := range dataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Active).To(BeTrue())
-						}
-					})
-
-					dataSetTypeAssertions()
-				})
-
-				When("data set type is normal", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("normal")
-					})
-
-					AfterEach(func() {
-						for _, datum := range dataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Active).To(BeFalse())
-						}
-					})
-
-					dataSetTypeAssertions()
-				})
-			})
-
-			Context("DeleteData", func() {
-				var selectors *data.Selectors
-
-				BeforeEach(func() {
-					selectors = dataTest.RandomSelectors()
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.DeleteData(nil, repository, dataSet, selectors)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, nil, dataSet, selectors)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, nil, selectors)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the selectors is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, dataSet, nil)).To(MatchError("selectors is missing"))
-				})
-
-				When("archive data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.ArchiveDataSetDataInputs).To(Equal([]dataStoreTest.ArchiveDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-					})
-
-					It("returns an error when archive data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.ArchiveDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when archive data set data returns successfully", func() {
-						repository.ArchiveDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Succeed())
-					})
-				})
-			})
-
-			Context("Close", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Close(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Close(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Close(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("data set type is continuous", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("continuous")
-					})
-
-					It("returns successfully", func() {
-						Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
-					})
-				})
-
-				When("UpdateDataSet is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
-					})
-
-					updateAssertions := func() {
-						It("returns an error when update data set data returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-						})
-
-						When("activate data set data is invoked", func() {
+						When("data set type is not specified", func() {
 							BeforeEach(func() {
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								dataSet.DataSetType = nil
 							})
 
-							AfterEach(func() {
-								Expect(repository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
-							})
-
-							It("returns an error when active data set data returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.ActivateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-							})
-
-							It("returns successfully when active data set data returns successfully", func() {
-								repository.ActivateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
-							})
-						})
-					}
-
-					When("data set type is not specified", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = nil
+							updateAssertions()
 						})
 
-						updateAssertions()
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+							})
+
+							updateAssertions()
+						})
+					})
+				})
+
+				Context("Delete", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Delete(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					When("data set type is normal", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("normal")
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Delete(ctx, nil)).To(MatchError("data set is missing"))
+					})
+
+					When("delete data set is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
 						})
 
-						updateAssertions()
-					})
-				})
-			})
+						It("returns an error when delete data set returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataSetRepository.DeleteDataSetOutputs = []error{responseErr}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Equal(responseErr))
+						})
 
-			Context("Delete", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Delete(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Delete(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Delete(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("delete data set is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
-					})
-
-					It("returns an error when delete data set returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DeleteDataSetOutputs = []error{responseErr}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when delete data set returns successfully", func() {
-						repository.DeleteDataSetOutputs = []error{nil}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Succeed())
+						It("returns successfully when delete data set returns successfully", func() {
+							dataSetRepository.DeleteDataSetOutputs = []error{nil}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Succeed())
+						})
 					})
 				})
 			})

--- a/data/deduplicator/deduplicator/device_deactivate_hash.go
+++ b/data/deduplicator/deduplicator/device_deactivate_hash.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 )
 
@@ -21,8 +20,8 @@ type DeviceDeactivateHash struct {
 	*Base
 }
 
-func NewDeviceDeactivateHash() (*DeviceDeactivateHash, error) {
-	base, err := NewBase(DeviceDeactivateHashName, "1.1.0")
+func NewDeviceDeactivateHash(dependencies Dependencies) (*DeviceDeactivateHash, error) {
+	base, err := NewBase(dependencies, DeviceDeactivateHashName, "1.1.0")
 	if err != nil {
 		return nil, err
 	}
@@ -73,12 +72,9 @@ func (d *DeviceDeactivateHash) Get(ctx context.Context, dataSet *data.DataSet) (
 	return dataSet.HasDeduplicatorNameMatch("org.tidepool.hash-deactivate-old"), nil // TODO: DEPRECATED
 }
 
-func (d *DeviceDeactivateHash) AddData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error {
+func (d *DeviceDeactivateHash) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -91,41 +87,35 @@ func (d *DeviceDeactivateHash) AddData(ctx context.Context, repository dataStore
 		return err
 	}
 
-	return d.Base.AddData(ctx, repository, dataSet, dataSetData)
+	return d.Base.AddData(ctx, dataSet, dataSetData)
 }
 
-func (d *DeviceDeactivateHash) Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (d *DeviceDeactivateHash) Close(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
 	}
 
-	if err := repository.ArchiveDeviceDataUsingHashesFromDataSet(ctx, dataSet); err != nil {
+	if err := d.DataStore.ArchiveDeviceDataUsingHashesFromDataSet(ctx, dataSet); err != nil {
 		return err
 	}
 
-	return d.Base.Close(ctx, repository, dataSet)
+	return d.Base.Close(ctx, dataSet)
 }
 
-func (d *DeviceDeactivateHash) Delete(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (d *DeviceDeactivateHash) Delete(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
 	}
 
-	if err := repository.UnarchiveDeviceDataUsingHashesFromDataSet(ctx, dataSet); err != nil {
+	if err := d.DataStore.UnarchiveDeviceDataUsingHashesFromDataSet(ctx, dataSet); err != nil {
 		return err
 	}
 
-	return d.Base.Delete(ctx, repository, dataSet)
+	return d.Base.Delete(ctx, dataSet)
 }

--- a/data/deduplicator/deduplicator/device_deactivate_hash_test.go
+++ b/data/deduplicator/deduplicator/device_deactivate_hash_test.go
@@ -23,504 +23,496 @@ var _ = Describe("DeviceDeactivateHash", func() {
 		Expect(dataDeduplicatorDeduplicator.DeviceDeactivateHashName).To(Equal("org.tidepool.deduplicator.device.deactivate.hash"))
 	})
 
-	Context("NewDeviceDeactivateHash", func() {
-		It("returns succesfully", func() {
-			Expect(dataDeduplicatorDeduplicator.NewDeviceDeactivateHash()).ToNot(BeNil())
-		})
-	})
-
-	Context("with new deduplicator", func() {
-		var deduplicator *dataDeduplicatorDeduplicator.DeviceDeactivateHash
-		var dataSet *data.DataSet
+	Context("with dependencies", func() {
+		var dataSetRepository *dataStoreTest.DataRepository
+		var dataRepository *dataStoreTest.DataRepository
+		var dependencies dataDeduplicatorDeduplicator.Dependencies
 
 		BeforeEach(func() {
-			var err error
-			deduplicator, err = dataDeduplicatorDeduplicator.NewDeviceDeactivateHash()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(deduplicator).ToNot(BeNil())
-			dataSet = dataTest.RandomDataSet()
-			dataSet.DataSetType = pointer.FromString("normal")
-			dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.device.deactivate.hash")
-			dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Abbott"})
-			dataSet.DeviceModel = pointer.FromString("FreeStyle Libre")
+			dataSetRepository = dataStoreTest.NewDataRepository()
+			dataRepository = dataStoreTest.NewDataRepository()
+			dependencies = dataDeduplicatorDeduplicator.Dependencies{
+				DataSetStore: dataSetRepository,
+				DataStore:    dataRepository,
+			}
 		})
 
-		Context("New", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
+		AfterEach(func() {
+			dataRepository.AssertOutputsEmpty()
+			dataSetRepository.AssertOutputsEmpty()
+		})
+
+		Context("NewDeviceDeactivateHash", func() {
+			It("returns successfully", func() {
+				Expect(dataDeduplicatorDeduplicator.NewDeviceDeactivateHash(dependencies)).ToNot(BeNil())
+			})
+		})
+
+		Context("with new deduplicator", func() {
+			var deduplicator *dataDeduplicatorDeduplicator.DeviceDeactivateHash
+			var dataSet *data.DataSet
+
+			BeforeEach(func() {
+				var err error
+				deduplicator, err = dataDeduplicatorDeduplicator.NewDeviceDeactivateHash(dependencies)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deduplicator).ToNot(BeNil())
+				dataSet = dataTest.RandomDataSet()
+				dataSet.DataSetType = pointer.FromString("normal")
+				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.device.deactivate.hash")
+				dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Abbott"})
+				dataSet.DeviceModel = pointer.FromString("FreeStyle Libre")
 			})
 
-			It("returns false when the data set type is not normal", func() {
-				dataSet.DataSetType = pointer.FromString("continuous")
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
+			Context("New", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.New(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
 
-			It("returns false when the device id is missing", func() {
-				dataSet.DeviceID = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			dataSetTypeAssertions := func() {
-				It("returns false when the deduplicator name does not match", func() {
-					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+				It("returns false when the data set type is not normal", func() {
+					dataSet.DataSetType = pointer.FromString("continuous")
 					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 				})
 
-				It("returns true when the deduplicator name matches", func() {
-					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				It("returns false when the device id is missing", func() {
+					dataSet.DeviceID = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 				})
 
-				It("returns true when the deduplicator name matches deprecated", func() {
-					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.hash-deactivate-old")
-					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
-				})
-
-				When("the deduplicator is missing", func() {
-					BeforeEach(func() {
-						dataSet.Deduplicator = nil
-					})
-
-					It("returns false when the device manufacturers is missing", func() {
-						dataSet.DeviceManufacturers = nil
+				dataSetTypeAssertions := func() {
+					It("returns false when the deduplicator name does not match", func() {
+						dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
 						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
-					It("returns false when the device manufacturers is empty", func() {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{})
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns false when the device manufacturers does not match", func() {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Bravo"})
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns false when the device model is missing", func() {
-						dataSet.DeviceModel = nil
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns false when the device model is empty", func() {
-						dataSet.DeviceModel = pointer.FromString("")
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns false when the device model does not match", func() {
-						dataSet.DeviceModel = pointer.FromString("Alpha")
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns true when the device manufacturers and device model matches", func() {
+					It("returns true when the deduplicator name matches", func() {
 						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
 
-					It("returns true when the device manufacturers and device model matches with multiple", func() {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Abbott", "Bravo"})
+					It("returns true when the deduplicator name matches deprecated", func() {
+						dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.hash-deactivate-old")
 						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
-				})
 
-				DescribeTable("returns true when",
-					func(deviceManufacturer string, deviceModel string) {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{deviceManufacturer})
-						dataSet.DeviceModel = pointer.FromString(deviceModel)
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
-					},
-					Entry("is Abbott FreeStyle Libre", "Abbott", "FreeStyle Libre"),
-					Entry("is LifeScan OneTouch Ultra 2", "LifeScan", "OneTouch Ultra 2"),
-					Entry("is LifeScan OneTouch UltraMini", "LifeScan", "OneTouch UltraMini"),
-					Entry("is LifeScan Verio", "LifeScan", "Verio"),
-					Entry("is LifeScan Verio Flex", "LifeScan", "Verio Flex"),
-					Entry("is Medtronic 523", "Medtronic", "523"),
-					Entry("is Medtronic 523K", "Medtronic", "523K"),
-					Entry("is Medtronic 551", "Medtronic", "551"),
-					Entry("is Medtronic 554", "Medtronic", "554"),
-					Entry("is Medtronic 723", "Medtronic", "723"),
-					Entry("is Medtronic 723K", "Medtronic", "723K"),
-					Entry("is Medtronic 751", "Medtronic", "751"),
-					Entry("is Medtronic 754", "Medtronic", "754"),
-					Entry("is Medtronic 1510", "Medtronic", "1510"),
-					Entry("is Medtronic 1510K", "Medtronic", "1510K"),
-					Entry("is Medtronic 1511", "Medtronic", "1511"),
-					Entry("is Medtronic 1512", "Medtronic", "1512"),
-					Entry("is Medtronic 1580", "Medtronic", "1580"),
-					Entry("is Medtronic 1581", "Medtronic", "1581"),
-					Entry("is Medtronic 1582", "Medtronic", "1582"),
-					Entry("is Medtronic 1710", "Medtronic", "1710"),
-					Entry("is Medtronic 1710K", "Medtronic", "1710K"),
-					Entry("is Medtronic 1711", "Medtronic", "1711"),
-					Entry("is Medtronic 1712", "Medtronic", "1712"),
-					Entry("is Medtronic 1714", "Medtronic", "1714"),
-					Entry("is Medtronic 1714K", "Medtronic", "1714K"),
-					Entry("is Medtronic 1715", "Medtronic", "1715"),
-					Entry("is Medtronic 1780", "Medtronic", "1780"),
-					Entry("is Medtronic 1781", "Medtronic", "1781"),
-					Entry("is Medtronic 1782", "Medtronic", "1782"),
-					Entry("is Trividia Health TRUE METRIX", "Trividia Health", "TRUE METRIX"),
-					Entry("is Trividia Health TRUE METRIX AIR", "Trividia Health", "TRUE METRIX AIR"),
-					Entry("is Trividia Health TRUE METRIX GO", "Trividia Health", "TRUE METRIX GO"),
-				)
-			}
-
-			When("the data set type is missing", func() {
-				BeforeEach(func() {
-					dataSet.DataSetType = nil
-				})
-
-				dataSetTypeAssertions()
-			})
-
-			When("the data set type is normal", func() {
-				BeforeEach(func() {
-					dataSet.DataSetType = pointer.FromString("normal")
-				})
-
-				dataSetTypeAssertions()
-			})
-		})
-
-		Context("Get", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-
-			It("returns true when the deduplicator name matches deprecated", func() {
-				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.hash-deactivate-old")
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-		})
-
-		Context("with context and repository", func() {
-			var ctx context.Context
-			var repository *dataStoreTest.DataRepository
-
-			BeforeEach(func() {
-				ctx = context.Background()
-				repository = dataStoreTest.NewDataRepository()
-			})
-
-			AfterEach(func() {
-				repository.AssertOutputsEmpty()
-			})
-
-			Context("Open", func() {
-				It("returns an error when the context is missing", func() {
-					result, err := deduplicator.Open(nil, repository, dataSet)
-					Expect(err).To(MatchError("context is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the repository is missing", func() {
-					result, err := deduplicator.Open(ctx, nil, dataSet)
-					Expect(err).To(MatchError("repository is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the data set is missing", func() {
-					result, err := deduplicator.Open(ctx, repository, nil)
-					Expect(err).To(MatchError("data set is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				When("UpdateDataSet is invoked", func() {
-					var update *data.DataSetUpdate
-
-					BeforeEach(func() {
-						update = data.NewDataSetUpdate()
-						update.Active = pointer.FromBool(false)
-						update.Deduplicator = &data.DeduplicatorDescriptor{
-							Name:    pointer.FromString("org.tidepool.deduplicator.device.deactivate.hash"),
-							Version: pointer.FromString("1.1.0"),
-						}
-					})
-
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
-					})
-
-					When("the data set does not have a deduplicator", func() {
+					When("the deduplicator is missing", func() {
 						BeforeEach(func() {
 							dataSet.Deduplicator = nil
 						})
 
-						It("returns an error when update data set returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							result, err := deduplicator.Open(ctx, repository, dataSet)
-							Expect(err).To(Equal(responseErr))
-							Expect(result).To(BeNil())
+						It("returns false when the device manufacturers is missing", func() {
+							dataSet.DeviceManufacturers = nil
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 						})
 
-						It("returns successfully when update data set returns successfully", func() {
-							responseDataSet := dataTest.RandomDataSet()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-							Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
+						It("returns false when the device manufacturers is empty", func() {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{})
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns false when the device manufacturers does not match", func() {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Bravo"})
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns false when the device model is missing", func() {
+							dataSet.DeviceModel = nil
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns false when the device model is empty", func() {
+							dataSet.DeviceModel = pointer.FromString("")
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns false when the device model does not match", func() {
+							dataSet.DeviceModel = pointer.FromString("Alpha")
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns true when the device manufacturers and device model matches", func() {
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+						})
+
+						It("returns true when the device manufacturers and device model matches with multiple", func() {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Abbott", "Bravo"})
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 						})
 					})
 
-					When("the data set has a deduplicator with matching name and version does not exist", func() {
-						BeforeEach(func() {
-							dataSet.Deduplicator.Version = nil
-						})
+					DescribeTable("returns true when",
+						func(deviceManufacturer string, deviceModel string) {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{deviceManufacturer})
+							dataSet.DeviceModel = pointer.FromString(deviceModel)
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+						},
+						Entry("is Abbott FreeStyle Libre", "Abbott", "FreeStyle Libre"),
+						Entry("is LifeScan OneTouch Ultra 2", "LifeScan", "OneTouch Ultra 2"),
+						Entry("is LifeScan OneTouch UltraMini", "LifeScan", "OneTouch UltraMini"),
+						Entry("is LifeScan Verio", "LifeScan", "Verio"),
+						Entry("is LifeScan Verio Flex", "LifeScan", "Verio Flex"),
+						Entry("is Medtronic 523", "Medtronic", "523"),
+						Entry("is Medtronic 523K", "Medtronic", "523K"),
+						Entry("is Medtronic 551", "Medtronic", "551"),
+						Entry("is Medtronic 554", "Medtronic", "554"),
+						Entry("is Medtronic 723", "Medtronic", "723"),
+						Entry("is Medtronic 723K", "Medtronic", "723K"),
+						Entry("is Medtronic 751", "Medtronic", "751"),
+						Entry("is Medtronic 754", "Medtronic", "754"),
+						Entry("is Medtronic 1510", "Medtronic", "1510"),
+						Entry("is Medtronic 1510K", "Medtronic", "1510K"),
+						Entry("is Medtronic 1511", "Medtronic", "1511"),
+						Entry("is Medtronic 1512", "Medtronic", "1512"),
+						Entry("is Medtronic 1580", "Medtronic", "1580"),
+						Entry("is Medtronic 1581", "Medtronic", "1581"),
+						Entry("is Medtronic 1582", "Medtronic", "1582"),
+						Entry("is Medtronic 1710", "Medtronic", "1710"),
+						Entry("is Medtronic 1710K", "Medtronic", "1710K"),
+						Entry("is Medtronic 1711", "Medtronic", "1711"),
+						Entry("is Medtronic 1712", "Medtronic", "1712"),
+						Entry("is Medtronic 1714", "Medtronic", "1714"),
+						Entry("is Medtronic 1714K", "Medtronic", "1714K"),
+						Entry("is Medtronic 1715", "Medtronic", "1715"),
+						Entry("is Medtronic 1780", "Medtronic", "1780"),
+						Entry("is Medtronic 1781", "Medtronic", "1781"),
+						Entry("is Medtronic 1782", "Medtronic", "1782"),
+						Entry("is Trividia Health TRUE METRIX", "Trividia Health", "TRUE METRIX"),
+						Entry("is Trividia Health TRUE METRIX AIR", "Trividia Health", "TRUE METRIX AIR"),
+						Entry("is Trividia Health TRUE METRIX GO", "Trividia Health", "TRUE METRIX GO"),
+					)
+				}
 
-						It("returns an error when update data set returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							result, err := deduplicator.Open(ctx, repository, dataSet)
-							Expect(err).To(Equal(responseErr))
-							Expect(result).To(BeNil())
-						})
-
-						It("returns successfully when update data set returns successfully", func() {
-							responseDataSet := dataTest.RandomDataSet()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-							Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-						})
+				When("the data set type is missing", func() {
+					BeforeEach(func() {
+						dataSet.DataSetType = nil
 					})
 
-					When("the data set has a deduplicator with matching name and version exists", func() {
-						BeforeEach(func() {
-							dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
-						})
+					dataSetTypeAssertions()
+				})
 
-						It("returns an error when update data set returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							result, err := deduplicator.Open(ctx, repository, dataSet)
-							Expect(err).To(Equal(responseErr))
-							Expect(result).To(BeNil())
-						})
-
-						It("returns successfully when update data set returns successfully", func() {
-							responseDataSet := dataTest.RandomDataSet()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-							Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-						})
+				When("the data set type is normal", func() {
+					BeforeEach(func() {
+						dataSet.DataSetType = pointer.FromString("normal")
 					})
+
+					dataSetTypeAssertions()
 				})
 			})
 
-			Context("AddData", func() {
-				var dataSetData data.Data
+			Context("Get", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.Get(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+
+				It("returns true when the deduplicator name matches deprecated", func() {
+					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.hash-deactivate-old")
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("with context", func() {
+				var ctx context.Context
 
 				BeforeEach(func() {
-					dataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
-					for index := range dataSetData {
-						base := dataTypesTest.RandomBase()
-						base.Deduplicator.Hash = nil
-						dataSetData[index] = base
-					}
+					ctx = context.Background()
 				})
 
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.AddData(nil, repository, dataSet, dataSetData)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.AddData(ctx, nil, dataSet, dataSetData)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, nil, dataSetData)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the data set data is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, dataSet, nil)).To(MatchError("data set data is missing"))
-				})
-
-				When("create data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
-						for _, datum := range dataSetData {
-							base, ok := datum.(*dataTypes.Base)
-							Expect(ok).To(BeTrue())
-							Expect(base).ToNot(BeNil())
-							Expect(base.Deduplicator.Hash).ToNot(BeNil())
-						}
+				Context("Open", func() {
+					It("returns an error when the context is missing", func() {
+						result, err := deduplicator.Open(nil, dataSet)
+						Expect(err).To(MatchError("context is missing"))
+						Expect(result).To(BeNil())
 					})
 
-					It("returns an error when create data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.CreateDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when create data set data returns successfully", func() {
-						repository.CreateDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Succeed())
-					})
-				})
-			})
-
-			Context("DeleteData", func() {
-				var selectors *data.Selectors
-
-				BeforeEach(func() {
-					selectors = dataTest.RandomSelectors()
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.DeleteData(nil, repository, dataSet, selectors)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, nil, dataSet, selectors)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, nil, selectors)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the selectors is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, dataSet, nil)).To(MatchError("selectors is missing"))
-				})
-
-				When("destroy data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DestroyDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-					})
-
-					It("returns an error when destroy data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DestroyDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when destroy data set data returns successfully", func() {
-						repository.DestroyDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Succeed())
-					})
-				})
-			})
-
-			Context("Close", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Close(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Close(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Close(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("archive device data using hashes from data sets is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.ArchiveDeviceDataUsingHashesFromDataSetInputs).To(Equal([]dataStoreTest.ArchiveDeviceDataUsingHashesFromDataSetInput{{Context: ctx, DataSet: dataSet}}))
-					})
-
-					It("returns an error when archive device data using hashes from data sets returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.ArchiveDeviceDataUsingHashesFromDataSetOutputs = []error{responseErr}
-						Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
+					It("returns an error when the data set is missing", func() {
+						result, err := deduplicator.Open(ctx, nil)
+						Expect(err).To(MatchError("data set is missing"))
+						Expect(result).To(BeNil())
 					})
 
 					When("UpdateDataSet is invoked", func() {
+						var update *data.DataSetUpdate
+
 						BeforeEach(func() {
-							repository.ArchiveDeviceDataUsingHashesFromDataSetOutputs = []error{nil}
+							update = data.NewDataSetUpdate()
+							update.Active = pointer.FromBool(false)
+							update.Deduplicator = &data.DeduplicatorDescriptor{
+								Name:    pointer.FromString("org.tidepool.deduplicator.device.deactivate.hash"),
+								Version: pointer.FromString("1.1.0"),
+							}
 						})
 
 						AfterEach(func() {
-							Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
 						})
 
-						It("returns an error when update data set data returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-						})
-
-						When("activate data set data is invoked", func() {
+						When("the data set does not have a deduplicator", func() {
 							BeforeEach(func() {
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								dataSet.Deduplicator = nil
+							})
+
+							It("returns an error when update data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								result, err := deduplicator.Open(ctx, dataSet)
+								Expect(err).To(Equal(responseErr))
+								Expect(result).To(BeNil())
+							})
+
+							It("returns successfully when update data set returns successfully", func() {
+								responseDataSet := dataTest.RandomDataSet()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+								Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+							})
+						})
+
+						When("the data set has a deduplicator with matching name and version does not exist", func() {
+							BeforeEach(func() {
+								dataSet.Deduplicator.Version = nil
+							})
+
+							It("returns an error when update data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								result, err := deduplicator.Open(ctx, dataSet)
+								Expect(err).To(Equal(responseErr))
+								Expect(result).To(BeNil())
+							})
+
+							It("returns successfully when update data set returns successfully", func() {
+								responseDataSet := dataTest.RandomDataSet()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+								Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+							})
+						})
+
+						When("the data set has a deduplicator with matching name and version exists", func() {
+							BeforeEach(func() {
+								dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
+							})
+
+							It("returns an error when update data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								result, err := deduplicator.Open(ctx, dataSet)
+								Expect(err).To(Equal(responseErr))
+								Expect(result).To(BeNil())
+							})
+
+							It("returns successfully when update data set returns successfully", func() {
+								responseDataSet := dataTest.RandomDataSet()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+								Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+							})
+						})
+					})
+				})
+
+				Context("AddData", func() {
+					var dataSetData data.Data
+
+					BeforeEach(func() {
+						dataSetData = make(data.Data, test.RandomIntFromRange(1, 3))
+						for index := range dataSetData {
+							base := dataTypesTest.RandomBase()
+							base.Deduplicator.Hash = nil
+							dataSetData[index] = base
+						}
+					})
+
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.AddData(nil, dataSet, dataSetData)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.AddData(ctx, nil, dataSetData)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the data set data is missing", func() {
+						Expect(deduplicator.AddData(ctx, dataSet, nil)).To(MatchError("data set data is missing"))
+					})
+
+					When("create data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+							for _, datum := range dataSetData {
+								base, ok := datum.(*dataTypes.Base)
+								Expect(ok).To(BeTrue())
+								Expect(base).ToNot(BeNil())
+								Expect(base.Deduplicator.Hash).ToNot(BeNil())
+							}
+						})
+
+						It("returns an error when create data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when create data set data returns successfully", func() {
+							dataRepository.CreateDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Succeed())
+						})
+					})
+				})
+
+				Context("DeleteData", func() {
+					var selectors *data.Selectors
+
+					BeforeEach(func() {
+						selectors = dataTest.RandomSelectors()
+					})
+
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.DeleteData(nil, dataSet, selectors)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, nil, selectors)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the selectors is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, dataSet, nil)).To(MatchError("selectors is missing"))
+					})
+
+					When("destroy data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.DestroyDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+						})
+
+						It("returns an error when destroy data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.DestroyDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when destroy data set data returns successfully", func() {
+							dataRepository.DestroyDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Succeed())
+						})
+					})
+				})
+
+				Context("Close", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Close(nil, dataSet)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Close(ctx, nil)).To(MatchError("data set is missing"))
+					})
+
+					When("archive device data using hashes from data sets is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.ArchiveDeviceDataUsingHashesFromDataSetInputs).To(Equal([]dataStoreTest.ArchiveDeviceDataUsingHashesFromDataSetInput{{Context: ctx, DataSet: dataSet}}))
+						})
+
+						It("returns an error when archive device data using hashes from data sets returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.ArchiveDeviceDataUsingHashesFromDataSetOutputs = []error{responseErr}
+							Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
+						})
+
+						When("UpdateDataSet is invoked", func() {
+							BeforeEach(func() {
+								dataRepository.ArchiveDeviceDataUsingHashesFromDataSetOutputs = []error{nil}
 							})
 
 							AfterEach(func() {
-								Expect(repository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+								Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
 							})
 
-							It("returns an error when active data set data returns an error", func() {
+							It("returns an error when update data set data returns an error", func() {
 								responseErr := errorsTest.RandomError()
-								repository.ActivateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
 							})
 
-							It("returns successfully when active data set data returns successfully", func() {
-								repository.ActivateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
+							When("activate data set data is invoked", func() {
+								BeforeEach(func() {
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								})
+
+								AfterEach(func() {
+									Expect(dataRepository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+								})
+
+								It("returns an error when active data set data returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.ActivateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
+								})
+
+								It("returns successfully when active data set data returns successfully", func() {
+									dataRepository.ActivateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
+								})
 							})
 						})
 					})
 				})
-			})
 
-			Context("Delete", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Delete(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Delete(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Delete(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("unarchive device data using hashes from data sets is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.UnarchiveDeviceDataUsingHashesFromDataSetInputs).To(Equal([]dataStoreTest.UnarchiveDeviceDataUsingHashesFromDataSetInput{{Context: ctx, DataSet: dataSet}}))
+				Context("Delete", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Delete(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					It("returns an error when unarchive device data using hashes from data sets returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.UnarchiveDeviceDataUsingHashesFromDataSetOutputs = []error{responseErr}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Equal(responseErr))
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Delete(ctx, nil)).To(MatchError("data set is missing"))
 					})
 
-					When("delete data set is invoked", func() {
-						BeforeEach(func() {
-							repository.UnarchiveDeviceDataUsingHashesFromDataSetOutputs = []error{nil}
-						})
-
+					When("unarchive device data using hashes from data sets is invoked", func() {
 						AfterEach(func() {
-							Expect(repository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
+							Expect(dataRepository.UnarchiveDeviceDataUsingHashesFromDataSetInputs).To(Equal([]dataStoreTest.UnarchiveDeviceDataUsingHashesFromDataSetInput{{Context: ctx, DataSet: dataSet}}))
 						})
 
-						It("returns an error when delete data set returns an error", func() {
+						It("returns an error when unarchive device data using hashes from data sets returns an error", func() {
 							responseErr := errorsTest.RandomError()
-							repository.DeleteDataSetOutputs = []error{responseErr}
-							Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Equal(responseErr))
+							dataRepository.UnarchiveDeviceDataUsingHashesFromDataSetOutputs = []error{responseErr}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Equal(responseErr))
 						})
 
-						It("returns successfully when delete data set returns successfully", func() {
-							repository.DeleteDataSetOutputs = []error{nil}
-							Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Succeed())
+						When("delete data set is invoked", func() {
+							BeforeEach(func() {
+								dataRepository.UnarchiveDeviceDataUsingHashesFromDataSetOutputs = []error{nil}
+							})
+
+							AfterEach(func() {
+								Expect(dataSetRepository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
+							})
+
+							It("returns an error when delete data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.DeleteDataSetOutputs = []error{responseErr}
+								Expect(deduplicator.Delete(ctx, dataSet)).To(Equal(responseErr))
+							})
+
+							It("returns successfully when delete data set returns successfully", func() {
+								dataSetRepository.DeleteDataSetOutputs = []error{nil}
+								Expect(deduplicator.Delete(ctx, dataSet)).To(Succeed())
+							})
 						})
 					})
 				})

--- a/data/deduplicator/deduplicator/device_truncate_data_set.go
+++ b/data/deduplicator/deduplicator/device_truncate_data_set.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 )
 
@@ -16,8 +15,8 @@ type DeviceTruncateDataSet struct {
 	*Base
 }
 
-func NewDeviceTruncateDataSet() (*DeviceTruncateDataSet, error) {
-	base, err := NewBase(DeviceTruncateDataSetName, "1.1.0")
+func NewDeviceTruncateDataSet(dependencies Dependencies) (*DeviceTruncateDataSet, error) {
+	base, err := NewBase(dependencies, DeviceTruncateDataSetName, "1.1.0")
 	if err != nil {
 		return nil, err
 	}
@@ -66,12 +65,9 @@ func (d *DeviceTruncateDataSet) Get(ctx context.Context, dataSet *data.DataSet) 
 	return dataSet.HasDeduplicatorNameMatch("org.tidepool.truncate"), nil // TODO: DEPRECATED
 }
 
-func (d *DeviceTruncateDataSet) Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (d *DeviceTruncateDataSet) Close(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -80,9 +76,9 @@ func (d *DeviceTruncateDataSet) Close(ctx context.Context, repository dataStore.
 	// TODO: Technically, DeleteOtherDataSetData could succeed, but Close fail. This would
 	// temporarily result in missing data, which is better than the opposite (duplicate data).
 	// If this fails, a subsequent successful upload will resolve.
-	if err := repository.DeleteOtherDataSetData(ctx, dataSet); err != nil {
+	if err := d.DataStore.DeleteOtherDataSetData(ctx, dataSet); err != nil {
 		return err
 	}
 
-	return d.Base.Close(ctx, repository, dataSet)
+	return d.Base.Close(ctx, dataSet)
 }

--- a/data/deduplicator/deduplicator/device_truncate_data_set_test.go
+++ b/data/deduplicator/deduplicator/device_truncate_data_set_test.go
@@ -22,424 +22,416 @@ var _ = Describe("DeviceTruncateDataSet", func() {
 		Expect(dataDeduplicatorDeduplicator.DeviceTruncateDataSetName).To(Equal("org.tidepool.deduplicator.device.truncate.dataset"))
 	})
 
-	Context("NewDeviceTruncateDataSet", func() {
-		It("returns succesfully", func() {
-			Expect(dataDeduplicatorDeduplicator.NewDeviceTruncateDataSet()).ToNot(BeNil())
-		})
-	})
-
-	Context("with new deduplicator", func() {
-		var deduplicator *dataDeduplicatorDeduplicator.DeviceTruncateDataSet
-		var dataSet *data.DataSet
+	Context("with dependencies", func() {
+		var dataSetRepository *dataStoreTest.DataRepository
+		var dataRepository *dataStoreTest.DataRepository
+		var dependencies dataDeduplicatorDeduplicator.Dependencies
 
 		BeforeEach(func() {
-			var err error
-			deduplicator, err = dataDeduplicatorDeduplicator.NewDeviceTruncateDataSet()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(deduplicator).ToNot(BeNil())
-			dataSet = dataTest.RandomDataSet()
-			dataSet.DataSetType = pointer.FromString("normal")
-			dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.device.truncate.dataset")
-			dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Animas"})
+			dataSetRepository = dataStoreTest.NewDataRepository()
+			dataRepository = dataStoreTest.NewDataRepository()
+			dependencies = dataDeduplicatorDeduplicator.Dependencies{
+				DataSetStore: dataSetRepository,
+				DataStore:    dataRepository,
+			}
 		})
 
-		Context("New", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
+		AfterEach(func() {
+			dataRepository.AssertOutputsEmpty()
+			dataSetRepository.AssertOutputsEmpty()
+		})
+
+		Context("NewDeviceTruncateDataSet", func() {
+			It("returns successfully", func() {
+				Expect(dataDeduplicatorDeduplicator.NewDeviceTruncateDataSet(dependencies)).ToNot(BeNil())
+			})
+		})
+
+		Context("with new deduplicator", func() {
+			var deduplicator *dataDeduplicatorDeduplicator.DeviceTruncateDataSet
+			var dataSet *data.DataSet
+
+			BeforeEach(func() {
+				var err error
+				deduplicator, err = dataDeduplicatorDeduplicator.NewDeviceTruncateDataSet(dependencies)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deduplicator).ToNot(BeNil())
+				dataSet = dataTest.RandomDataSet()
+				dataSet.DataSetType = pointer.FromString("normal")
+				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.device.truncate.dataset")
+				dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Animas"})
 			})
 
-			It("returns false when the data set type is not normal", func() {
-				dataSet.DataSetType = pointer.FromString("continuous")
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
+			Context("New", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.New(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
 
-			It("returns false when the device id is missing", func() {
-				dataSet.DeviceID = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			dataSetTypeAssertions := func() {
-				It("returns false when the deduplicator name does not match", func() {
-					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+				It("returns false when the data set type is not normal", func() {
+					dataSet.DataSetType = pointer.FromString("continuous")
 					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 				})
 
-				It("returns true when the deduplicator name matches", func() {
-					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				It("returns false when the device id is missing", func() {
+					dataSet.DeviceID = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 				})
 
-				It("returns true when the deduplicator name matches deprecated", func() {
-					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.truncate")
-					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
-				})
-
-				When("the deduplicator is missing", func() {
-					BeforeEach(func() {
-						dataSet.Deduplicator = nil
-					})
-
-					It("returns false when the device manufacturers is missing", func() {
-						dataSet.DeviceManufacturers = nil
+				dataSetTypeAssertions := func() {
+					It("returns false when the deduplicator name does not match", func() {
+						dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
 						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 					})
 
-					It("returns false when the device manufacturers is empty", func() {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{})
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns false when the device manufacturers does not match", func() {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Bravo"})
-						Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-					})
-
-					It("returns true when the device manufacturers matches", func() {
+					It("returns true when the deduplicator name matches", func() {
 						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
 
-					It("returns true when the device manufacturers matches with multiple", func() {
-						dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Animas", "Bravo"})
+					It("returns true when the deduplicator name matches deprecated", func() {
+						dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.truncate")
 						Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 					})
-				})
-			}
 
-			When("the data set type is missing", func() {
-				BeforeEach(func() {
-					dataSet.DataSetType = nil
-				})
-
-				dataSetTypeAssertions()
-			})
-
-			When("the data set type is normal", func() {
-				BeforeEach(func() {
-					dataSet.DataSetType = pointer.FromString("normal")
-				})
-
-				dataSetTypeAssertions()
-			})
-		})
-
-		Context("Get", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-
-			It("returns true when the deduplicator name matches deprecated", func() {
-				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.truncate")
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-		})
-
-		Context("with context and repository", func() {
-			var ctx context.Context
-			var repository *dataStoreTest.DataRepository
-
-			BeforeEach(func() {
-				ctx = context.Background()
-				repository = dataStoreTest.NewDataRepository()
-			})
-
-			AfterEach(func() {
-				repository.AssertOutputsEmpty()
-			})
-
-			Context("Open", func() {
-				It("returns an error when the context is missing", func() {
-					result, err := deduplicator.Open(nil, repository, dataSet)
-					Expect(err).To(MatchError("context is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the repository is missing", func() {
-					result, err := deduplicator.Open(ctx, nil, dataSet)
-					Expect(err).To(MatchError("repository is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the data set is missing", func() {
-					result, err := deduplicator.Open(ctx, repository, nil)
-					Expect(err).To(MatchError("data set is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				When("UpdateDataSet is invoked", func() {
-					var update *data.DataSetUpdate
-
-					BeforeEach(func() {
-						update = data.NewDataSetUpdate()
-						update.Active = pointer.FromBool(false)
-						update.Deduplicator = &data.DeduplicatorDescriptor{
-							Name:    pointer.FromString("org.tidepool.deduplicator.device.truncate.dataset"),
-							Version: pointer.FromString("1.1.0"),
-						}
-					})
-
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
-					})
-
-					When("the data set does not have a deduplicator", func() {
+					When("the deduplicator is missing", func() {
 						BeforeEach(func() {
 							dataSet.Deduplicator = nil
 						})
 
-						It("returns an error when update data set returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							result, err := deduplicator.Open(ctx, repository, dataSet)
-							Expect(err).To(Equal(responseErr))
-							Expect(result).To(BeNil())
+						It("returns false when the device manufacturers is missing", func() {
+							dataSet.DeviceManufacturers = nil
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
 						})
 
-						It("returns successfully when update data set returns successfully", func() {
-							responseDataSet := dataTest.RandomDataSet()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-							Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
+						It("returns false when the device manufacturers is empty", func() {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{})
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns false when the device manufacturers does not match", func() {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Bravo"})
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+						})
+
+						It("returns true when the device manufacturers matches", func() {
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+						})
+
+						It("returns true when the device manufacturers matches with multiple", func() {
+							dataSet.DeviceManufacturers = pointer.FromStringArray([]string{"Alpha", "Animas", "Bravo"})
+							Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
 						})
 					})
+				}
 
-					When("the data set has a deduplicator with matching name and version does not exist", func() {
-						BeforeEach(func() {
-							dataSet.Deduplicator.Version = nil
-						})
-
-						It("returns an error when update data set returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							result, err := deduplicator.Open(ctx, repository, dataSet)
-							Expect(err).To(Equal(responseErr))
-							Expect(result).To(BeNil())
-						})
-
-						It("returns successfully when update data set returns successfully", func() {
-							responseDataSet := dataTest.RandomDataSet()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-							Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-						})
+				When("the data set type is missing", func() {
+					BeforeEach(func() {
+						dataSet.DataSetType = nil
 					})
 
-					When("the data set has a deduplicator with matching name and version exists", func() {
-						BeforeEach(func() {
-							dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
-						})
+					dataSetTypeAssertions()
+				})
 
-						It("returns an error when update data set returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							result, err := deduplicator.Open(ctx, repository, dataSet)
-							Expect(err).To(Equal(responseErr))
-							Expect(result).To(BeNil())
-						})
-
-						It("returns successfully when update data set returns successfully", func() {
-							responseDataSet := dataTest.RandomDataSet()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-							Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-						})
+				When("the data set type is normal", func() {
+					BeforeEach(func() {
+						dataSet.DataSetType = pointer.FromString("normal")
 					})
+
+					dataSetTypeAssertions()
 				})
 			})
 
-			Context("AddData", func() {
-				var dataSetData data.Data
+			Context("Get", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.Get(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+
+				It("returns true when the deduplicator name matches deprecated", func() {
+					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.truncate")
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("with context", func() {
+				var ctx context.Context
 
 				BeforeEach(func() {
-					dataSetData = make(data.Data, test.RandomIntFromRange(0, 3))
-					for index := range dataSetData {
-						dataSetData[index] = dataTypesTest.RandomBase()
-					}
+					ctx = context.Background()
 				})
 
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.AddData(nil, repository, dataSet, dataSetData)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.AddData(ctx, nil, dataSet, dataSetData)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, nil, dataSetData)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the data set data is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, dataSet, nil)).To(MatchError("data set data is missing"))
-				})
-
-				When("create data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+				Context("Open", func() {
+					It("returns an error when the context is missing", func() {
+						result, err := deduplicator.Open(nil, dataSet)
+						Expect(err).To(MatchError("context is missing"))
+						Expect(result).To(BeNil())
 					})
 
-					It("returns an error when create data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.CreateDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when create data set data returns successfully", func() {
-						repository.CreateDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Succeed())
-					})
-				})
-			})
-
-			Context("DeleteData", func() {
-				var selectors *data.Selectors
-
-				BeforeEach(func() {
-					selectors = dataTest.RandomSelectors()
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.DeleteData(nil, repository, dataSet, selectors)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, nil, dataSet, selectors)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, nil, selectors)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the selectors is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, dataSet, nil)).To(MatchError("selectors is missing"))
-				})
-
-				When("destroy data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DestroyDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-					})
-
-					It("returns an error when destroy data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DestroyDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when destroy data set data returns successfully", func() {
-						repository.DestroyDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Succeed())
-					})
-				})
-			})
-
-			Context("Close", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Close(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Close(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Close(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("delete other data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DeleteOtherDataSetDataInputs).To(Equal([]dataStoreTest.DeleteOtherDataSetDataInput{{Context: ctx, DataSet: dataSet}}))
-					})
-
-					It("returns an error when delete other data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DeleteOtherDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
+					It("returns an error when the data set is missing", func() {
+						result, err := deduplicator.Open(ctx, nil)
+						Expect(err).To(MatchError("data set is missing"))
+						Expect(result).To(BeNil())
 					})
 
 					When("UpdateDataSet is invoked", func() {
+						var update *data.DataSetUpdate
+
 						BeforeEach(func() {
-							repository.DeleteOtherDataSetDataOutputs = []error{nil}
+							update = data.NewDataSetUpdate()
+							update.Active = pointer.FromBool(false)
+							update.Deduplicator = &data.DeduplicatorDescriptor{
+								Name:    pointer.FromString("org.tidepool.deduplicator.device.truncate.dataset"),
+								Version: pointer.FromString("1.1.0"),
+							}
 						})
 
 						AfterEach(func() {
-							Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
 						})
 
-						It("returns an error when update data set data returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-						})
-
-						When("activate data set data is invoked", func() {
+						When("the data set does not have a deduplicator", func() {
 							BeforeEach(func() {
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								dataSet.Deduplicator = nil
+							})
+
+							It("returns an error when update data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								result, err := deduplicator.Open(ctx, dataSet)
+								Expect(err).To(Equal(responseErr))
+								Expect(result).To(BeNil())
+							})
+
+							It("returns successfully when update data set returns successfully", func() {
+								responseDataSet := dataTest.RandomDataSet()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+								Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+							})
+						})
+
+						When("the data set has a deduplicator with matching name and version does not exist", func() {
+							BeforeEach(func() {
+								dataSet.Deduplicator.Version = nil
+							})
+
+							It("returns an error when update data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								result, err := deduplicator.Open(ctx, dataSet)
+								Expect(err).To(Equal(responseErr))
+								Expect(result).To(BeNil())
+							})
+
+							It("returns successfully when update data set returns successfully", func() {
+								responseDataSet := dataTest.RandomDataSet()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+								Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+							})
+						})
+
+						When("the data set has a deduplicator with matching name and version exists", func() {
+							BeforeEach(func() {
+								dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
+							})
+
+							It("returns an error when update data set returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								result, err := deduplicator.Open(ctx, dataSet)
+								Expect(err).To(Equal(responseErr))
+								Expect(result).To(BeNil())
+							})
+
+							It("returns successfully when update data set returns successfully", func() {
+								responseDataSet := dataTest.RandomDataSet()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+								Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+							})
+						})
+					})
+				})
+
+				Context("AddData", func() {
+					var dataSetData data.Data
+
+					BeforeEach(func() {
+						dataSetData = make(data.Data, test.RandomIntFromRange(0, 3))
+						for index := range dataSetData {
+							dataSetData[index] = dataTypesTest.RandomBase()
+						}
+					})
+
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.AddData(nil, dataSet, dataSetData)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.AddData(ctx, nil, dataSetData)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the data set data is missing", func() {
+						Expect(deduplicator.AddData(ctx, dataSet, nil)).To(MatchError("data set data is missing"))
+					})
+
+					When("create data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+						})
+
+						It("returns an error when create data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when create data set data returns successfully", func() {
+							dataRepository.CreateDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Succeed())
+						})
+					})
+				})
+
+				Context("DeleteData", func() {
+					var selectors *data.Selectors
+
+					BeforeEach(func() {
+						selectors = dataTest.RandomSelectors()
+					})
+
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.DeleteData(nil, dataSet, selectors)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, nil, selectors)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the selectors is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, dataSet, nil)).To(MatchError("selectors is missing"))
+					})
+
+					When("destroy data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.DestroyDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+						})
+
+						It("returns an error when destroy data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.DestroyDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when destroy data set data returns successfully", func() {
+							dataRepository.DestroyDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Succeed())
+						})
+					})
+				})
+
+				Context("Close", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Close(nil, dataSet)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Close(ctx, nil)).To(MatchError("data set is missing"))
+					})
+
+					When("delete other data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.DeleteOtherDataSetDataInputs).To(Equal([]dataStoreTest.DeleteOtherDataSetDataInput{{Context: ctx, DataSet: dataSet}}))
+						})
+
+						It("returns an error when delete other data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.DeleteOtherDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
+						})
+
+						When("UpdateDataSet is invoked", func() {
+							BeforeEach(func() {
+								dataRepository.DeleteOtherDataSetDataOutputs = []error{nil}
 							})
 
 							AfterEach(func() {
-								Expect(repository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+								Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
 							})
 
-							It("returns an error when active data set data returns an error", func() {
+							It("returns an error when update data set data returns an error", func() {
 								responseErr := errorsTest.RandomError()
-								repository.ActivateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
 							})
 
-							It("returns successfully when active data set data returns successfully", func() {
-								repository.ActivateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
+							When("activate data set data is invoked", func() {
+								BeforeEach(func() {
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								})
+
+								AfterEach(func() {
+									Expect(dataRepository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+								})
+
+								It("returns an error when active data set data returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.ActivateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
+								})
+
+								It("returns successfully when active data set data returns successfully", func() {
+									dataRepository.ActivateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
+								})
 							})
 						})
 					})
 				})
-			})
 
-			Context("Delete", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Delete(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Delete(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Delete(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("delete data set is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
+				Context("Delete", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Delete(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					It("returns an error when delete data set returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DeleteDataSetOutputs = []error{responseErr}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Equal(responseErr))
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Delete(ctx, nil)).To(MatchError("data set is missing"))
 					})
 
-					It("returns successfully when delete data set returns successfully", func() {
-						repository.DeleteDataSetOutputs = []error{nil}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Succeed())
+					When("delete data set is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
+						})
+
+						It("returns an error when delete data set returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataSetRepository.DeleteDataSetOutputs = []error{responseErr}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when delete data set returns successfully", func() {
+							dataSetRepository.DeleteDataSetOutputs = []error{nil}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Succeed())
+						})
 					})
 				})
 			})

--- a/data/deduplicator/deduplicator/none.go
+++ b/data/deduplicator/deduplicator/none.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 )
 
@@ -15,8 +14,8 @@ type None struct {
 	*Base
 }
 
-func NewNone() (*None, error) {
-	base, err := NewBase(NoneName, NoneVersion)
+func NewNone(dependencies Dependencies) (*None, error) {
+	base, err := NewBase(dependencies, NoneName, NoneVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -38,12 +37,9 @@ func (n *None) Get(ctx context.Context, dataSet *data.DataSet) (bool, error) {
 	return dataSet.HasDeduplicatorNameMatch("org.tidepool.continuous"), nil // TODO: DEPRECATED
 }
 
-func (n *None) Open(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) (*data.DataSet, error) {
+func (n *None) Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")
-	}
-	if repository == nil {
-		return nil, errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return nil, errors.New("data set is missing")
@@ -53,15 +49,12 @@ func (n *None) Open(ctx context.Context, repository dataStore.DataRepository, da
 		dataSet.Active = true
 	}
 
-	return n.Base.Open(ctx, repository, dataSet)
+	return n.Base.Open(ctx, dataSet)
 }
 
-func (n *None) AddData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error {
+func (n *None) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -74,15 +67,12 @@ func (n *None) AddData(ctx context.Context, repository dataStore.DataRepository,
 		dataSetData.SetActive(true)
 	}
 
-	return n.Base.AddData(ctx, repository, dataSet, dataSetData)
+	return n.Base.AddData(ctx, dataSet, dataSetData)
 }
 
-func (n *None) Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (n *None) Close(ctx context.Context, dataSet *data.DataSet) error {
 	if ctx == nil {
 		return errors.New("context is missing")
-	}
-	if repository == nil {
-		return errors.New("repository is missing")
 	}
 	if dataSet == nil {
 		return errors.New("data set is missing")
@@ -92,5 +82,5 @@ func (n *None) Close(ctx context.Context, repository dataStore.DataRepository, d
 		return nil
 	}
 
-	return n.Base.Close(ctx, repository, dataSet)
+	return n.Base.Close(ctx, dataSet)
 }

--- a/data/deduplicator/deduplicator/none_test.go
+++ b/data/deduplicator/deduplicator/none_test.go
@@ -27,479 +27,471 @@ var _ = Describe("None", func() {
 		Expect(dataDeduplicatorDeduplicator.NoneVersion).To(Equal("1.0.0"))
 	})
 
-	Context("NewNone", func() {
-		It("returns succesfully", func() {
-			Expect(dataDeduplicatorDeduplicator.NewNone()).ToNot(BeNil())
-		})
-	})
-
-	Context("with new deduplicator", func() {
-		var deduplicator *dataDeduplicatorDeduplicator.None
-		var dataSet *data.DataSet
+	Context("with dependencies", func() {
+		var dataSetRepository *dataStoreTest.DataRepository
+		var dataRepository *dataStoreTest.DataRepository
+		var dependencies dataDeduplicatorDeduplicator.Dependencies
 
 		BeforeEach(func() {
-			var err error
-			deduplicator, err = dataDeduplicatorDeduplicator.NewNone()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(deduplicator).ToNot(BeNil())
-			dataSet = dataTest.RandomDataSet()
-			dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.none")
+			dataSetRepository = dataStoreTest.NewDataRepository()
+			dataRepository = dataStoreTest.NewDataRepository()
+			dependencies = dataDeduplicatorDeduplicator.Dependencies{
+				DataSetStore: dataSetRepository,
+				DataStore:    dataRepository,
+			}
 		})
 
-		Context("New", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.New(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
+		AfterEach(func() {
+			dataRepository.AssertOutputsEmpty()
+			dataSetRepository.AssertOutputsEmpty()
+		})
 
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
-			})
-
-			It("returns true when the deduplicator name matches deprecated", func() {
-				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous")
-				Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+		Context("NewNone", func() {
+			It("returns successfully", func() {
+				Expect(dataDeduplicatorDeduplicator.NewNone(dependencies)).ToNot(BeNil())
 			})
 		})
 
-		Context("Get", func() {
-			It("returns an error when the data set is missing", func() {
-				found, err := deduplicator.Get(context.Background(), nil)
-				Expect(err).To(MatchError("data set is missing"))
-				Expect(found).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator is missing", func() {
-				dataSet.Deduplicator = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name is missing", func() {
-				dataSet.Deduplicator.Name = nil
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns false when the deduplicator name does not match", func() {
-				dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
-			})
-
-			It("returns true when the deduplicator name matches", func() {
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-
-			It("returns true when the deduplicator name matches deprecated", func() {
-				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous")
-				Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
-			})
-		})
-
-		Context("with context and repository", func() {
-			var ctx context.Context
-			var repository *dataStoreTest.DataRepository
+		Context("with new deduplicator", func() {
+			var deduplicator *dataDeduplicatorDeduplicator.None
+			var dataSet *data.DataSet
 
 			BeforeEach(func() {
-				ctx = context.Background()
-				repository = dataStoreTest.NewDataRepository()
+				var err error
+				deduplicator, err = dataDeduplicatorDeduplicator.NewNone(dependencies)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deduplicator).ToNot(BeNil())
+				dataSet = dataTest.RandomDataSet()
+				dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.deduplicator.none")
 			})
 
-			AfterEach(func() {
-				repository.AssertOutputsEmpty()
-			})
-
-			Context("Open", func() {
-				It("returns an error when the context is missing", func() {
-					result, err := deduplicator.Open(nil, repository, dataSet)
-					Expect(err).To(MatchError("context is missing"))
-					Expect(result).To(BeNil())
-				})
-
-				It("returns an error when the repository is missing", func() {
-					result, err := deduplicator.Open(ctx, nil, dataSet)
-					Expect(err).To(MatchError("repository is missing"))
-					Expect(result).To(BeNil())
-				})
-
+			Context("New", func() {
 				It("returns an error when the data set is missing", func() {
-					result, err := deduplicator.Open(ctx, repository, nil)
+					found, err := deduplicator.New(context.Background(), nil)
 					Expect(err).To(MatchError("data set is missing"))
-					Expect(result).To(BeNil())
+					Expect(found).To(BeFalse())
 				})
 
-				When("UpdateDataSet is invoked", func() {
-					var update *data.DataSetUpdate
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
 
-					BeforeEach(func() {
-						update = data.NewDataSetUpdate()
-						update.Deduplicator = &data.DeduplicatorDescriptor{
-							Name:    pointer.FromString("org.tidepool.deduplicator.none"),
-							Version: pointer.FromString("1.0.0"),
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				})
+
+				It("returns true when the deduplicator name matches deprecated", func() {
+					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous")
+					Expect(deduplicator.New(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("Get", func() {
+				It("returns an error when the data set is missing", func() {
+					found, err := deduplicator.Get(context.Background(), nil)
+					Expect(err).To(MatchError("data set is missing"))
+					Expect(found).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator is missing", func() {
+					dataSet.Deduplicator = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name is missing", func() {
+					dataSet.Deduplicator.Name = nil
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns false when the deduplicator name does not match", func() {
+					dataSet.Deduplicator.Name = pointer.FromString(netTest.RandomReverseDomain())
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeFalse())
+				})
+
+				It("returns true when the deduplicator name matches", func() {
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+
+				It("returns true when the deduplicator name matches deprecated", func() {
+					dataSet.Deduplicator.Name = pointer.FromString("org.tidepool.continuous")
+					Expect(deduplicator.Get(context.Background(), dataSet)).To(BeTrue())
+				})
+			})
+
+			Context("with context", func() {
+				var ctx context.Context
+
+				BeforeEach(func() {
+					ctx = context.Background()
+				})
+
+				Context("Open", func() {
+					It("returns an error when the context is missing", func() {
+						result, err := deduplicator.Open(nil, dataSet)
+						Expect(err).To(MatchError("context is missing"))
+						Expect(result).To(BeNil())
+					})
+
+					It("returns an error when the data set is missing", func() {
+						result, err := deduplicator.Open(ctx, nil)
+						Expect(err).To(MatchError("data set is missing"))
+						Expect(result).To(BeNil())
+					})
+
+					When("UpdateDataSet is invoked", func() {
+						var update *data.DataSetUpdate
+
+						BeforeEach(func() {
+							update = data.NewDataSetUpdate()
+							update.Deduplicator = &data.DeduplicatorDescriptor{
+								Name:    pointer.FromString("org.tidepool.deduplicator.none"),
+								Version: pointer.FromString("1.0.0"),
+							}
+						})
+
+						AfterEach(func() {
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
+						})
+
+						updateAssertions := func() {
+							When("the data set does not have a deduplicator", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator = nil
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+
+							When("the data set has a deduplicator with matching name and version does not exist", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator.Version = nil
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
+
+							When("the data set has a deduplicator with matching name and version exists", func() {
+								BeforeEach(func() {
+									dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
+								})
+
+								It("returns an error when update data set returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+									result, err := deduplicator.Open(ctx, dataSet)
+									Expect(err).To(Equal(responseErr))
+									Expect(result).To(BeNil())
+								})
+
+								It("returns successfully when update data set returns successfully", func() {
+									responseDataSet := dataTest.RandomDataSet()
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
+									Expect(deduplicator.Open(ctx, dataSet)).To(Equal(responseDataSet))
+								})
+							})
 						}
-					})
 
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: update}}))
-					})
-
-					updateAssertions := func() {
-						When("the data set does not have a deduplicator", func() {
+						When("data set type is not specified", func() {
 							BeforeEach(func() {
-								dataSet.Deduplicator = nil
-							})
-
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
-						})
-
-						When("the data set has a deduplicator with matching name and version does not exist", func() {
-							BeforeEach(func() {
-								dataSet.Deduplicator.Version = nil
-							})
-
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
-						})
-
-						When("the data set has a deduplicator with matching name and version exists", func() {
-							BeforeEach(func() {
-								dataSet.Deduplicator.Version = pointer.FromString(netTest.RandomSemanticVersion())
-							})
-
-							It("returns an error when update data set returns an error", func() {
-								responseErr := errorsTest.RandomError()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-								result, err := deduplicator.Open(ctx, repository, dataSet)
-								Expect(err).To(Equal(responseErr))
-								Expect(result).To(BeNil())
-							})
-
-							It("returns successfully when update data set returns successfully", func() {
-								responseDataSet := dataTest.RandomDataSet()
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: responseDataSet, Error: nil}}
-								Expect(deduplicator.Open(ctx, repository, dataSet)).To(Equal(responseDataSet))
-							})
-						})
-					}
-
-					When("data set type is not specified", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = nil
-							update.Active = pointer.FromBool(false)
-						})
-
-						AfterEach(func() {
-							Expect(dataSet.Active).To(BeFalse())
-						})
-
-						updateAssertions()
-					})
-
-					When("data set type is continuous", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("continuous")
-							update.Active = pointer.FromBool(true)
-						})
-
-						AfterEach(func() {
-							Expect(dataSet.Active).To(BeTrue())
-						})
-
-						updateAssertions()
-					})
-
-					When("data set type is normal", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("normal")
-							update.Active = pointer.FromBool(false)
-						})
-
-						AfterEach(func() {
-							Expect(dataSet.Active).To(BeFalse())
-						})
-
-						updateAssertions()
-					})
-				})
-			})
-
-			Context("AddData", func() {
-				var dataSetData data.Data
-
-				BeforeEach(func() {
-					dataSetData = make(data.Data, test.RandomIntFromRange(0, 3))
-					for index := range dataSetData {
-						dataSetData[index] = dataTypesTest.RandomBase()
-					}
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.AddData(nil, repository, dataSet, dataSetData)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.AddData(ctx, nil, dataSet, dataSetData)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, nil, dataSetData)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the data set data is missing", func() {
-					Expect(deduplicator.AddData(ctx, repository, dataSet, nil)).To(MatchError("data set data is missing"))
-				})
-
-				When("create data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
-					})
-
-					createAssertions := func() {
-						It("returns an error when create data set data returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.CreateDataSetDataOutputs = []error{responseErr}
-							Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Equal(responseErr))
-						})
-
-						It("returns successfully when create data set data returns successfully", func() {
-							repository.CreateDataSetDataOutputs = []error{nil}
-							Expect(deduplicator.AddData(ctx, repository, dataSet, dataSetData)).To(Succeed())
-						})
-					}
-
-					When("data set type is not specified", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = nil
-						})
-
-						AfterEach(func() {
-							for _, datum := range dataSetData {
-								base, ok := datum.(*dataTypes.Base)
-								Expect(ok).To(BeTrue())
-								Expect(base).ToNot(BeNil())
-								Expect(base.Active).To(BeFalse())
-							}
-						})
-
-						createAssertions()
-					})
-
-					When("data set type is continuous", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("continuous")
-						})
-
-						AfterEach(func() {
-							for _, datum := range dataSetData {
-								base, ok := datum.(*dataTypes.Base)
-								Expect(ok).To(BeTrue())
-								Expect(base).ToNot(BeNil())
-								Expect(base.Active).To(BeTrue())
-							}
-						})
-
-						createAssertions()
-					})
-
-					When("data set type is normal", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("normal")
-						})
-
-						AfterEach(func() {
-							for _, datum := range dataSetData {
-								base, ok := datum.(*dataTypes.Base)
-								Expect(ok).To(BeTrue())
-								Expect(base).ToNot(BeNil())
-								Expect(base.Active).To(BeFalse())
-							}
-						})
-
-						createAssertions()
-					})
-				})
-			})
-
-			Context("DeleteData", func() {
-				var selectors *data.Selectors
-
-				BeforeEach(func() {
-					selectors = dataTest.RandomSelectors()
-				})
-
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.DeleteData(nil, repository, dataSet, selectors)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, nil, dataSet, selectors)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, nil, selectors)).To(MatchError("data set is missing"))
-				})
-
-				It("returns an error when the selectors is missing", func() {
-					Expect(deduplicator.DeleteData(ctx, repository, dataSet, nil)).To(MatchError("selectors is missing"))
-				})
-
-				When("destroy data set data is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DestroyDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
-					})
-
-					It("returns an error when destroy data set data returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DestroyDataSetDataOutputs = []error{responseErr}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Equal(responseErr))
-					})
-
-					It("returns successfully when destroy data set data returns successfully", func() {
-						repository.DestroyDataSetDataOutputs = []error{nil}
-						Expect(deduplicator.DeleteData(ctx, repository, dataSet, selectors)).To(Succeed())
-					})
-				})
-			})
-
-			Context("Close", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Close(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Close(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Close(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("data set type is continuous", func() {
-					BeforeEach(func() {
-						dataSet.DataSetType = pointer.FromString("continuous")
-					})
-
-					It("returns successfully", func() {
-						Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
-					})
-				})
-
-				When("UpdateDataSet is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
-					})
-
-					updateAssertions := func() {
-						It("returns an error when update data set data returns an error", func() {
-							responseErr := errorsTest.RandomError()
-							repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
-							Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
-						})
-
-						When("activate data set data is invoked", func() {
-							BeforeEach(func() {
-								repository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								dataSet.DataSetType = nil
+								update.Active = pointer.FromBool(false)
 							})
 
 							AfterEach(func() {
-								Expect(repository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+								Expect(dataSet.Active).To(BeFalse())
 							})
 
-							It("returns an error when active data set data returns an error", func() {
+							updateAssertions()
+						})
+
+						When("data set type is continuous", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("continuous")
+								update.Active = pointer.FromBool(true)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeTrue())
+							})
+
+							updateAssertions()
+						})
+
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+								update.Active = pointer.FromBool(false)
+							})
+
+							AfterEach(func() {
+								Expect(dataSet.Active).To(BeFalse())
+							})
+
+							updateAssertions()
+						})
+					})
+				})
+
+				Context("AddData", func() {
+					var dataSetData data.Data
+
+					BeforeEach(func() {
+						dataSetData = make(data.Data, test.RandomIntFromRange(0, 3))
+						for index := range dataSetData {
+							dataSetData[index] = dataTypesTest.RandomBase()
+						}
+					})
+
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.AddData(nil, dataSet, dataSetData)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.AddData(ctx, nil, dataSetData)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the data set data is missing", func() {
+						Expect(deduplicator.AddData(ctx, dataSet, nil)).To(MatchError("data set data is missing"))
+					})
+
+					When("create data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.CreateDataSetDataInputs).To(Equal([]dataStoreTest.CreateDataSetDataInput{{Context: ctx, DataSet: dataSet, DataSetData: dataSetData}}))
+						})
+
+						createAssertions := func() {
+							It("returns an error when create data set data returns an error", func() {
 								responseErr := errorsTest.RandomError()
-								repository.ActivateDataSetDataOutputs = []error{responseErr}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Equal(responseErr))
+								dataRepository.CreateDataSetDataOutputs = []error{responseErr}
+								Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Equal(responseErr))
 							})
 
-							It("returns successfully when active data set data returns successfully", func() {
-								repository.ActivateDataSetDataOutputs = []error{nil}
-								Expect(deduplicator.Close(ctx, repository, dataSet)).To(Succeed())
+							It("returns successfully when create data set data returns successfully", func() {
+								dataRepository.CreateDataSetDataOutputs = []error{nil}
+								Expect(deduplicator.AddData(ctx, dataSet, dataSetData)).To(Succeed())
 							})
-						})
-					}
+						}
 
-					When("data set type is not specified", func() {
+						When("data set type is not specified", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = nil
+							})
+
+							AfterEach(func() {
+								for _, datum := range dataSetData {
+									base, ok := datum.(*dataTypes.Base)
+									Expect(ok).To(BeTrue())
+									Expect(base).ToNot(BeNil())
+									Expect(base.Active).To(BeFalse())
+								}
+							})
+
+							createAssertions()
+						})
+
+						When("data set type is continuous", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("continuous")
+							})
+
+							AfterEach(func() {
+								for _, datum := range dataSetData {
+									base, ok := datum.(*dataTypes.Base)
+									Expect(ok).To(BeTrue())
+									Expect(base).ToNot(BeNil())
+									Expect(base.Active).To(BeTrue())
+								}
+							})
+
+							createAssertions()
+						})
+
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+							})
+
+							AfterEach(func() {
+								for _, datum := range dataSetData {
+									base, ok := datum.(*dataTypes.Base)
+									Expect(ok).To(BeTrue())
+									Expect(base).ToNot(BeNil())
+									Expect(base.Active).To(BeFalse())
+								}
+							})
+
+							createAssertions()
+						})
+					})
+				})
+
+				Context("DeleteData", func() {
+					var selectors *data.Selectors
+
+					BeforeEach(func() {
+						selectors = dataTest.RandomSelectors()
+					})
+
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.DeleteData(nil, dataSet, selectors)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, nil, selectors)).To(MatchError("data set is missing"))
+					})
+
+					It("returns an error when the selectors is missing", func() {
+						Expect(deduplicator.DeleteData(ctx, dataSet, nil)).To(MatchError("selectors is missing"))
+					})
+
+					When("destroy data set data is invoked", func() {
+						AfterEach(func() {
+							Expect(dataRepository.DestroyDataSetDataInputs).To(Equal([]dataStoreTest.DestroyDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: selectors}}))
+						})
+
+						It("returns an error when destroy data set data returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataRepository.DestroyDataSetDataOutputs = []error{responseErr}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when destroy data set data returns successfully", func() {
+							dataRepository.DestroyDataSetDataOutputs = []error{nil}
+							Expect(deduplicator.DeleteData(ctx, dataSet, selectors)).To(Succeed())
+						})
+					})
+				})
+
+				Context("Close", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Close(nil, dataSet)).To(MatchError("context is missing"))
+					})
+
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Close(ctx, nil)).To(MatchError("data set is missing"))
+					})
+
+					When("data set type is continuous", func() {
 						BeforeEach(func() {
-							dataSet.DataSetType = nil
+							dataSet.DataSetType = pointer.FromString("continuous")
 						})
 
-						updateAssertions()
+						It("returns successfully", func() {
+							Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
+						})
 					})
 
-					When("data set type is normal", func() {
-						BeforeEach(func() {
-							dataSet.DataSetType = pointer.FromString("normal")
+					When("UpdateDataSet is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.UpdateDataSetInputs).To(Equal([]dataStoreTest.UpdateDataSetInput{{Context: ctx, ID: *dataSet.UploadID, Update: &data.DataSetUpdate{Active: pointer.FromBool(true)}}}))
 						})
 
-						updateAssertions()
+						updateAssertions := func() {
+							It("returns an error when update data set data returns an error", func() {
+								responseErr := errorsTest.RandomError()
+								dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: nil, Error: responseErr}}
+								Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
+							})
+
+							When("activate data set data is invoked", func() {
+								BeforeEach(func() {
+									dataSetRepository.UpdateDataSetOutputs = []dataStoreTest.UpdateDataSetOutput{{DataSet: dataSet, Error: nil}}
+								})
+
+								AfterEach(func() {
+									Expect(dataRepository.ActivateDataSetDataInputs).To(Equal([]dataStoreTest.ActivateDataSetDataInput{{Context: ctx, DataSet: dataSet, Selectors: nil}}))
+								})
+
+								It("returns an error when active data set data returns an error", func() {
+									responseErr := errorsTest.RandomError()
+									dataRepository.ActivateDataSetDataOutputs = []error{responseErr}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Equal(responseErr))
+								})
+
+								It("returns successfully when active data set data returns successfully", func() {
+									dataRepository.ActivateDataSetDataOutputs = []error{nil}
+									Expect(deduplicator.Close(ctx, dataSet)).To(Succeed())
+								})
+							})
+						}
+
+						When("data set type is not specified", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = nil
+							})
+
+							updateAssertions()
+						})
+
+						When("data set type is normal", func() {
+							BeforeEach(func() {
+								dataSet.DataSetType = pointer.FromString("normal")
+							})
+
+							updateAssertions()
+						})
 					})
 				})
-			})
 
-			Context("Delete", func() {
-				It("returns an error when the context is missing", func() {
-					Expect(deduplicator.Delete(nil, repository, dataSet)).To(MatchError("context is missing"))
-				})
-
-				It("returns an error when the repository is missing", func() {
-					Expect(deduplicator.Delete(ctx, nil, dataSet)).To(MatchError("repository is missing"))
-				})
-
-				It("returns an error when the data set is missing", func() {
-					Expect(deduplicator.Delete(ctx, repository, nil)).To(MatchError("data set is missing"))
-				})
-
-				When("delete data set is invoked", func() {
-					AfterEach(func() {
-						Expect(repository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
+				Context("Delete", func() {
+					It("returns an error when the context is missing", func() {
+						Expect(deduplicator.Delete(nil, dataSet)).To(MatchError("context is missing"))
 					})
 
-					It("returns an error when delete data set returns an error", func() {
-						responseErr := errorsTest.RandomError()
-						repository.DeleteDataSetOutputs = []error{responseErr}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Equal(responseErr))
+					It("returns an error when the data set is missing", func() {
+						Expect(deduplicator.Delete(ctx, nil)).To(MatchError("data set is missing"))
 					})
 
-					It("returns successfully when delete data set returns successfully", func() {
-						repository.DeleteDataSetOutputs = []error{nil}
-						Expect(deduplicator.Delete(ctx, repository, dataSet)).To(Succeed())
+					When("delete data set is invoked", func() {
+						AfterEach(func() {
+							Expect(dataSetRepository.DeleteDataSetInputs).To(Equal([]dataStoreTest.DeleteDataSetInput{{Context: ctx, DataSet: dataSet}}))
+						})
+
+						It("returns an error when delete data set returns an error", func() {
+							responseErr := errorsTest.RandomError()
+							dataSetRepository.DeleteDataSetOutputs = []error{responseErr}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Equal(responseErr))
+						})
+
+						It("returns successfully when delete data set returns successfully", func() {
+							dataSetRepository.DeleteDataSetOutputs = []error{nil}
+							Expect(deduplicator.Delete(ctx, dataSet)).To(Succeed())
+						})
 					})
 				})
 			})

--- a/data/deduplicator/factory/factory.go
+++ b/data/deduplicator/factory/factory.go
@@ -6,9 +6,6 @@ import (
 	"github.com/tidepool-org/platform/data"
 	dataDeduplicator "github.com/tidepool-org/platform/data/deduplicator"
 	"github.com/tidepool-org/platform/errors"
-	"github.com/tidepool-org/platform/log"
-	"github.com/tidepool-org/platform/structure"
-	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
 
 type Deduplicator interface {
@@ -35,8 +32,6 @@ func New(deduplicators []Deduplicator) (*Factory, error) {
 func (f *Factory) New(ctx context.Context, dataSet *data.DataSet) (dataDeduplicator.Deduplicator, error) {
 	if dataSet == nil {
 		return nil, errors.New("data set is missing")
-	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).WithOrigin(structure.OriginStore).Validate(dataSet); err != nil {
-		return nil, errors.Wrap(err, "data set is invalid")
 	}
 
 	if dataSet.HasDeduplicatorName() {
@@ -57,8 +52,6 @@ func (f *Factory) New(ctx context.Context, dataSet *data.DataSet) (dataDeduplica
 func (f *Factory) Get(ctx context.Context, dataSet *data.DataSet) (dataDeduplicator.Deduplicator, error) {
 	if dataSet == nil {
 		return nil, errors.New("data set is missing")
-	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).WithOrigin(structure.OriginStore).Validate(dataSet); err != nil {
-		return nil, errors.Wrap(err, "data set is invalid")
 	}
 
 	if dataSet.HasDeduplicatorName() {

--- a/data/deduplicator/factory/factory_test.go
+++ b/data/deduplicator/factory/factory_test.go
@@ -70,13 +70,6 @@ var _ = Describe("Factory", func() {
 				Expect(deduplicator).To(BeNil())
 			})
 
-			It("returns an error when the data set is invalid", func() {
-				dataSet.DeviceModel = pointer.FromString("")
-				deduplicator, err := factory.New(ctx, dataSet)
-				Expect(err).To(MatchError("data set is invalid; value is empty"))
-				Expect(deduplicator).To(BeNil())
-			})
-
 			When("the data set has a deduplicator name", func() {
 
 				BeforeEach(func() {
@@ -165,13 +158,6 @@ var _ = Describe("Factory", func() {
 			It("returns an error when the data set is missing", func() {
 				deduplicator, err := factory.Get(ctx, nil)
 				Expect(err).To(MatchError("data set is missing"))
-				Expect(deduplicator).To(BeNil())
-			})
-
-			It("returns an error when the data set is invalid", func() {
-				dataSet.DeviceModel = pointer.FromString("")
-				deduplicator, err := factory.Get(ctx, dataSet)
-				Expect(err).To(MatchError("data set is invalid; value is empty"))
 				Expect(deduplicator).To(BeNil())
 			})
 

--- a/data/deduplicator/test/deduplicator.go
+++ b/data/deduplicator/test/deduplicator.go
@@ -4,13 +4,11 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	dataStore "github.com/tidepool-org/platform/data/store"
 )
 
 type OpenInput struct {
-	Context    context.Context
-	Repository dataStore.DataRepository
-	DataSet    *data.DataSet
+	Context context.Context
+	DataSet *data.DataSet
 }
 
 type OpenOutput struct {
@@ -20,54 +18,50 @@ type OpenOutput struct {
 
 type AddDataInput struct {
 	Context     context.Context
-	Repository  dataStore.DataRepository
 	DataSet     *data.DataSet
 	DataSetData data.Data
 }
 
 type DeleteDataInput struct {
-	Context    context.Context
-	Repository dataStore.DataRepository
-	DataSet    *data.DataSet
-	Selectors  *data.Selectors
+	Context   context.Context
+	DataSet   *data.DataSet
+	Selectors *data.Selectors
 }
 
 type CloseInput struct {
-	Context    context.Context
-	Repository dataStore.DataRepository
-	DataSet    *data.DataSet
+	Context context.Context
+	DataSet *data.DataSet
 }
 
 type DeleteInput struct {
-	Context    context.Context
-	Repository dataStore.DataRepository
-	DataSet    *data.DataSet
+	Context context.Context
+	DataSet *data.DataSet
 }
 
 type Deduplicator struct {
 	OpenInvocations       int
 	OpenInputs            []OpenInput
-	OpenStub              func(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) (*data.DataSet, error)
+	OpenStub              func(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error)
 	OpenOutputs           []OpenOutput
 	OpenOutput            *OpenOutput
 	AddDataInvocations    int
 	AddDataInputs         []AddDataInput
-	AddDataStub           func(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error
+	AddDataStub           func(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error
 	AddDataOutputs        []error
 	AddDataOutput         *error
 	DeleteDataInvocations int
 	DeleteDataInputs      []DeleteDataInput
-	DeleteDataStub        func(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, selectors *data.Selectors) error
+	DeleteDataStub        func(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
 	DeleteDataOutputs     []error
 	DeleteDataOutput      *error
 	CloseInvocations      int
 	CloseInputs           []CloseInput
-	CloseStub             func(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error
+	CloseStub             func(ctx context.Context, dataSet *data.DataSet) error
 	CloseOutputs          []error
 	CloseOutput           *error
 	DeleteInvocations     int
 	DeleteInputs          []DeleteInput
-	DeleteStub            func(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error
+	DeleteStub            func(ctx context.Context, dataSet *data.DataSet) error
 	DeleteOutputs         []error
 	DeleteOutput          *error
 }
@@ -76,11 +70,11 @@ func NewDeduplicator() *Deduplicator {
 	return &Deduplicator{}
 }
 
-func (d *Deduplicator) Open(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) (*data.DataSet, error) {
+func (d *Deduplicator) Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error) {
 	d.OpenInvocations++
-	d.OpenInputs = append(d.OpenInputs, OpenInput{Context: ctx, Repository: repository, DataSet: dataSet})
+	d.OpenInputs = append(d.OpenInputs, OpenInput{Context: ctx, DataSet: dataSet})
 	if d.OpenStub != nil {
-		return d.OpenStub(ctx, repository, dataSet)
+		return d.OpenStub(ctx, dataSet)
 	}
 	if len(d.OpenOutputs) > 0 {
 		output := d.OpenOutputs[0]
@@ -93,11 +87,11 @@ func (d *Deduplicator) Open(ctx context.Context, repository dataStore.DataReposi
 	panic("Open has no output")
 }
 
-func (d *Deduplicator) AddData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, dataSetData data.Data) error {
+func (d *Deduplicator) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
 	d.AddDataInvocations++
-	d.AddDataInputs = append(d.AddDataInputs, AddDataInput{Context: ctx, Repository: repository, DataSet: dataSet, DataSetData: dataSetData})
+	d.AddDataInputs = append(d.AddDataInputs, AddDataInput{Context: ctx, DataSet: dataSet, DataSetData: dataSetData})
 	if d.AddDataStub != nil {
-		return d.AddDataStub(ctx, repository, dataSet, dataSetData)
+		return d.AddDataStub(ctx, dataSet, dataSetData)
 	}
 	if len(d.AddDataOutputs) > 0 {
 		output := d.AddDataOutputs[0]
@@ -110,11 +104,11 @@ func (d *Deduplicator) AddData(ctx context.Context, repository dataStore.DataRep
 	panic("AddData has no output")
 }
 
-func (d *Deduplicator) DeleteData(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet, selectors *data.Selectors) error {
+func (d *Deduplicator) DeleteData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error {
 	d.DeleteDataInvocations++
-	d.DeleteDataInputs = append(d.DeleteDataInputs, DeleteDataInput{Context: ctx, Repository: repository, DataSet: dataSet, Selectors: selectors})
+	d.DeleteDataInputs = append(d.DeleteDataInputs, DeleteDataInput{Context: ctx, DataSet: dataSet, Selectors: selectors})
 	if d.DeleteDataStub != nil {
-		return d.DeleteDataStub(ctx, repository, dataSet, selectors)
+		return d.DeleteDataStub(ctx, dataSet, selectors)
 	}
 	if len(d.DeleteDataOutputs) > 0 {
 		output := d.DeleteDataOutputs[0]
@@ -127,11 +121,11 @@ func (d *Deduplicator) DeleteData(ctx context.Context, repository dataStore.Data
 	panic("DeleteData has no output")
 }
 
-func (d *Deduplicator) Close(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (d *Deduplicator) Close(ctx context.Context, dataSet *data.DataSet) error {
 	d.CloseInvocations++
-	d.CloseInputs = append(d.CloseInputs, CloseInput{Context: ctx, Repository: repository, DataSet: dataSet})
+	d.CloseInputs = append(d.CloseInputs, CloseInput{Context: ctx, DataSet: dataSet})
 	if d.CloseStub != nil {
-		return d.CloseStub(ctx, repository, dataSet)
+		return d.CloseStub(ctx, dataSet)
 	}
 	if len(d.CloseOutputs) > 0 {
 		output := d.CloseOutputs[0]
@@ -144,11 +138,11 @@ func (d *Deduplicator) Close(ctx context.Context, repository dataStore.DataRepos
 	panic("Close has no output")
 }
 
-func (d *Deduplicator) Delete(ctx context.Context, repository dataStore.DataRepository, dataSet *data.DataSet) error {
+func (d *Deduplicator) Delete(ctx context.Context, dataSet *data.DataSet) error {
 	d.DeleteInvocations++
-	d.DeleteInputs = append(d.DeleteInputs, DeleteInput{Context: ctx, Repository: repository, DataSet: dataSet})
+	d.DeleteInputs = append(d.DeleteInputs, DeleteInput{Context: ctx, DataSet: dataSet})
 	if d.DeleteStub != nil {
-		return d.DeleteStub(ctx, repository, dataSet)
+		return d.DeleteStub(ctx, dataSet)
 	}
 	if len(d.DeleteOutputs) > 0 {
 		output := d.DeleteOutputs[0]

--- a/data/service/api/v1/datasets_data_create.go
+++ b/data/service/api/v1/datasets_data_create.go
@@ -116,7 +116,7 @@ func DataSetsDataCreate(dataServiceContext dataService.Context) {
 	} else if deduplicator == nil {
 		dataServiceContext.RespondWithInternalServerFailure("Deduplicator not found")
 		return
-	} else if err = deduplicator.AddData(ctx, dataServiceContext.DataRepository(), dataSet, datumArray); err != nil {
+	} else if err = deduplicator.AddData(ctx, dataSet, datumArray); err != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to add data", err)
 		return
 	}

--- a/data/service/api/v1/datasets_data_delete.go
+++ b/data/service/api/v1/datasets_data_delete.go
@@ -63,7 +63,7 @@ func DataSetsDataDelete(dataServiceContext dataService.Context) {
 	} else if deduplicator == nil {
 		dataServiceContext.RespondWithInternalServerFailure("Deduplicator not found")
 		return
-	} else if err = deduplicator.DeleteData(ctx, dataServiceContext.DataRepository(), dataSet, selectors); err != nil {
+	} else if err = deduplicator.DeleteData(ctx, dataSet, selectors); err != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to delete data", err)
 		return
 	}

--- a/data/service/api/v1/datasets_delete.go
+++ b/data/service/api/v1/datasets_delete.go
@@ -68,7 +68,7 @@ func DataSetsDelete(dataServiceContext dataService.Context) {
 			return
 		}
 	} else {
-		if err = deduplicator.Delete(ctx, dataServiceContext.DataRepository(), dataSet); err != nil {
+		if err = deduplicator.Delete(ctx, dataSet); err != nil {
 			dataServiceContext.RespondWithInternalServerFailure("Unable to delete", err)
 			return
 		}

--- a/data/service/api/v1/datasets_update.go
+++ b/data/service/api/v1/datasets_update.go
@@ -88,7 +88,7 @@ func DataSetsUpdate(dataServiceContext dataService.Context) {
 		} else if deduplicator == nil {
 			dataServiceContext.RespondWithInternalServerFailure("Deduplicator not found")
 			return
-		} else if err = deduplicator.Close(ctx, dataServiceContext.DataRepository(), dataSet); err != nil {
+		} else if err = deduplicator.Close(ctx, dataSet); err != nil {
 			dataServiceContext.RespondWithInternalServerFailure("Unable to close", err)
 			return
 		}

--- a/data/service/api/v1/users_datasets_create.go
+++ b/data/service/api/v1/users_datasets_create.go
@@ -97,7 +97,7 @@ func UsersDataSetsCreate(dataServiceContext dataService.Context) {
 	} else if deduplicator == nil {
 		dataServiceContext.RespondWithInternalServerFailure("Deduplicator not found", err)
 		return
-	} else if dataSet, err = deduplicator.Open(ctx, dataServiceContext.DataRepository(), dataSet); err != nil {
+	} else if dataSet, err = deduplicator.Open(ctx, dataSet); err != nil {
 		dataServiceContext.RespondWithInternalServerFailure("Unable to open", err)
 		return
 	}


### PR DESCRIPTION
- Refactor data deduplicator dependencies
- Inject repository into data deduplicator during creation
- Remove repository from various data deduplicator functions
- Remove unnecessary data set validation in data deduplicator factory
- Reorder data service initialization to allow data deduplicator dependencies
- https://tidepool.atlassian.net/browse/BACK-3723