### PR TITLE
fix GetBucketsRange query with both start and end time

### DIFF
--- a/summary/store/buckets.go
+++ b/summary/store/buckets.go
@@ -87,12 +87,15 @@ func (r *Buckets[PB, B]) GetBucketsRange(ctx context.Context, userId string, sta
 		"type":   r.Type,
 	}
 
+	timeSelector := bson.M{}
 	if startTime != nil && !startTime.IsZero() {
-		selector["time"] = bson.M{"$gte": startTime}
+		timeSelector["$gte"] = startTime
 	}
-
 	if endTime != nil && !endTime.IsZero() {
-		selector["time"] = bson.M{"$lte": endTime}
+		timeSelector["$lte"] = endTime
+	}
+	if len(timeSelector) > 0 {
+		selector["time"] = timeSelector
 	}
 
 	opts := options.Find()

--- a/summary/store/buckets_test.go
+++ b/summary/store/buckets_test.go
@@ -141,5 +141,53 @@ var _ = Describe("Buckets", Label("mongodb", "slow", "integration"), func() {
 				Expect(r).To(HaveKey(bucketTime.Add(-time.Hour * 24).Truncate(time.Millisecond)))
 			})
 		})
+
+		When("two buckets are in range, and two are out of range", func() {
+			BeforeEach(func() {
+				buckets := []types.Bucket[*types.ContinuousBucket, types.ContinuousBucket]{
+					// A bucket that's too old by 1s
+					{BaseBucket: types.BaseBucket{
+						UserId: userId,
+						Type:   types.SummaryTypeContinuous,
+						Time:   bucketTime.Add(-(time.Hour*24 + time.Second)),
+					}},
+					// A bucket that's right on the lower edge
+					{BaseBucket: types.BaseBucket{
+						UserId: userId,
+						Type:   types.SummaryTypeContinuous,
+						Time:   bucketTime.Add(-time.Hour * 24),
+					}},
+					// A bucket that's right on the upper edge
+					{BaseBucket: types.BaseBucket{
+						UserId: userId,
+						Type:   types.SummaryTypeContinuous,
+						Time:   bucketTime,
+					}},
+					// A bucket that's too new by 1s
+					{BaseBucket: types.BaseBucket{
+						UserId: userId,
+						Type:   types.SummaryTypeContinuous,
+						Time:   bucketTime.Add(time.Second),
+					}},
+				}
+				opts := options.BulkWrite().SetOrdered(false)
+				_, err := bucketsRepository.BulkWrite(ctx, SliceToInsertWriteModel(buckets), opts)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			Context("GetBucketsRange", func() {
+				It("includes only the two in-time-range buckets", func() {
+					startTime := bucketTime.Add(-24 * time.Hour)
+					cursor, err := conStore.GetBucketsRange(ctx, userId, &startTime, &bucketTime)
+					Expect(err).To(Succeed())
+
+					conBuckets := []types.Bucket[*types.ContinuousBucket, types.ContinuousBucket]{}
+					Expect(cursor.All(context.Background(), &conBuckets)).To(Succeed())
+					Expect(len(conBuckets)).To(Equal(2))
+					Expect(conBuckets[0].Time).To(Equal(bucketTime))
+					Expect(conBuckets[1].Time).To(Equal(bucketTime.Add(-24 * time.Hour)))
+				})
+			})
+		})
 	})
 })


### PR DESCRIPTION
Previously, if both a start and end time were present, the end time
would overwrite the start time in the query filter, causing more data
to be retrieved than expected.

This showed up in EHR Reports where a report over the past 30 days
would indicate that 61 days of data were in scope.

BACK-3777
