### PR TITLE
[BACK-3726] Refactor ServiceAccountAuthorizer into common interface

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -31,6 +31,10 @@ type ExternalAccessor interface {
 	EnsureAuthorizedUser(ctx context.Context, targetUserID string, permission string) (string, error)
 }
 
+type ServiceAccountAuthorizer interface {
+	IsServiceAccountAuthorized(userID string) bool
+}
+
 type ServerSessionTokenProvider interface {
 	ServerSessionToken() (string, error)
 }

--- a/auth/service/api/v1/auth_service_mock.go
+++ b/auth/service/api/v1/auth_service_mock.go
@@ -25,7 +25,6 @@ import (
 	log "github.com/tidepool-org/platform/log"
 	provider "github.com/tidepool-org/platform/provider"
 	task "github.com/tidepool-org/platform/task"
-	twiist "github.com/tidepool-org/platform/twiist"
 	version "github.com/tidepool-org/platform/version"
 )
 
@@ -250,10 +249,10 @@ func (mr *MockAuthServiceMockRecorder) TaskClient() *gomock.Call {
 }
 
 // TwiistServiceAccountAuthorizer mocks base method.
-func (m *MockAuthService) TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer {
+func (m *MockAuthService) TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TwiistServiceAccountAuthorizer")
-	ret0, _ := ret[0].(twiist.ServiceAccountAuthorizer)
+	ret0, _ := ret[0].(auth.ServiceAccountAuthorizer)
 	return ret0
 }
 

--- a/auth/service/api/v1/provider_session.go
+++ b/auth/service/api/v1/provider_session.go
@@ -171,7 +171,7 @@ func (r *Router) DeleteProviderSessionByTidepoolLinkID(res rest.ResponseWriter, 
 
 	// Authorize the service account
 	authDetails := request.GetAuthDetails(req.Context())
-	if !authDetails.IsService() && !r.TwiistServiceAccountAuthorizer().IsAuthorized(authDetails.UserID()) {
+	if !authDetails.IsService() && !r.TwiistServiceAccountAuthorizer().IsServiceAccountAuthorized(authDetails.UserID()) {
 		responder.Error(http.StatusForbidden, request.ErrorUnauthorized())
 		return
 	}

--- a/auth/service/service.go
+++ b/auth/service/service.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/tidepool-org/platform/apple"
 	"github.com/tidepool-org/platform/appvalidate"
+	"github.com/tidepool-org/platform/auth"
 	authStore "github.com/tidepool-org/platform/auth/store"
 	"github.com/tidepool-org/platform/provider"
 	"github.com/tidepool-org/platform/service"
 	"github.com/tidepool-org/platform/task"
-	"github.com/tidepool-org/platform/twiist"
 )
 
 type Service interface {
@@ -33,7 +33,7 @@ type Service interface {
 
 	PartnerSecrets() *appvalidate.PartnerSecrets
 
-	TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer
+	TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer
 }
 
 type Status struct {

--- a/auth/service/service/service.go
+++ b/auth/service/service/service.go
@@ -62,7 +62,7 @@ type Service struct {
 	deviceCheck                    apple.DeviceCheck
 	appValidator                   *appvalidate.Validator
 	partnerSecrets                 *appvalidate.PartnerSecrets
-	twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer
+	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer
 }
 
 func New() *Service {
@@ -189,7 +189,7 @@ func (s *Service) PartnerSecrets() *appvalidate.PartnerSecrets {
 	return s.partnerSecrets
 }
 
-func (s *Service) TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer {
+func (s *Service) TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer {
 	return s.twiistServiceAccountAuthorizer
 }
 

--- a/auth/service/test/service.go
+++ b/auth/service/test/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tidepool-org/platform/apple"
 	"github.com/tidepool-org/platform/appvalidate"
+	"github.com/tidepool-org/platform/auth"
 	authService "github.com/tidepool-org/platform/auth/service"
 	authStore "github.com/tidepool-org/platform/auth/store"
 	authStoreTest "github.com/tidepool-org/platform/auth/store/test"
@@ -17,7 +18,6 @@ import (
 	serviceTest "github.com/tidepool-org/platform/service/test"
 	"github.com/tidepool-org/platform/task"
 	taskTest "github.com/tidepool-org/platform/task/test"
-	"github.com/tidepool-org/platform/twiist"
 )
 
 type Service struct {
@@ -43,7 +43,7 @@ type Service struct {
 	PartnerSecretsInvocations                 int
 	PartnerSecretsImpl                        *appvalidate.PartnerSecrets
 	TwiistServiceAccountAuthorizerInvocations int
-	TwiistServiceAccountAuthorizerImpl        twiist.ServiceAccountAuthorizer
+	TwiistServiceAccountAuthorizerImpl        auth.ServiceAccountAuthorizer
 }
 
 func NewService() *Service {
@@ -123,7 +123,7 @@ func (s *Service) PartnerSecrets() *appvalidate.PartnerSecrets {
 	return s.PartnerSecretsImpl
 }
 
-func (s *Service) TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer {
+func (s *Service) TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer {
 	s.TwiistServiceAccountAuthorizerInvocations++
 
 	return s.TwiistServiceAccountAuthorizerImpl

--- a/auth/test/mock.go
+++ b/auth/test/mock.go
@@ -406,6 +406,44 @@ func (mr *MockExternalAccessorMockRecorder) ValidateSessionToken(ctx, token any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateSessionToken", reflect.TypeOf((*MockExternalAccessor)(nil).ValidateSessionToken), ctx, token)
 }
 
+// MockServiceAccountAuthorizer is a mock of ServiceAccountAuthorizer interface.
+type MockServiceAccountAuthorizer struct {
+	ctrl     *gomock.Controller
+	recorder *MockServiceAccountAuthorizerMockRecorder
+	isgomock struct{}
+}
+
+// MockServiceAccountAuthorizerMockRecorder is the mock recorder for MockServiceAccountAuthorizer.
+type MockServiceAccountAuthorizerMockRecorder struct {
+	mock *MockServiceAccountAuthorizer
+}
+
+// NewMockServiceAccountAuthorizer creates a new mock instance.
+func NewMockServiceAccountAuthorizer(ctrl *gomock.Controller) *MockServiceAccountAuthorizer {
+	mock := &MockServiceAccountAuthorizer{ctrl: ctrl}
+	mock.recorder = &MockServiceAccountAuthorizerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockServiceAccountAuthorizer) EXPECT() *MockServiceAccountAuthorizerMockRecorder {
+	return m.recorder
+}
+
+// IsServiceAccountAuthorized mocks base method.
+func (m *MockServiceAccountAuthorizer) IsServiceAccountAuthorized(userID string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsServiceAccountAuthorized", userID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsServiceAccountAuthorized indicates an expected call of IsServiceAccountAuthorized.
+func (mr *MockServiceAccountAuthorizerMockRecorder) IsServiceAccountAuthorized(userID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsServiceAccountAuthorized", reflect.TypeOf((*MockServiceAccountAuthorizer)(nil).IsServiceAccountAuthorized), userID)
+}
+
 // MockServerSessionTokenProvider is a mock of ServerSessionTokenProvider interface.
 type MockServerSessionTokenProvider struct {
 	ctrl     *gomock.Controller

--- a/data/service/api/standard.go
+++ b/data/service/api/standard.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/ant0ine/go-json-rest/rest"
 
+	"github.com/tidepool-org/platform/auth"
 	dataClient "github.com/tidepool-org/platform/data/client"
 	dataDuplicator "github.com/tidepool-org/platform/data/deduplicator"
 	dataService "github.com/tidepool-org/platform/data/service"
@@ -15,7 +16,6 @@ import (
 	"github.com/tidepool-org/platform/service"
 	serviceApi "github.com/tidepool-org/platform/service/api"
 	syncTaskStore "github.com/tidepool-org/platform/synctask/store"
-	"github.com/tidepool-org/platform/twiist"
 )
 
 type Standard struct {
@@ -27,12 +27,12 @@ type Standard struct {
 	syncTaskStore                  syncTaskStore.Store
 	dataClient                     dataClient.Client
 	dataSourceClient               dataSourceService.Client
-	twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer
+	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer
 }
 
 func NewStandard(svc service.Service, metricClient metric.Client, permissionClient permission.Client,
 	dataDeduplicatorFactory dataDuplicator.Factory,
-	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client, dataSourceClient dataSourceService.Client, twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer) (*Standard, error) {
+	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client, dataSourceClient dataSourceService.Client, twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer) (*Standard, error) {
 	if metricClient == nil {
 		return nil, errors.New("metric client is missing")
 	}

--- a/data/service/api/v1/twiist_data_create.go
+++ b/data/service/api/v1/twiist_data_create.go
@@ -26,8 +26,8 @@ func NewTwiistDataCreateHandler(datasetDataCreate func(ctx dataService.Context))
 
 		// Authorize the service account
 		authDetails := request.GetAuthDetails(req.Context())
-		if !authDetails.IsService() && !dataServiceContext.TwiistServiceAccountAuthorizer().IsAuthorized(authDetails.UserID()) {
-			lgr.Debugf("the subject is not authorized twiist service account")
+		if !authDetails.IsService() && !dataServiceContext.TwiistServiceAccountAuthorizer().IsServiceAccountAuthorized(authDetails.UserID()) {
+			lgr.Debug("the subject is not authorized twiist service account")
 			dataServiceContext.RespondWithError(service.ErrorUnauthorized())
 			return
 		}

--- a/data/service/api/v1/users_datasets_create_test.go
+++ b/data/service/api/v1/users_datasets_create_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/tidepool-org/platform/summary"
 	"github.com/tidepool-org/platform/summary/reporters"
 	synctaskStore "github.com/tidepool-org/platform/synctask/store"
-	"github.com/tidepool-org/platform/twiist"
 )
 
 var _ = Describe("UsersDataSetsCreate", func() {
@@ -225,6 +224,6 @@ func (c *mockDataServiceContext) SummaryReporter() *reporters.PatientRealtimeDay
 	panic("not implemented")
 }
 
-func (c *mockDataServiceContext) TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer {
+func (c *mockDataServiceContext) TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer {
 	panic("not implemented")
 }

--- a/data/service/context.go
+++ b/data/service/context.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tidepool-org/platform/summary"
 	summaryReporters "github.com/tidepool-org/platform/summary/reporters"
 	syncTaskStore "github.com/tidepool-org/platform/synctask/store"
-	"github.com/tidepool-org/platform/twiist"
 )
 
 type Context interface {
@@ -38,7 +37,7 @@ type Context interface {
 	ClinicsClient() clinics.Client
 	DataSourceClient() dataSourceService.Client
 
-	TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer
+	TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer
 }
 
 type HandlerFunc func(context Context)

--- a/data/service/context/standard.go
+++ b/data/service/context/standard.go
@@ -21,7 +21,6 @@ import (
 	"github.com/tidepool-org/platform/summary"
 	summaryReporters "github.com/tidepool-org/platform/summary/reporters"
 	syncTaskStore "github.com/tidepool-org/platform/synctask/store"
-	"github.com/tidepool-org/platform/twiist"
 )
 
 type Standard struct {
@@ -42,12 +41,12 @@ type Standard struct {
 	clinicsClient                  clinics.Client
 	dataSourceClient               dataSourceService.Client
 	alertsRepository               alerts.Repository
-	twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer
+	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer
 }
 
 func WithContext(authClient auth.Client, metricClient metric.Client, permissionClient permission.Client,
 	dataDeduplicatorFactory dataDeduplicator.Factory,
-	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client, dataSourceClient dataSourceService.Client, twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer, handler dataService.HandlerFunc) rest.HandlerFunc {
+	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client, dataSourceClient dataSourceService.Client, twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer, handler dataService.HandlerFunc) rest.HandlerFunc {
 	return func(response rest.ResponseWriter, request *rest.Request) {
 		standard, standardErr := NewStandard(response, request, authClient, metricClient, permissionClient,
 			dataDeduplicatorFactory, store, syncTaskStore, dataClient, dataSourceClient, twiistServiceAccountAuthorizer)
@@ -68,7 +67,7 @@ func WithContext(authClient auth.Client, metricClient metric.Client, permissionC
 func NewStandard(response rest.ResponseWriter, request *rest.Request,
 	authClient auth.Client, metricClient metric.Client, permissionClient permission.Client,
 	dataDeduplicatorFactory dataDeduplicator.Factory,
-	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client, dataSourceClient dataSourceService.Client, twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer) (*Standard, error) {
+	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client, dataSourceClient dataSourceService.Client, twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer) (*Standard, error) {
 	if authClient == nil {
 		return nil, errors.New("auth client is missing")
 	}
@@ -214,7 +213,7 @@ func (s *Standard) DataSourceClient() dataSourceService.Client {
 	return s.dataSourceClient
 }
 
-func (s *Standard) TwiistServiceAccountAuthorizer() twiist.ServiceAccountAuthorizer {
+func (s *Standard) TwiistServiceAccountAuthorizer() auth.ServiceAccountAuthorizer {
 	return s.twiistServiceAccountAuthorizer
 }
 

--- a/data/service/service/standard.go
+++ b/data/service/service/standard.go
@@ -46,7 +46,7 @@ type Standard struct {
 	dataClient                     *Client
 	dataSourceClient               *dataSourceServiceClient.Client
 	userEventsHandler              events.Runner
-	twiistServiceAccountAuthorizer twiist.ServiceAccountAuthorizer
+	twiistServiceAccountAuthorizer *twiist.ServiceAccountAuthorizer
 	api                            *api.Standard
 	server                         *server.Standard
 }

--- a/twiist/account.go
+++ b/twiist/account.go
@@ -6,24 +6,18 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-type ServiceAccountAuthorizer interface {
-	IsAuthorized(userID string) bool
-}
-
-func NewServiceAccountAuthorizer() (ServiceAccountAuthorizer, error) {
-	authorizer := &serviceAccountAuthorizer{}
-	err := envconfig.Process("", authorizer)
-	if err != nil {
+func NewServiceAccountAuthorizer() (*ServiceAccountAuthorizer, error) {
+	serviceAccountAuthorizer := &ServiceAccountAuthorizer{}
+	if err := envconfig.Process("", serviceAccountAuthorizer); err != nil {
 		return nil, err
 	}
-
-	return authorizer, nil
+	return serviceAccountAuthorizer, nil
 }
 
-type serviceAccountAuthorizer struct {
+type ServiceAccountAuthorizer struct {
 	ServiceAccountIDs []string `envconfig:"TIDEPOOL_TWIIST_SERVICE_ACCOUNT_IDS"`
 }
 
-func (s *serviceAccountAuthorizer) IsAuthorized(userID string) bool {
+func (s *ServiceAccountAuthorizer) IsServiceAccountAuthorized(userID string) bool {
 	return slices.Contains(s.ServiceAccountIDs, userID)
 }

--- a/twiist/account_test.go
+++ b/twiist/account_test.go
@@ -4,12 +4,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/tidepool-org/platform/auth"
 	"github.com/tidepool-org/platform/twiist"
 )
 
 var _ = Describe("ServiceAccountAuthorizer", func() {
 	var (
-		authorizer twiist.ServiceAccountAuthorizer
+		authorizer auth.ServiceAccountAuthorizer
 		err        error
 	)
 
@@ -27,7 +28,7 @@ var _ = Describe("ServiceAccountAuthorizer", func() {
 		})
 
 		It("should not authorize any user", func() {
-			Expect(authorizer.IsAuthorized("any-user-id")).To(BeFalse())
+			Expect(authorizer.IsServiceAccountAuthorized("any-user-id")).To(BeFalse())
 		})
 	})
 
@@ -45,13 +46,13 @@ var _ = Describe("ServiceAccountAuthorizer", func() {
 		})
 
 		It("should authorize configured service accounts", func() {
-			Expect(authorizer.IsAuthorized("service-account-1")).To(BeTrue())
-			Expect(authorizer.IsAuthorized("service-account-2")).To(BeTrue())
+			Expect(authorizer.IsServiceAccountAuthorized("service-account-1")).To(BeTrue())
+			Expect(authorizer.IsServiceAccountAuthorized("service-account-2")).To(BeTrue())
 		})
 
 		It("should not authorize unconfigured accounts", func() {
-			Expect(authorizer.IsAuthorized("service-account-3")).To(BeFalse())
-			Expect(authorizer.IsAuthorized("random-user")).To(BeFalse())
+			Expect(authorizer.IsServiceAccountAuthorized("service-account-3")).To(BeFalse())
+			Expect(authorizer.IsServiceAccountAuthorized("random-user")).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
- Add auth.ServiceAccountAuthorizer interface
- Rename IsAuthorized to IsServiceAccountAuthorized
- https://tidepool.atlassian.net/browse/BACK-3726