### PR TITLE
[BACK-3724] Refactor provider session API and repository functions

### DIFF
--- a/auth/client/client.go
+++ b/auth/client/client.go
@@ -121,7 +121,7 @@ func (c *Client) CreateUserProviderSession(ctx context.Context, userID string, c
 	return providerSession, nil
 }
 
-func (c *Client) DeleteAllProviderSessions(ctx context.Context, userID string) error {
+func (c *Client) DeleteUserProviderSessions(ctx context.Context, userID string) error {
 	if ctx == nil {
 		return errors.New("context is missing")
 	}
@@ -131,10 +131,6 @@ func (c *Client) DeleteAllProviderSessions(ctx context.Context, userID string) e
 
 	url := c.client.ConstructURL("v1", "users", userID, "provider_sessions")
 	return c.client.RequestData(ctx, http.MethodDelete, url, nil, nil, nil)
-}
-
-func (c *Client) DeleteAllProviderSessionsByExternalID(ctx context.Context, filter auth.ProviderSessionFilter) error {
-	return errors.New("not implemented")
 }
 
 func (c *Client) GetProviderSession(ctx context.Context, id string) (*auth.ProviderSession, error) {

--- a/auth/events/events.go
+++ b/auth/events/events.go
@@ -35,7 +35,7 @@ func (u *userDeletionEventsHandler) HandleDeleteUserEvent(payload ev.DeleteUserE
 	}
 
 	logger.Infof("Deleting provider sessions for user")
-	if err := u.client.DeleteAllProviderSessions(u.ctx, payload.UserID); err != nil {
+	if err := u.client.DeleteUserProviderSessions(u.ctx, payload.UserID); err != nil {
 		errs = append(errs, err)
 		logger.WithError(err).Error("unable to delete provider sessions for user")
 	}

--- a/auth/provider_session.go
+++ b/auth/provider_session.go
@@ -28,8 +28,7 @@ func ProviderTypes() []string {
 type ProviderSessionAccessor interface {
 	ListUserProviderSessions(ctx context.Context, userID string, filter *ProviderSessionFilter, pagination *page.Pagination) (ProviderSessions, error)
 	CreateUserProviderSession(ctx context.Context, userID string, create *ProviderSessionCreate) (*ProviderSession, error)
-	DeleteAllProviderSessions(ctx context.Context, userID string) error
-	DeleteAllProviderSessionsByExternalID(ctx context.Context, filter ProviderSessionFilter) error
+	DeleteUserProviderSessions(ctx context.Context, userID string) error
 
 	GetProviderSession(ctx context.Context, id string) (*ProviderSession, error)
 	UpdateProviderSession(ctx context.Context, id string, update *ProviderSessionUpdate) (*ProviderSession, error)

--- a/auth/service/api/v1/auth_service_mock.go
+++ b/auth/service/api/v1/auth_service_mock.go
@@ -81,6 +81,20 @@ func (mr *MockAuthServiceMockRecorder) AuthClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthClient", reflect.TypeOf((*MockAuthService)(nil).AuthClient))
 }
 
+// AuthServiceClient mocks base method.
+func (m *MockAuthService) AuthServiceClient() service.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthServiceClient")
+	ret0, _ := ret[0].(service.Client)
+	return ret0
+}
+
+// AuthServiceClient indicates an expected call of AuthServiceClient.
+func (mr *MockAuthServiceMockRecorder) AuthServiceClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthServiceClient", reflect.TypeOf((*MockAuthService)(nil).AuthServiceClient))
+}
+
 // AuthStore mocks base method.
 func (m *MockAuthService) AuthStore() store.Store {
 	m.ctrl.T.Helper()

--- a/auth/service/api/v1/provider_session.go
+++ b/auth/service/api/v1/provider_session.go
@@ -3,30 +3,28 @@ package v1
 import (
 	"net/http"
 
-	"github.com/tidepool-org/platform/errors"
-	oauthProvider "github.com/tidepool-org/platform/oauth/provider"
-	"github.com/tidepool-org/platform/pointer"
-	"github.com/tidepool-org/platform/twiist/provider"
-
 	"github.com/ant0ine/go-json-rest/rest"
 
 	"github.com/tidepool-org/platform/auth"
+	oauthProvider "github.com/tidepool-org/platform/oauth/provider"
 	"github.com/tidepool-org/platform/page"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
-	"github.com/tidepool-org/platform/service/api"
+	serviceApi "github.com/tidepool-org/platform/service/api"
+	twiistProvider "github.com/tidepool-org/platform/twiist/provider"
 )
 
 func (r *Router) ProviderSessionsRoutes() []*rest.Route {
 	return []*rest.Route{
-		rest.Get("/v1/users/:userId/provider_sessions", api.RequireServer(r.ListUserProviderSessions)),
-		rest.Post("/v1/users/:userId/provider_sessions", api.RequireServer(r.CreateUserProviderSession)),
-		rest.Delete("/v1/users/:userId/provider_sessions", api.RequireServer(r.DeleteAllProviderSessions)),
-		rest.Get("/v1/provider_sessions/:id", api.RequireServer(r.GetProviderSession)),
-		rest.Put("/v1/provider_sessions/:id", api.RequireServer(r.UpdateProviderSession)),
-		rest.Delete("/v1/provider_sessions/:id", api.RequireServer(r.DeleteProviderSession)),
+		rest.Get("/v1/users/:userId/provider_sessions", serviceApi.RequireServer(r.ListUserProviderSessions)),
+		rest.Post("/v1/users/:userId/provider_sessions", serviceApi.RequireServer(r.CreateUserProviderSession)),
+		rest.Delete("/v1/users/:userId/provider_sessions", serviceApi.RequireServer(r.DeleteUserProviderSessions)),
+		rest.Get("/v1/provider_sessions/:id", serviceApi.RequireServer(r.GetProviderSession)),
+		rest.Put("/v1/provider_sessions/:id", serviceApi.RequireServer(r.UpdateProviderSession)),
+		rest.Delete("/v1/provider_sessions/:id", serviceApi.RequireServer(r.DeleteProviderSession)),
 
-		// Temporary endpoint for deleting provider sessions given a twiist tidepool link id
-		rest.Delete("/v1/partners/twiist/links/:tidepoolLinkId", api.RequireAuth(r.DeleteProviderSessionByTidepoolLinkID)),
+		// TODO: Temporary endpoint for deleting provider sessions given a twiist tidepool link id
+		rest.Delete("/v1/partners/twiist/links/:tidepoolLinkId", serviceApi.RequireAuth(r.DeleteProviderSessionByTidepoolLinkID)),
 	}
 }
 
@@ -79,7 +77,7 @@ func (r *Router) CreateUserProviderSession(res rest.ResponseWriter, req *rest.Re
 	responder.Data(http.StatusCreated, providerSession)
 }
 
-func (r *Router) DeleteAllProviderSessions(res rest.ResponseWriter, req *rest.Request) {
+func (r *Router) DeleteUserProviderSessions(res rest.ResponseWriter, req *rest.Request) {
 	responder := request.MustNewResponder(res, req)
 
 	userID := req.PathParam("userId")
@@ -88,7 +86,7 @@ func (r *Router) DeleteAllProviderSessions(res rest.ResponseWriter, req *rest.Re
 		return
 	}
 
-	if err := r.AuthClient().DeleteAllProviderSessions(req.Context(), userID); err != nil {
+	if err := r.AuthClient().DeleteUserProviderSessions(req.Context(), userID); err != nil {
 		responder.Error(http.StatusInternalServerError, err)
 		return
 	}
@@ -174,17 +172,16 @@ func (r *Router) DeleteProviderSessionByTidepoolLinkID(res rest.ResponseWriter, 
 	// Authorize the service account
 	authDetails := request.GetAuthDetails(req.Context())
 	if !authDetails.IsService() && !r.TwiistServiceAccountAuthorizer().IsAuthorized(authDetails.UserID()) {
-		responder.Error(http.StatusForbidden, errors.New("auth token is not authorized for requested action"))
+		responder.Error(http.StatusForbidden, request.ErrorUnauthorized())
 		return
 	}
 
 	filter := auth.ProviderSessionFilter{
 		Type:       pointer.FromString(oauthProvider.ProviderType),
-		Name:       pointer.FromString(provider.ProviderName),
+		Name:       pointer.FromString(twiistProvider.ProviderName),
 		ExternalID: pointer.FromString(tidepoolLinkID),
 	}
-	err := r.AuthClient().DeleteAllProviderSessionsByExternalID(req.Context(), filter)
-	if err != nil {
+	if err := r.AuthServiceClient().DeleteAllProviderSessions(req.Context(), filter); err != nil {
 		responder.Error(http.StatusInternalServerError, err)
 		return
 	}

--- a/auth/service/client.go
+++ b/auth/service/client.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"context"
+
+	"github.com/tidepool-org/platform/auth"
+)
+
+type Client interface {
+	auth.Client
+
+	DeleteAllProviderSessions(ctx context.Context, filter auth.ProviderSessionFilter) error
+}

--- a/auth/service/service.go
+++ b/auth/service/service.go
@@ -3,26 +3,26 @@ package service
 import (
 	"context"
 
-	"github.com/tidepool-org/platform/twiist"
-
 	confirmationClient "github.com/tidepool-org/hydrophone/client"
 
 	"github.com/tidepool-org/platform/apple"
 	"github.com/tidepool-org/platform/appvalidate"
-	"github.com/tidepool-org/platform/auth/store"
+	authStore "github.com/tidepool-org/platform/auth/store"
 	"github.com/tidepool-org/platform/provider"
 	"github.com/tidepool-org/platform/service"
 	"github.com/tidepool-org/platform/task"
+	"github.com/tidepool-org/platform/twiist"
 )
 
 type Service interface {
 	service.Service
 
 	Domain() string
-	AuthStore() store.Store
+	AuthStore() authStore.Store
 
 	ProviderFactory() provider.Factory
 
+	AuthServiceClient() Client
 	TaskClient() task.Client
 	ConfirmationClient() confirmationClient.ClientWithResponsesInterface
 	DeviceCheck() apple.DeviceCheck
@@ -38,6 +38,6 @@ type Service interface {
 
 type Status struct {
 	Version   string
-	Server    interface{}
-	AuthStore interface{}
+	Server    any
+	AuthStore any
 }

--- a/auth/service/test/service.go
+++ b/auth/service/test/service.go
@@ -3,37 +3,47 @@ package test
 import (
 	"context"
 
-	"github.com/tidepool-org/platform/twiist"
-
 	"github.com/onsi/gomega"
+
 	confirmationClient "github.com/tidepool-org/hydrophone/client"
 
 	"github.com/tidepool-org/platform/apple"
 	"github.com/tidepool-org/platform/appvalidate"
-	"github.com/tidepool-org/platform/auth/service"
-	"github.com/tidepool-org/platform/auth/store"
-	"github.com/tidepool-org/platform/provider"
-	"github.com/tidepool-org/platform/task"
-
+	authService "github.com/tidepool-org/platform/auth/service"
+	authStore "github.com/tidepool-org/platform/auth/store"
 	authStoreTest "github.com/tidepool-org/platform/auth/store/test"
+	"github.com/tidepool-org/platform/provider"
 	providerTest "github.com/tidepool-org/platform/provider/test"
 	serviceTest "github.com/tidepool-org/platform/service/test"
+	"github.com/tidepool-org/platform/task"
 	taskTest "github.com/tidepool-org/platform/task/test"
+	"github.com/tidepool-org/platform/twiist"
 )
 
 type Service struct {
 	*serviceTest.Service
-	DomainInvocations          int
-	DomainOutputs              []string
-	AuthStoreInvocations       int
-	AuthStoreImpl              *authStoreTest.Store
-	ProviderFactoryInvocations int
-	ProviderFactoryImpl        *providerTest.Factory
-	TaskClientInvocations      int
-	TaskClientImpl             *taskTest.Client
-	StatusInvocations          int
-	StatusOutputs              []*service.Status
-	confirmationClient         confirmationClient.ClientWithResponsesInterface
+	DomainInvocations                         int
+	DomainOutputs                             []string
+	AuthStoreInvocations                      int
+	AuthStoreImpl                             *authStoreTest.Store
+	ProviderFactoryInvocations                int
+	ProviderFactoryImpl                       *providerTest.Factory
+	AuthServiceClientInvocations              int
+	AuthServiceClientImpl                     authService.Client
+	TaskClientInvocations                     int
+	TaskClientImpl                            *taskTest.Client
+	ConfirmationClientInvocations             int
+	ConfirmationClientImpl                    confirmationClient.ClientWithResponsesInterface
+	DeviceCheckInvocations                    int
+	DeviceCheckImpl                           apple.DeviceCheck
+	StatusInvocations                         int
+	StatusOutputs                             []*authService.Status
+	AppvalidateValidatorInvocations           int
+	AppvalidateValidatorImpl                  *appvalidate.Validator
+	PartnerSecretsInvocations                 int
+	PartnerSecretsImpl                        *appvalidate.PartnerSecrets
+	TwiistServiceAccountAuthorizerInvocations int
+	TwiistServiceAccountAuthorizerImpl        twiist.ServiceAccountAuthorizer
 }
 
 func NewService() *Service {
@@ -55,7 +65,7 @@ func (s *Service) Domain() string {
 	return output
 }
 
-func (s *Service) AuthStore() store.Store {
+func (s *Service) AuthStore() authStore.Store {
 	s.AuthStoreInvocations++
 
 	return s.AuthStoreImpl
@@ -67,6 +77,12 @@ func (s *Service) ProviderFactory() provider.Factory {
 	return s.ProviderFactoryImpl
 }
 
+func (s *Service) AuthServiceClient() authService.Client {
+	s.AuthServiceClientInvocations++
+
+	return s.AuthServiceClientImpl
+}
+
 func (s *Service) TaskClient() task.Client {
 	s.TaskClientInvocations++
 
@@ -74,18 +90,18 @@ func (s *Service) TaskClient() task.Client {
 }
 
 func (s *Service) ConfirmationClient() confirmationClient.ClientWithResponsesInterface {
-	return s.confirmationClient
-}
+	s.ConfirmationClientInvocations++
 
-func (s *Service) AppValidator() *appvalidate.Validator {
-	return &appvalidate.Validator{}
+	return s.ConfirmationClientImpl
 }
 
 func (s *Service) DeviceCheck() apple.DeviceCheck {
-	return nil
+	s.DeviceCheckInvocations++
+
+	return s.DeviceCheckImpl
 }
 
-func (s *Service) Status(ctx context.Context) *service.Status {
+func (s *Service) Status(ctx context.Context) *authService.Status {
 	s.StatusInvocations++
 
 	gomega.Expect(s.StatusOutputs).ToNot(gomega.BeEmpty())
@@ -95,12 +111,22 @@ func (s *Service) Status(ctx context.Context) *service.Status {
 	return output
 }
 
+func (s *Service) AppValidator() *appvalidate.Validator {
+	s.AppvalidateValidatorInvocations++
+
+	return s.AppvalidateValidatorImpl
+}
+
 func (s *Service) PartnerSecrets() *appvalidate.PartnerSecrets {
-	return nil
+	s.PartnerSecretsInvocations++
+
+	return s.PartnerSecretsImpl
 }
 
 func (s *Service) TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer {
-	return nil
+	s.TwiistServiceAccountAuthorizerInvocations++
+
+	return s.TwiistServiceAccountAuthorizerImpl
 }
 
 func (s *Service) Expectations() {

--- a/auth/store/store.go
+++ b/auth/store/store.go
@@ -18,7 +18,8 @@ type Store interface {
 
 type ProviderSessionRepository interface {
 	auth.ProviderSessionAccessor
-	ListProviderSessions(ctx context.Context, filter *auth.ProviderSessionFilter, pagination *page.Pagination) (auth.ProviderSessions, error)
+
+	ListAllProviderSessions(ctx context.Context, filter auth.ProviderSessionFilter, pagination page.Pagination) (auth.ProviderSessions, error)
 }
 
 type RestrictedTokenRepository interface {

--- a/auth/store/test/provider_session_repository.go
+++ b/auth/store/test/provider_session_repository.go
@@ -1,11 +1,31 @@
 package test
 
 import (
+	"context"
+
+	"github.com/onsi/gomega"
+
+	"github.com/tidepool-org/platform/auth"
 	authTest "github.com/tidepool-org/platform/auth/test"
+	"github.com/tidepool-org/platform/page"
 )
+
+type ListAllProviderSessionsInput struct {
+	Context    context.Context
+	Filter     auth.ProviderSessionFilter
+	Pagination page.Pagination
+}
+
+type ListAllProviderSessionsOutput struct {
+	ProviderSessions auth.ProviderSessions
+	Error            error
+}
 
 type ProviderSessionRepository struct {
 	*authTest.ProviderSessionAccessor
+	ListAllProviderSessionsInvocations int
+	ListAllProviderSessionsInputs      []ListAllProviderSessionsInput
+	ListAllProviderSessionsOutputs     []ListAllProviderSessionsOutput
 }
 
 func NewProviderSessionRepository() *ProviderSessionRepository {
@@ -14,6 +34,19 @@ func NewProviderSessionRepository() *ProviderSessionRepository {
 	}
 }
 
+func (p *ProviderSessionRepository) ListAllProviderSessions(ctx context.Context, filter auth.ProviderSessionFilter, pagination page.Pagination) (auth.ProviderSessions, error) {
+	p.ListAllProviderSessionsInvocations++
+
+	p.ListAllProviderSessionsInputs = append(p.ListAllProviderSessionsInputs, ListAllProviderSessionsInput{Context: ctx, Filter: filter, Pagination: pagination})
+
+	gomega.Expect(p.ListAllProviderSessionsOutputs).ToNot(gomega.BeEmpty())
+
+	output := p.ListAllProviderSessionsOutputs[0]
+	p.ListAllProviderSessionsOutputs = p.ListAllProviderSessionsOutputs[1:]
+	return output.ProviderSessions, output.Error
+}
+
 func (p *ProviderSessionRepository) Expectations() {
 	p.ProviderSessionAccessor.Expectations()
+	gomega.Expect(p.ListAllProviderSessionsOutputs).To(gomega.BeEmpty())
 }

--- a/auth/test/mock.go
+++ b/auth/test/mock.go
@@ -75,34 +75,6 @@ func (mr *MockClientMockRecorder) CreateUserRestrictedToken(ctx, userID, create 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserRestrictedToken", reflect.TypeOf((*MockClient)(nil).CreateUserRestrictedToken), ctx, userID, create)
 }
 
-// DeleteAllProviderSessions mocks base method.
-func (m *MockClient) DeleteAllProviderSessions(ctx context.Context, userID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAllProviderSessions", ctx, userID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteAllProviderSessions indicates an expected call of DeleteAllProviderSessions.
-func (mr *MockClientMockRecorder) DeleteAllProviderSessions(ctx, userID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllProviderSessions", reflect.TypeOf((*MockClient)(nil).DeleteAllProviderSessions), ctx, userID)
-}
-
-// DeleteAllProviderSessionsByExternalID mocks base method.
-func (m *MockClient) DeleteAllProviderSessionsByExternalID(ctx context.Context, filter auth.ProviderSessionFilter) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAllProviderSessionsByExternalID", ctx, filter)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteAllProviderSessionsByExternalID indicates an expected call of DeleteAllProviderSessionsByExternalID.
-func (mr *MockClientMockRecorder) DeleteAllProviderSessionsByExternalID(ctx, filter any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllProviderSessionsByExternalID", reflect.TypeOf((*MockClient)(nil).DeleteAllProviderSessionsByExternalID), ctx, filter)
-}
-
 // DeleteAllRestrictedTokens mocks base method.
 func (m *MockClient) DeleteAllRestrictedTokens(ctx context.Context, userID string) error {
 	m.ctrl.T.Helper()
@@ -143,6 +115,20 @@ func (m *MockClient) DeleteRestrictedToken(ctx context.Context, id string) error
 func (mr *MockClientMockRecorder) DeleteRestrictedToken(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRestrictedToken", reflect.TypeOf((*MockClient)(nil).DeleteRestrictedToken), ctx, id)
+}
+
+// DeleteUserProviderSessions mocks base method.
+func (m *MockClient) DeleteUserProviderSessions(ctx context.Context, userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserProviderSessions", ctx, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUserProviderSessions indicates an expected call of DeleteUserProviderSessions.
+func (mr *MockClientMockRecorder) DeleteUserProviderSessions(ctx, userID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserProviderSessions", reflect.TypeOf((*MockClient)(nil).DeleteUserProviderSessions), ctx, userID)
 }
 
 // EnsureAuthorized mocks base method.

--- a/auth/test/provider_session_accessor.go
+++ b/auth/test/provider_session_accessor.go
@@ -32,7 +32,7 @@ type CreateUserProviderSessionOutput struct {
 	Error           error
 }
 
-type DeleteAllProviderSessionsInput struct {
+type DeleteUserProviderSessionsInput struct {
 	Context context.Context
 	UserID  string
 }
@@ -64,24 +64,24 @@ type DeleteProviderSessionInput struct {
 }
 
 type ProviderSessionAccessor struct {
-	ListUserProviderSessionsInvocations  int
-	ListUserProviderSessionsInputs       []ListUserProviderSessionsInput
-	ListUserProviderSessionsOutputs      []ListUserProviderSessionsOutput
-	CreateUserProviderSessionInvocations int
-	CreateUserProviderSessionInputs      []CreateUserProviderSessionInput
-	CreateUserProviderSessionOutputs     []CreateUserProviderSessionOutput
-	DeleteAllProviderSessionsInvocations int
-	DeleteAllProviderSessionsInputs      []DeleteAllProviderSessionsInput
-	DeleteAllProviderSessionsOutputs     []error
-	GetProviderSessionInvocations        int
-	GetProviderSessionInputs             []GetProviderSessionInput
-	GetProviderSessionOutputs            []GetProviderSessionOutput
-	UpdateProviderSessionInvocations     int
-	UpdateProviderSessionInputs          []UpdateProviderSessionInput
-	UpdateProviderSessionOutputs         []UpdateProviderSessionOutput
-	DeleteProviderSessionInvocations     int
-	DeleteProviderSessionInputs          []DeleteProviderSessionInput
-	DeleteProviderSessionOutputs         []error
+	ListUserProviderSessionsInvocations   int
+	ListUserProviderSessionsInputs        []ListUserProviderSessionsInput
+	ListUserProviderSessionsOutputs       []ListUserProviderSessionsOutput
+	CreateUserProviderSessionInvocations  int
+	CreateUserProviderSessionInputs       []CreateUserProviderSessionInput
+	CreateUserProviderSessionOutputs      []CreateUserProviderSessionOutput
+	DeleteUserProviderSessionsInvocations int
+	DeleteUserProviderSessionsInputs      []DeleteUserProviderSessionsInput
+	DeleteUserProviderSessionsOutputs     []error
+	GetProviderSessionInvocations         int
+	GetProviderSessionInputs              []GetProviderSessionInput
+	GetProviderSessionOutputs             []GetProviderSessionOutput
+	UpdateProviderSessionInvocations      int
+	UpdateProviderSessionInputs           []UpdateProviderSessionInput
+	UpdateProviderSessionOutputs          []UpdateProviderSessionOutput
+	DeleteProviderSessionInvocations      int
+	DeleteProviderSessionInputs           []DeleteProviderSessionInput
+	DeleteProviderSessionOutputs          []error
 }
 
 func NewProviderSessionAccessor() *ProviderSessionAccessor {
@@ -112,15 +112,15 @@ func (p *ProviderSessionAccessor) CreateUserProviderSession(ctx context.Context,
 	return output.ProviderSession, output.Error
 }
 
-func (p *ProviderSessionAccessor) DeleteAllProviderSessions(ctx context.Context, userID string) error {
-	p.DeleteAllProviderSessionsInvocations++
+func (p *ProviderSessionAccessor) DeleteUserProviderSessions(ctx context.Context, userID string) error {
+	p.DeleteUserProviderSessionsInvocations++
 
-	p.DeleteAllProviderSessionsInputs = append(p.DeleteAllProviderSessionsInputs, DeleteAllProviderSessionsInput{Context: ctx, UserID: userID})
+	p.DeleteUserProviderSessionsInputs = append(p.DeleteUserProviderSessionsInputs, DeleteUserProviderSessionsInput{Context: ctx, UserID: userID})
 
-	gomega.Expect(p.DeleteAllProviderSessionsOutputs).ToNot(gomega.BeEmpty())
+	gomega.Expect(p.DeleteUserProviderSessionsOutputs).ToNot(gomega.BeEmpty())
 
-	output := p.DeleteAllProviderSessionsOutputs[0]
-	p.DeleteAllProviderSessionsOutputs = p.DeleteAllProviderSessionsOutputs[1:]
+	output := p.DeleteUserProviderSessionsOutputs[0]
+	p.DeleteUserProviderSessionsOutputs = p.DeleteUserProviderSessionsOutputs[1:]
 	return output
 }
 
@@ -160,18 +160,10 @@ func (p *ProviderSessionAccessor) DeleteProviderSession(ctx context.Context, id 
 	return output
 }
 
-func (p *ProviderSessionAccessor) DeleteAllProviderSessionsByExternalID(ctx context.Context, filter auth.ProviderSessionFilter) error {
-	panic("implement me")
-}
-
-func (p *ProviderSessionAccessor) ListProviderSessions(ctx context.Context, filter *auth.ProviderSessionFilter, pagination *page.Pagination) (auth.ProviderSessions, error) {
-	panic("implement me")
-}
-
 func (p *ProviderSessionAccessor) Expectations() {
 	gomega.Expect(p.ListUserProviderSessionsOutputs).To(gomega.BeEmpty())
 	gomega.Expect(p.CreateUserProviderSessionOutputs).To(gomega.BeEmpty())
-	gomega.Expect(p.DeleteAllProviderSessionsOutputs).To(gomega.BeEmpty())
+	gomega.Expect(p.DeleteUserProviderSessionsOutputs).To(gomega.BeEmpty())
 	gomega.Expect(p.GetProviderSessionOutputs).To(gomega.BeEmpty())
 	gomega.Expect(p.UpdateProviderSessionOutputs).To(gomega.BeEmpty())
 	gomega.Expect(p.DeleteProviderSessionOutputs).To(gomega.BeEmpty())

--- a/page/pagination.go
+++ b/page/pagination.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/request"
 	"github.com/tidepool-org/platform/structure"
 )
@@ -12,11 +13,9 @@ const (
 	PaginationPageDefault = 0
 	PaginationPageMinimum = 0
 	PaginationSizeDefault = 100
-	PaginationSizeMinimum = 1
 	PaginationSizeMaximum = 1000
+	PaginationSizeMinimum = 1
 )
-
-// FUTURE: Use pointers to Page and Size
 
 type Pagination struct {
 	Page int `json:"page,omitempty"`
@@ -53,4 +52,27 @@ func (p *Pagination) MutateRequest(req *http.Request) error {
 		parameters["size"] = strconv.Itoa(p.Size)
 	}
 	return request.NewParametersMutator(parameters).MutateRequest(req)
+}
+
+type Paginator func(pagination Pagination) (done bool, err error)
+
+func Paginate(paginator Paginator) error {
+	return PaginateWithSize(PaginationSizeDefault, paginator)
+}
+
+func PaginateWithSize(size int, paginator Paginator) error {
+	if size < PaginationSizeMinimum {
+		return errors.New("size is less than minimum")
+	}
+	if paginator == nil {
+		return errors.New("paginator is missing")
+	}
+
+	for page := 0; ; page++ {
+		if done, err := paginator(Pagination{Page: page, Size: size}); err != nil {
+			return err
+		} else if done {
+			return nil
+		}
+	}
 }

--- a/page/pagination_test.go
+++ b/page/pagination_test.go
@@ -8,13 +8,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/tidepool-org/platform/errors"
 	errorsTest "github.com/tidepool-org/platform/errors/test"
 	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/page"
 	pageTest "github.com/tidepool-org/platform/page/test"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
+	"github.com/tidepool-org/platform/test"
 	testHttp "github.com/tidepool-org/platform/test/http"
 )
 
@@ -31,12 +31,12 @@ var _ = Describe("Pagination", func() {
 		Expect(page.PaginationSizeDefault).To(Equal(100))
 	})
 
-	It("PaginationSizeMinimum is expected", func() {
-		Expect(page.PaginationSizeMinimum).To(Equal(1))
-	})
-
 	It("PaginationSizeMaximum is expected", func() {
 		Expect(page.PaginationSizeMaximum).To(Equal(1000))
+	})
+
+	It("PaginationSizeMinimum is expected", func() {
+		Expect(page.PaginationSizeMinimum).To(Equal(1))
 	})
 
 	Context("Pagination", func() {
@@ -44,152 +44,195 @@ var _ = Describe("Pagination", func() {
 			It("returns successfully with default values", func() {
 				datum := page.NewPagination()
 				Expect(datum).ToNot(BeNil())
-				Expect(datum.Page).To(Equal(0))
-				Expect(datum.Size).To(Equal(100))
+				Expect(datum.Page).To(Equal(page.PaginationPageDefault))
+				Expect(datum.Size).To(Equal(page.PaginationSizeDefault))
 			})
+		})
+
+		Context("Parse", func() {
+			DescribeTable("parses the datum",
+				func(mutator func(object map[string]any, expectedDatum *page.Pagination), expectedErrors ...error) {
+					expectedDatum := pageTest.RandomPagination()
+					object := pageTest.NewObjectFromPagination(expectedDatum, test.ObjectFormatJSON)
+					mutator(object, expectedDatum)
+					datum := &page.Pagination{}
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(datum), expectedErrors...)
+					Expect(datum).To(Equal(expectedDatum))
+				},
+				Entry("succeeds",
+					func(object map[string]any, expectedDatum *page.Pagination) {},
+				),
+				Entry("page invalid type",
+					func(object map[string]any, expectedDatum *page.Pagination) {
+						object["page"] = true
+						expectedDatum.Page = 0
+					},
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(true), "/page"),
+				),
+				Entry("page valid",
+					func(object map[string]any, expectedDatum *page.Pagination) {
+						valid := pageTest.RandomPage()
+						object["page"] = valid
+						expectedDatum.Page = valid
+					},
+				),
+				Entry("size invalid type",
+					func(object map[string]any, expectedDatum *page.Pagination) {
+						object["size"] = true
+						expectedDatum.Size = 0
+					},
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(true), "/size"),
+				),
+				Entry("size valid",
+					func(object map[string]any, expectedDatum *page.Pagination) {
+						valid := pageTest.RandomSize()
+						object["size"] = valid
+						expectedDatum.Size = valid
+					},
+				),
+				Entry("multiple errors",
+					func(object map[string]any, expectedDatum *page.Pagination) {
+						object["page"] = true
+						object["size"] = true
+						expectedDatum.Page = 0
+						expectedDatum.Size = 0
+					},
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(true), "/page"),
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(true), "/size"),
+				),
+			)
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *page.Pagination), expectedErrors ...error) {
+					datum := pageTest.RandomPagination()
+					mutator(datum)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *page.Pagination) {},
+				),
+				Entry("page out of range (lower)",
+					func(datum *page.Pagination) { datum.Page = page.PaginationPageMinimum - 1 },
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(page.PaginationPageMinimum-1, page.PaginationPageMinimum), "/page"),
+				),
+				Entry("page valid",
+					func(datum *page.Pagination) { datum.Page = pageTest.RandomPage() },
+				),
+				Entry("size out of range (lower)",
+					func(datum *page.Pagination) { datum.Size = page.PaginationSizeMinimum - 1 },
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(page.PaginationSizeMinimum-1, page.PaginationSizeMinimum, page.PaginationSizeMaximum), "/size"),
+				),
+				Entry("size out of range (upper)",
+					func(datum *page.Pagination) { datum.Size = page.PaginationSizeMaximum + 1 },
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(page.PaginationSizeMaximum+1, page.PaginationSizeMinimum, page.PaginationSizeMaximum), "/size"),
+				),
+				Entry("size valid",
+					func(datum *page.Pagination) { datum.Size = pageTest.RandomSize() },
+				),
+				Entry("multiple errors",
+					func(datum *page.Pagination) {
+						datum.Page = page.PaginationPageMinimum - 1
+						datum.Size = page.PaginationSizeMinimum - 1
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(page.PaginationPageMinimum-1, page.PaginationPageMinimum), "/page"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(page.PaginationSizeMinimum-1, page.PaginationSizeMinimum, page.PaginationSizeMaximum), "/size"),
+				),
+			)
 		})
 
 		Context("with a new pagination", func() {
 			var datum *page.Pagination
-			var original *page.Pagination
 
 			BeforeEach(func() {
 				datum = pageTest.RandomPagination()
-				original = pageTest.ClonePagination(datum)
-			})
-
-			// TODO: Use current Parse test mechanism
-
-			Context("Parse", func() {
-				It("parses the page", func() {
-					object := map[string]interface{}{"page": 2}
-					parser := structureParser.NewObject(logTest.NewLogger(), &object)
-					datum.Parse(parser)
-					Expect(datum.Page).To(Equal(2))
-					Expect(datum.Size).To(Equal(original.Size))
-					Expect(parser.Error()).ToNot(HaveOccurred())
-				})
-
-				It("parses the size", func() {
-					object := map[string]interface{}{"size": 10}
-					parser := structureParser.NewObject(logTest.NewLogger(), &object)
-					datum.Parse(parser)
-					Expect(datum.Page).To(Equal(original.Page))
-					Expect(datum.Size).To(Equal(10))
-					Expect(parser.Error()).ToNot(HaveOccurred())
-				})
-
-				It("parses the page and size", func() {
-					object := map[string]interface{}{"page": 2, "size": 10}
-					parser := structureParser.NewObject(logTest.NewLogger(), &object)
-					datum.Parse(parser)
-					Expect(datum.Page).To(Equal(2))
-					Expect(datum.Size).To(Equal(10))
-					Expect(parser.Error()).ToNot(HaveOccurred())
-				})
-
-				It("reports an error if page is not an int", func() {
-					object := map[string]interface{}{"page": false, "size": 10}
-					parser := structureParser.NewObject(logTest.NewLogger(), &object)
-					datum.Parse(parser)
-					Expect(datum.Page).To(Equal(original.Page))
-					Expect(datum.Size).To(Equal(10))
-					Expect(parser.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(parser.Error(), errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(false), "/page"))
-				})
-
-				It("reports an error if size is not an int", func() {
-					object := map[string]interface{}{"page": 2, "size": false}
-					parser := structureParser.NewObject(logTest.NewLogger(), &object)
-					datum.Parse(parser)
-					Expect(datum.Page).To(Equal(2))
-					Expect(datum.Size).To(Equal(original.Size))
-					Expect(parser.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(parser.Error(), errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(false), "/size"))
-				})
-
-				It("reports an error if page and size are not ints", func() {
-					object := map[string]interface{}{"page": false, "size": false}
-					parser := structureParser.NewObject(logTest.NewLogger(), &object)
-					datum.Parse(parser)
-					Expect(datum.Page).To(Equal(original.Page))
-					Expect(datum.Size).To(Equal(original.Size))
-					Expect(parser.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(parser.Error(), errors.Append(
-						errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(false), "/page"),
-						errorsTest.WithPointerSource(structureParser.ErrorTypeNotInt(false), "/size"),
-					))
-				})
-			})
-
-			// TODO: Use current Validate test mechanism
-
-			Context("Validate", func() {
-				var validator *structureValidator.Validator
-
-				BeforeEach(func() {
-					validator = structureValidator.New(logTest.NewLogger())
-				})
-
-				It("succeeds with defaults", func() {
-					datum.Validate(validator)
-					Expect(validator.Error()).ToNot(HaveOccurred())
-				})
-
-				It("reports an error if the page is less than zero", func() {
-					datum.Page = -1
-					datum.Validate(validator)
-					Expect(validator.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(validator.Error(), errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/page"))
-				})
-
-				It("reports an error if the size is less than 1", func() {
-					datum.Size = 0
-					datum.Validate(validator)
-					Expect(validator.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(validator.Error(), errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(0, 1, 1000), "/size"))
-				})
-
-				It("reports an error if the size is greater than 1000", func() {
-					datum.Size = 1001
-					datum.Validate(validator)
-					Expect(validator.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(validator.Error(), errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(1001, 1, 1000), "/size"))
-				})
-
-				It("reports an error if the page and size are less than minimum", func() {
-					datum.Page = -1
-					datum.Size = 0
-					datum.Validate(validator)
-					Expect(validator.Error()).To(HaveOccurred())
-					errorsTest.ExpectEqual(validator.Error(), errors.Append(
-						errorsTest.WithPointerSource(structureValidator.ErrorValueNotGreaterThanOrEqualTo(-1, 0), "/page"),
-						errorsTest.WithPointerSource(structureValidator.ErrorValueNotInRange(0, 1, 1000), "/size"),
-					))
-				})
 			})
 
 			Context("MutateRequest", func() {
-				var req *http.Request
-
-				BeforeEach(func() {
-					req = testHttp.NewRequest()
-				})
-
 				It("returns an error if the request is missing", func() {
 					Expect(datum.MutateRequest(nil)).To(MatchError("request is missing"))
 				})
 
-				It("does not adds default page and size to the request as query parameters", func() {
-					datum = page.NewPagination()
-					Expect(datum.MutateRequest(req)).To(Succeed())
-					Expect(req.URL.Query()).To(BeEmpty())
-				})
+				Context("with a request", func() {
+					var request *http.Request
 
-				It("adds custom page and size to the request as query parameters", func() {
-					Expect(datum.MutateRequest(req)).To(Succeed())
-					Expect(req.URL.Query()).To(Equal(url.Values{"page": []string{strconv.Itoa(datum.Page)}, "size": []string{strconv.Itoa(datum.Size)}}))
+					BeforeEach(func() {
+						request = testHttp.NewRequest()
+					})
+
+					It("does not adds default page and size to the request as query parameters", func() {
+						datum = page.NewPagination()
+						Expect(datum.MutateRequest(request)).To(Succeed())
+						Expect(request.URL.Query()).To(BeEmpty())
+					})
+
+					It("adds custom page and size to the request as query parameters", func() {
+						Expect(datum.MutateRequest(request)).To(Succeed())
+						Expect(request.URL.Query()).To(Equal(url.Values{"page": []string{strconv.Itoa(datum.Page)}, "size": []string{strconv.Itoa(datum.Size)}}))
+					})
 				})
+			})
+		})
+
+		Context("Paginate", func() {
+			It("calls paginator with default size and increments page until done", func() {
+				expectedPages := make([]int, test.RandomIntFromRange(1, 100))
+				for index := range expectedPages {
+					expectedPages[index] = index
+				}
+
+				var actualPages []int
+				paginator := func(p page.Pagination) (bool, error) {
+					Expect(p.Size).To(Equal(page.PaginationSizeDefault))
+					actualPages = append(actualPages, p.Page)
+					return len(actualPages) >= len(expectedPages), nil
+				}
+
+				Expect(page.Paginate(paginator)).To(Succeed())
+				Expect(actualPages).To(Equal(expectedPages))
+			})
+
+			It("returns error if paginator returns error", func() {
+				err := errorsTest.RandomError()
+				paginator := func(p page.Pagination) (bool, error) { return false, err }
+				Expect(page.Paginate(paginator)).To(Equal(err))
+			})
+		})
+
+		Context("PaginateWithSize", func() {
+			It("returns error if size is less than minimum", func() {
+				err := page.PaginateWithSize(page.PaginationSizeMinimum-1, func(p page.Pagination) (bool, error) { return false, nil })
+				Expect(err).To(MatchError("size is less than minimum"))
+			})
+
+			It("returns error if paginator is missing", func() {
+				err := page.PaginateWithSize(page.PaginationSizeDefault, nil)
+				Expect(err).To(MatchError("paginator is missing"))
+			})
+
+			It("calls paginator with given size and increments page until done", func() {
+				size := pageTest.RandomSize()
+				expectedPages := make([]int, test.RandomIntFromRange(1, 100))
+				for index := range expectedPages {
+					expectedPages[index] = index
+				}
+
+				var actualPages []int
+				paginator := func(p page.Pagination) (bool, error) {
+					Expect(p.Size).To(Equal(size))
+					actualPages = append(actualPages, p.Page)
+					return len(actualPages) >= len(expectedPages), nil
+				}
+
+				Expect(page.PaginateWithSize(size, paginator)).To(Succeed())
+				Expect(actualPages).To(Equal(expectedPages))
+			})
+
+			It("returns error if paginator returns error", func() {
+				err := errorsTest.RandomError()
+				paginator := func(p page.Pagination) (bool, error) { return false, err }
+				Expect(page.Paginate(paginator)).To(Equal(err))
 			})
 		})
 	})

--- a/page/test/pagination.go
+++ b/page/test/pagination.go
@@ -1,11 +1,25 @@
 package test
 
 import (
-	"math"
-
 	"github.com/tidepool-org/platform/page"
 	"github.com/tidepool-org/platform/test"
 )
+
+func RandomPage() int {
+	datum := page.PaginationPageDefault
+	for datum == page.PaginationPageDefault {
+		datum = test.RandomIntFromRange(page.PaginationPageMinimum, test.RandomIntMaximum())
+	}
+	return datum
+}
+
+func RandomSize() int {
+	datum := page.PaginationSizeDefault
+	for datum == page.PaginationSizeDefault {
+		datum = test.RandomIntFromRange(page.PaginationSizeMinimum, page.PaginationSizeMaximum)
+	}
+	return datum
+}
 
 func RandomPagination() *page.Pagination {
 	pagination := page.NewPagination()
@@ -24,18 +38,16 @@ func ClonePagination(datum *page.Pagination) *page.Pagination {
 	return clone
 }
 
-func RandomPage() int {
-	datum := page.PaginationPageDefault
-	for datum == page.PaginationPageDefault {
-		datum = test.RandomIntFromRange(page.PaginationPageMinimum, math.MaxInt32)
+func NewObjectFromPagination(datum *page.Pagination, objectFormat test.ObjectFormat) map[string]any {
+	if datum == nil {
+		return nil
 	}
-	return datum
-}
-
-func RandomSize() int {
-	datum := page.PaginationSizeDefault
-	for datum == page.PaginationSizeDefault {
-		datum = test.RandomIntFromRange(page.PaginationSizeMinimum, page.PaginationSizeMaximum)
+	object := map[string]any{}
+	if datum.Page != page.PaginationPageDefault {
+		object["page"] = test.NewObjectFromInt(datum.Page, objectFormat)
 	}
-	return datum
+	if datum.Size != page.PaginationSizeDefault {
+		object["size"] = test.NewObjectFromInt(datum.Size, objectFormat)
+	}
+	return object
 }


### PR DESCRIPTION
- Refactor provider session API and repository functions
- Rename DeleteAllProviderSessions to DeleteUserProviderSessions
- Move ListAllProviderSessions to repository only
- Add page.Paginator to enable easier paging through results
- https://tidepool.atlassian.net/browse/BACK-3724