### PR TITLE
[BACK-3603] Add DataSetDropHash deduplicator

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -7,13 +7,53 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/id"
+	"github.com/tidepool-org/platform/origin"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 )
 
-const (
-	SelectorOriginIDLengthMaximum = 100
-)
+type SelectorDeduplicator struct {
+	Hash *string `json:"hash,omitempty" bson:"hash,omitempty"`
+}
+
+func ParseSelectorDeduplicator(parser structure.ObjectParser) *SelectorDeduplicator {
+	if !parser.Exists() {
+		return nil
+	}
+	datum := NewSelectorDeduplicator()
+	parser.Parse(datum)
+	return datum
+}
+
+func NewSelectorDeduplicator() *SelectorDeduplicator {
+	return &SelectorDeduplicator{}
+}
+
+func (s *SelectorDeduplicator) Parse(parser structure.ObjectParser) {
+	s.Hash = parser.String("hash")
+}
+
+func (s *SelectorDeduplicator) Validate(validator structure.Validator) {
+	validator.String("hash", s.Hash).Exists().NotEmpty().LengthLessThanOrEqualTo(DeduplicatorHashLengthMaximum)
+}
+
+func (s *SelectorDeduplicator) Matches(other *SelectorDeduplicator) bool {
+	if s == nil || other == nil { // Must not be missing
+		return false
+	} else if s.Hash != nil && (other.Hash == nil || *s.Hash != *other.Hash) { // If hash matters, then must match
+		return false
+	} else {
+		return true
+	}
+}
+
+func (s *SelectorDeduplicator) NewerThan(other *SelectorDeduplicator) bool {
+	if s == nil || other == nil { // Must not be missing
+		return false
+	} else {
+		return true
+	}
+}
 
 type SelectorOrigin struct {
 	ID   *string `json:"id,omitempty" bson:"id,omitempty"`
@@ -39,14 +79,22 @@ func (s *SelectorOrigin) Parse(parser structure.ObjectParser) {
 }
 
 func (s *SelectorOrigin) Validate(validator structure.Validator) {
-	validator.String("id", s.ID).Exists().NotEmpty().LengthLessThanOrEqualTo(SelectorOriginIDLengthMaximum)
+	validator.String("id", s.ID).Exists().NotEmpty().LengthLessThanOrEqualTo(origin.IDLengthMaximum)
 	validator.String("time", s.Time).AsTime(time.RFC3339Nano).NotZero()
 }
 
-func (s *SelectorOrigin) Includes(other *SelectorOrigin) bool {
+func (s *SelectorOrigin) Matches(other *SelectorOrigin) bool {
 	if s == nil || other == nil { // Must not be missing
 		return false
-	} else if s.ID != nil && (other.ID == nil || *s.ID != *other.ID) { // If id matters, then must include
+	} else if s.ID != nil && (other.ID == nil || *s.ID != *other.ID) { // If id matters, then must match
+		return false
+	} else {
+		return true
+	}
+}
+
+func (s *SelectorOrigin) NewerThan(other *SelectorOrigin) bool {
+	if s == nil || other == nil { // Must not be missing
 		return false
 	} else if s.Time == nil { // If time does not matter, success
 		return true
@@ -56,7 +104,7 @@ func (s *SelectorOrigin) Includes(other *SelectorOrigin) bool {
 		return false
 	} else if otherTime, err := time.Parse(time.RFC3339Nano, *other.Time); err != nil || otherTime.IsZero() { // Must parse
 		return false
-	} else if otherTime.Before(sTime) { // Must include
+	} else if sTime.Before(otherTime) { // Must be newer
 		return false
 	} else {
 		return true
@@ -64,9 +112,10 @@ func (s *SelectorOrigin) Includes(other *SelectorOrigin) bool {
 }
 
 type Selector struct {
-	ID     *string         `json:"id,omitempty" bson:"id,omitempty"`
-	Time   *time.Time      `json:"time,omitempty" bson:"time,omitempty"` // Inclusive, currently NOT used in database query
-	Origin *SelectorOrigin `json:"origin,omitempty" bson:"origin,omitempty"`
+	ID           *string               `json:"id,omitempty" bson:"id,omitempty"`
+	Time         *time.Time            `json:"time,omitempty" bson:"time,omitempty"` // Inclusive, currently NOT used in database query
+	Deduplicator *SelectorDeduplicator `json:"deduplicator,omitempty" bson:"_deduplicator,omitempty"`
+	Origin       *SelectorOrigin       `json:"origin,omitempty" bson:"origin,omitempty"`
 }
 
 func ParseSelector(parser structure.ObjectParser) *Selector {
@@ -85,29 +134,59 @@ func NewSelector() *Selector {
 func (s *Selector) Parse(parser structure.ObjectParser) {
 	s.ID = parser.String("id")
 	s.Time = parser.Time("time", TimeFormat)
+	s.Deduplicator = ParseSelectorDeduplicator(parser.WithReferenceObjectParser("deduplicator"))
 	s.Origin = ParseSelectorOrigin(parser.WithReferenceObjectParser("origin"))
 }
 
 func (s *Selector) Validate(validator structure.Validator) {
-	if (s.ID != nil) == (s.Origin != nil) {
-		validator.ReportError(structureValidator.ErrorValuesNotExistForOne("id", "origin"))
-	} else if s.ID != nil {
+	if s.ID != nil {
 		validator.String("id", s.ID).Using(IDValidator)
-		validator.Time("time", s.Time).NotZero()
-	} else {
-		validator.Time("time", s.Time).NotExists()
+		if s.Deduplicator != nil {
+			validator.WithReference("deduplicator").ReportError(structureValidator.ErrorValueExists())
+		}
+		if s.Origin != nil {
+			validator.WithReference("origin").ReportError(structureValidator.ErrorValueExists())
+		}
+	} else if s.Deduplicator != nil {
+		s.Deduplicator.Validate(validator.WithReference("deduplicator"))
+		if s.Origin != nil {
+			validator.WithReference("origin").ReportError(structureValidator.ErrorValueExists())
+		}
+	} else if s.Origin != nil {
 		s.Origin.Validate(validator.WithReference("origin"))
+	} else {
+		validator.ReportError(structureValidator.ErrorValuesNotExistForOne("id", "deduplicator", "origin"))
+	}
+
+	if timeValidator := validator.Time("time", s.Time); s.ID != nil {
+		timeValidator.NotZero()
+	} else {
+		timeValidator.NotExists()
 	}
 }
 
-func (s *Selector) Includes(other *Selector) bool {
+func (s *Selector) Matches(other *Selector) bool {
 	if s == nil || other == nil { // Must not be missing
 		return false
-	} else if s.ID != nil && (other.ID == nil || *s.ID != *other.ID) { // If id matters, then must include
+	} else if s.ID != nil && (other.ID == nil || *s.ID != *other.ID) { // If id matters, then must match
 		return false
-	} else if s.Time != nil && (other.Time == nil || other.Time.Before(*s.Time)) { // If time matters, then must include
+	} else if s.Deduplicator != nil && (other.Deduplicator == nil || !s.Deduplicator.Matches(other.Deduplicator)) { // If deduplicator matters, then must match
 		return false
-	} else if s.Origin != nil && (other.Origin == nil || !s.Origin.Includes(other.Origin)) { // If origin matters, then must include
+	} else if s.Origin != nil && (other.Origin == nil || !s.Origin.Matches(other.Origin)) { // If origin matters, then must match
+		return false
+	} else {
+		return true
+	}
+}
+
+func (s *Selector) NewerThan(other *Selector) bool {
+	if s == nil || other == nil { // Must not be missing
+		return false
+	} else if s.Time != nil && (other.Time == nil || s.Time.Before(*other.Time)) { // If time matters, then must be newer
+		return false
+	} else if s.Deduplicator != nil && (other.Deduplicator == nil || !s.Deduplicator.NewerThan(other.Deduplicator)) { // If deduplicator matters, then must be newer
+		return false
+	} else if s.Origin != nil && (other.Origin == nil || !s.Origin.NewerThan(other.Origin)) { // If origin matters, then must be newer
 		return false
 	} else {
 		return true
@@ -156,6 +235,13 @@ func (s *Selectors) Filter(predicate func(*Selector) bool) *Selectors {
 		}
 	}
 	return &filtered
+}
+
+func (s *Selectors) Append(other *Selectors) *Selectors {
+	selectors := Selectors{}
+	selectors = append(selectors, *s...)
+	selectors = append(selectors, *other...)
+	return &selectors
 }
 
 func NewID() string {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -15,15 +15,45 @@ import (
 )
 
 var _ = Describe("Data", func() {
+	Context("SelectorDeduplicator", func() {
+		Context("Matches", func() {
+			hash := pointer.FromString(data.NewID())
+
+			DescribeTable("return the expected results when the selector deduplicator",
+				func(deduplicator *data.SelectorDeduplicator, otherDeduplicator *data.SelectorDeduplicator, expectedResult bool) {
+					Expect(deduplicator.Matches(otherDeduplicator)).To(Equal(expectedResult))
+				},
+				Entry("both are nil", nil, nil, false),
+				Entry("deduplicator is nil", nil, &data.SelectorDeduplicator{}, false),
+				Entry("other deduplicator is nil", &data.SelectorDeduplicator{}, nil, false),
+				Entry("both hashes are nil", &data.SelectorDeduplicator{}, &data.SelectorDeduplicator{}, true),
+				Entry("deduplicator hash is nil", &data.SelectorDeduplicator{}, &data.SelectorDeduplicator{Hash: hash}, true),
+				Entry("other deduplicator hash is nil", &data.SelectorDeduplicator{Hash: hash}, &data.SelectorDeduplicator{}, false),
+				Entry("hash mismatch", &data.SelectorDeduplicator{Hash: hash}, &data.SelectorDeduplicator{Hash: pointer.FromString("mismatch")}, false),
+				Entry("hash matches", &data.SelectorDeduplicator{Hash: hash}, &data.SelectorDeduplicator{Hash: hash}, true),
+			)
+		})
+
+		Context("NewerThan", func() {
+			DescribeTable("return the expected results when the selector deduplicator",
+				func(deduplicator *data.SelectorDeduplicator, otherDeduplicator *data.SelectorDeduplicator, expectedResult bool) {
+					Expect(deduplicator.NewerThan(otherDeduplicator)).To(Equal(expectedResult))
+				},
+				Entry("both are nil", nil, nil, false),
+				Entry("deduplicator is nil", nil, &data.SelectorDeduplicator{}, false),
+				Entry("other deduplicator is nil", &data.SelectorDeduplicator{}, nil, false),
+				Entry("both are not nil", &data.SelectorDeduplicator{}, &data.SelectorDeduplicator{}, true),
+			)
+		})
+	})
+
 	Context("SelectorOrigin", func() {
-		Context("Includes", func() {
-			now := time.Now()
-			tm := pointer.FromString(now.Format(time.RFC3339Nano))
+		Context("Matches", func() {
 			id := pointer.FromString(data.NewID())
 
-			DescribeTable("return the expected results when the selector origins",
+			DescribeTable("return the expected results when the selector origin",
 				func(origin *data.SelectorOrigin, otherOrigin *data.SelectorOrigin, expectedResult bool) {
-					Expect(origin.Includes(otherOrigin)).To(Equal(expectedResult))
+					Expect(origin.Matches(otherOrigin)).To(Equal(expectedResult))
 				},
 				Entry("both are nil", nil, nil, false),
 				Entry("origin is nil", nil, &data.SelectorOrigin{}, false),
@@ -33,45 +63,90 @@ var _ = Describe("Data", func() {
 				Entry("other origin id is nil", &data.SelectorOrigin{ID: id}, &data.SelectorOrigin{}, false),
 				Entry("id mismatch", &data.SelectorOrigin{ID: id}, &data.SelectorOrigin{ID: pointer.FromString("mismatch")}, false),
 				Entry("id includes", &data.SelectorOrigin{ID: id}, &data.SelectorOrigin{ID: id}, true),
-				Entry("origin time is nil", &data.SelectorOrigin{ID: id}, &data.SelectorOrigin{ID: id, Time: tm}, true),
-				Entry("other origin time is nil", &data.SelectorOrigin{ID: id, Time: tm}, &data.SelectorOrigin{ID: id}, false),
-				Entry("time earlier", &data.SelectorOrigin{ID: id, Time: tm}, &data.SelectorOrigin{ID: id, Time: pointer.FromString(now.Add(-time.Hour).Format(time.RFC3339Nano))}, false),
-				Entry("time same", &data.SelectorOrigin{ID: id, Time: tm}, &data.SelectorOrigin{ID: id, Time: tm}, true),
-				Entry("time same in different time zone", &data.SelectorOrigin{ID: id, Time: tm}, &data.SelectorOrigin{ID: id, Time: pointer.FromString(now.In(time.FixedZone("Etc/GMT-1", int(-time.Hour.Seconds()))).Format(time.RFC3339Nano))}, true),
-				Entry("time later", &data.SelectorOrigin{ID: id, Time: tm}, &data.SelectorOrigin{ID: id, Time: pointer.FromString(now.Add(time.Hour).Format(time.RFC3339Nano))}, true),
+			)
+		})
+
+		Context("NewerThan", func() {
+			now := time.Now()
+			tm := pointer.FromString(now.Format(time.RFC3339Nano))
+
+			DescribeTable("return the expected results when the selector origin",
+				func(origin *data.SelectorOrigin, otherOrigin *data.SelectorOrigin, expectedResult bool) {
+					Expect(origin.NewerThan(otherOrigin)).To(Equal(expectedResult))
+				},
+				Entry("both are nil", nil, nil, false),
+				Entry("origin is nil", nil, &data.SelectorOrigin{}, false),
+				Entry("other origin is nil", &data.SelectorOrigin{}, nil, false),
+				Entry("both times are nil", &data.SelectorOrigin{}, &data.SelectorOrigin{}, true),
+				Entry("origin time is nil", &data.SelectorOrigin{}, &data.SelectorOrigin{Time: tm}, true),
+				Entry("other origin time is nil", &data.SelectorOrigin{Time: tm}, &data.SelectorOrigin{}, false),
+				Entry("time earlier", &data.SelectorOrigin{Time: tm}, &data.SelectorOrigin{Time: pointer.FromString(now.Add(time.Hour).Format(time.RFC3339Nano))}, false),
+				Entry("time same", &data.SelectorOrigin{Time: tm}, &data.SelectorOrigin{Time: tm}, true),
+				Entry("time same in different time zone", &data.SelectorOrigin{Time: tm}, &data.SelectorOrigin{Time: pointer.FromString(now.In(time.FixedZone("Etc/GMT-1", int(-time.Hour.Seconds()))).Format(time.RFC3339Nano))}, true),
+				Entry("time later", &data.SelectorOrigin{Time: tm}, &data.SelectorOrigin{Time: pointer.FromString(now.Add(-time.Hour).Format(time.RFC3339Nano))}, true),
 			)
 		})
 	})
 
 	Context("Selector", func() {
-		Context("Includes", func() {
-			now := time.Now()
-			tm := pointer.FromTime(now)
+		Context("Matches", func() {
 			id := pointer.FromString(data.NewID())
+			deduplicatorHash := pointer.FromString(data.NewID())
 			originID := pointer.FromString(data.NewID())
 
-			DescribeTable("return the expected results when the selector origins",
-				func(origin *data.Selector, otherOrigin *data.Selector, expectedResult bool) {
-					Expect(origin.Includes(otherOrigin)).To(Equal(expectedResult))
+			DescribeTable("return the expected results when the selector",
+				func(selector *data.Selector, otherSector *data.Selector, expectedResult bool) {
+					Expect(selector.Matches(otherSector)).To(Equal(expectedResult))
 				},
 				Entry("both are nil", nil, nil, false),
 				Entry("selector is nil", nil, &data.Selector{}, false),
 				Entry("other selector is nil", &data.Selector{}, nil, false),
-				Entry("id, time, and origin are nil", &data.Selector{}, &data.Selector{}, true),
+				Entry("id, deduplicator, and origin are nil", &data.Selector{}, &data.Selector{}, true),
 				Entry("selector id is nil", &data.Selector{}, &data.Selector{ID: id}, true),
 				Entry("other selector id is nil", &data.Selector{ID: id}, &data.Selector{}, false),
 				Entry("id mismatch", &data.Selector{ID: id}, &data.Selector{ID: pointer.FromString("mismatch")}, false),
 				Entry("id includes", &data.Selector{ID: id}, &data.Selector{ID: id}, true),
-				Entry("selector time is nil", &data.Selector{ID: id}, &data.Selector{ID: id, Time: tm}, true),
-				Entry("other selector time is nil", &data.Selector{ID: id, Time: tm}, &data.Selector{ID: id}, false),
-				Entry("time earlier", &data.Selector{ID: id, Time: tm}, &data.Selector{ID: id, Time: pointer.FromTime(now.Add(-time.Hour))}, false),
-				Entry("time same", &data.Selector{ID: id, Time: tm}, &data.Selector{ID: id, Time: tm}, true),
-				Entry("time same in different time zone", &data.Selector{ID: id, Time: tm}, &data.Selector{ID: id, Time: pointer.FromTime(now.In(time.FixedZone("Etc/GMT-1", int(-time.Hour.Seconds()))))}, true),
-				Entry("time later", &data.Selector{ID: id, Time: tm}, &data.Selector{ID: id, Time: pointer.FromTime(now.Add(time.Hour))}, true),
+				Entry("selector deduplicator is nil", &data.Selector{ID: id}, &data.Selector{ID: id, Deduplicator: &data.SelectorDeduplicator{Hash: deduplicatorHash}}, true),
+				Entry("other selector deduplicator is nil", &data.Selector{ID: id, Deduplicator: &data.SelectorDeduplicator{Hash: deduplicatorHash}}, &data.Selector{ID: id}, false),
+				Entry("deduplicator id mismatch", &data.Selector{ID: id, Deduplicator: &data.SelectorDeduplicator{Hash: deduplicatorHash}}, &data.Selector{ID: id, Deduplicator: &data.SelectorDeduplicator{Hash: pointer.FromString("mismatch")}}, false),
+				Entry("deduplicator match", &data.Selector{ID: id, Deduplicator: &data.SelectorDeduplicator{Hash: deduplicatorHash}}, &data.Selector{ID: id, Deduplicator: &data.SelectorDeduplicator{Hash: deduplicatorHash}}, true),
 				Entry("selector origin is nil", &data.Selector{ID: id}, &data.Selector{ID: id, Origin: &data.SelectorOrigin{ID: originID}}, true),
 				Entry("other selector origin is nil", &data.Selector{ID: id, Origin: &data.SelectorOrigin{ID: originID}}, &data.Selector{ID: id}, false),
 				Entry("origin id mismatch", &data.Selector{ID: id, Origin: &data.SelectorOrigin{ID: originID}}, &data.Selector{ID: id, Origin: &data.SelectorOrigin{ID: pointer.FromString("mismatch")}}, false),
 				Entry("origin match", &data.Selector{ID: id, Origin: &data.SelectorOrigin{ID: originID}}, &data.Selector{ID: id, Origin: &data.SelectorOrigin{ID: originID}}, true),
+			)
+		})
+
+		Context("NewerThan", func() {
+			now := time.Now()
+			tm := pointer.FromTime(now)
+			tmString := pointer.FromString(tm.Format(time.RFC3339Nano))
+
+			DescribeTable("return the expected results when the selector",
+				func(deduplicator *data.Selector, otherDeduplicator *data.Selector, expectedResult bool) {
+					Expect(deduplicator.NewerThan(otherDeduplicator)).To(Equal(expectedResult))
+				},
+				Entry("both are nil", nil, nil, false),
+				Entry("selector is nil", nil, &data.Selector{}, false),
+				Entry("other selector is nil", &data.Selector{}, nil, false),
+				Entry("time, deduplicator, and origin are nil", &data.Selector{}, &data.Selector{}, true),
+				Entry("selector time is nil", &data.Selector{}, &data.Selector{Time: tm}, true),
+				Entry("other selector time is nil", &data.Selector{Time: tm}, &data.Selector{}, false),
+				Entry("time earlier", &data.Selector{Time: tm}, &data.Selector{Time: pointer.FromTime(now.Add(time.Hour))}, false),
+				Entry("time same", &data.Selector{Time: tm}, &data.Selector{Time: tm}, true),
+				Entry("time same in different time zone", &data.Selector{Time: tm}, &data.Selector{Time: pointer.FromTime(now.In(time.FixedZone("Etc/GMT-1", int(-time.Hour.Seconds()))))}, true),
+				Entry("time later", &data.Selector{Time: tm}, &data.Selector{Time: pointer.FromTime(now.Add(-time.Hour))}, true),
+				Entry("selector deduplicator is nil", &data.Selector{}, &data.Selector{Deduplicator: &data.SelectorDeduplicator{}}, true),
+				Entry("other selector deduplicator is nil", &data.Selector{Deduplicator: &data.SelectorDeduplicator{}}, &data.Selector{}, false),
+				Entry("both selector deduplicator are not nil", &data.Selector{Deduplicator: &data.SelectorDeduplicator{}}, &data.Selector{Deduplicator: &data.SelectorDeduplicator{}}, true),
+				Entry("selector origin is nil", &data.Selector{}, &data.Selector{Origin: &data.SelectorOrigin{}}, true),
+				Entry("other selector origin is nil", &data.Selector{Origin: &data.SelectorOrigin{}}, &data.Selector{}, false),
+				Entry("selector origin time is nil", &data.Selector{}, &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, true),
+				Entry("other selector origin time is nil", &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, &data.Selector{}, false),
+				Entry("selector origin time earlier", &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, &data.Selector{Origin: &data.SelectorOrigin{Time: pointer.FromString(now.Add(time.Hour).Format(time.RFC3339Nano))}}, false),
+				Entry("selector origin time same", &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, true),
+				Entry("selector origin time same in different time zone", &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, &data.Selector{Origin: &data.SelectorOrigin{Time: pointer.FromString(now.In(time.FixedZone("Etc/GMT-1", int(-time.Hour.Seconds()))).Format(time.RFC3339Nano))}}, true),
+				Entry("selector origin time later", &data.Selector{Origin: &data.SelectorOrigin{Time: tmString}}, &data.Selector{Origin: &data.SelectorOrigin{Time: pointer.FromString(now.Add(-time.Hour).Format(time.RFC3339Nano))}}, true),
 			)
 		})
 	})

--- a/data/datum.go
+++ b/data/datum.go
@@ -15,7 +15,7 @@ type Datum interface {
 	Validate(validator structure.Validator)
 	Normalize(normalizer Normalizer)
 
-	IdentityFields() ([]string, error)
+	IdentityFields(version string) ([]string, error)
 
 	GetOrigin() *origin.Origin
 	SetOrigin(origin *origin.Origin)
@@ -49,6 +49,18 @@ func DatumAsPointer(datum Datum) *Datum {
 }
 
 type Data []Datum
+
+func (d Data) SetUserID(userID *string) {
+	for _, datum := range d {
+		datum.SetUserID(userID)
+	}
+}
+
+func (d Data) SetDataSetID(dataSetID *string) {
+	for _, datum := range d {
+		datum.SetDataSetID(dataSetID)
+	}
+}
 
 func (d Data) SetActive(active bool) {
 	for _, datum := range d {

--- a/data/deduplicator.go
+++ b/data/deduplicator.go
@@ -5,6 +5,10 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
+const (
+	DeduplicatorHashLengthMaximum = 1000
+)
+
 type DeduplicatorDescriptor struct {
 	Name    *string `json:"name,omitempty" bson:"name,omitempty"`
 	Version *string `json:"version,omitempty" bson:"version,omitempty"`
@@ -31,7 +35,7 @@ func (d *DeduplicatorDescriptor) Parse(parser structure.ObjectParser) {
 func (d *DeduplicatorDescriptor) Validate(validator structure.Validator) {
 	validator.String("name", d.Name).Using(net.ReverseDomainValidator)
 	validator.String("version", d.Version).Using(net.SemanticVersionValidator)
-	validator.String("hash", d.Hash).NotEmpty()
+	validator.String("hash", d.Hash).NotEmpty().LengthLessThanOrEqualTo(DeduplicatorHashLengthMaximum)
 }
 
 func (d *DeduplicatorDescriptor) HasName() bool {

--- a/data/deduplicator/deduplicator/base.go
+++ b/data/deduplicator/deduplicator/base.go
@@ -168,12 +168,14 @@ func (b *Base) Delete(ctx context.Context, dataSet *data.DataSet) error {
 }
 
 func MapDataSetDataToSelectors(dataSetData data.Data, mapper func(datum data.Datum) *data.Selector) *data.Selectors {
-	if len(dataSetData) == 0 {
-		return nil
+	var selectors data.Selectors
+	for _, dataSetDatum := range dataSetData {
+		if selector := mapper(dataSetDatum); selector != nil {
+			selectors = append(selectors, selector)
+		}
 	}
-	selectors := make(data.Selectors, len(dataSetData))
-	for index, dataSetDatum := range dataSetData {
-		selectors[index] = mapper(dataSetDatum)
+	if len(selectors) == 0 {
+		return nil
 	}
 	return &selectors
 }

--- a/data/deduplicator/deduplicator/base_test.go
+++ b/data/deduplicator/deduplicator/base_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Base", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(deduplicator).ToNot(BeNil())
 			dataSet = dataTest.RandomDataSet()
+			dataSet.DataSetType = pointer.FromString(data.DataSetTypeNormal)
 			dataSet.Deduplicator.Name = pointer.FromString(name)
 		})
 

--- a/data/deduplicator/deduplicator/data_set_delete_origin_base.go
+++ b/data/deduplicator/deduplicator/data_set_delete_origin_base.go
@@ -48,21 +48,6 @@ func NewDataSetDeleteOriginBase(dependencies DataSetDeleteOriginDependencies, na
 	}, nil
 }
 
-func (d *DataSetDeleteOriginBase) Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error) {
-	if ctx == nil {
-		return nil, errors.New("context is missing")
-	}
-	if dataSet == nil {
-		return nil, errors.New("data set is missing")
-	}
-
-	if dataSet.HasDataSetTypeContinuous() {
-		dataSet.Active = true
-	}
-
-	return d.Base.Open(ctx, dataSet)
-}
-
 func (d *DataSetDeleteOriginBase) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
 	if ctx == nil {
 		return errors.New("context is missing")
@@ -72,10 +57,6 @@ func (d *DataSetDeleteOriginBase) AddData(ctx context.Context, dataSet *data.Dat
 	}
 	if dataSetData == nil {
 		return errors.New("data set data is missing")
-	}
-
-	if dataSet.HasDataSetTypeContinuous() {
-		dataSetData.SetActive(true)
 	}
 
 	var err error
@@ -108,19 +89,4 @@ func (d *DataSetDeleteOriginBase) DeleteData(ctx context.Context, dataSet *data.
 	}
 
 	return d.DataStore.ArchiveDataSetData(ctx, dataSet, selectors)
-}
-
-func (d *DataSetDeleteOriginBase) Close(ctx context.Context, dataSet *data.DataSet) error {
-	if ctx == nil {
-		return errors.New("context is missing")
-	}
-	if dataSet == nil {
-		return errors.New("data set is missing")
-	}
-
-	if dataSet.HasDataSetTypeContinuous() {
-		return nil
-	}
-
-	return d.Base.Close(ctx, dataSet)
 }

--- a/data/deduplicator/deduplicator/data_set_drop_hash.go
+++ b/data/deduplicator/deduplicator/data_set_drop_hash.go
@@ -1,0 +1,82 @@
+package deduplicator
+
+import (
+	"context"
+
+	"github.com/tidepool-org/platform/data"
+	dataTypes "github.com/tidepool-org/platform/data/types"
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/pointer"
+)
+
+const (
+	DataSetDropHashName    = "org.tidepool.deduplicator.dataset.drop.hash"
+	DataSetDropHashVersion = "1.0.0"
+)
+
+type DataSetDropHash struct {
+	*Base
+}
+
+func NewDataSetDropHash(dependencies Dependencies) (*DataSetDropHash, error) {
+	base, err := NewBase(dependencies, DataSetDropHashName, DataSetDropHashVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DataSetDropHash{
+		Base: base,
+	}, nil
+}
+
+func (d *DataSetDropHash) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
+	if ctx == nil {
+		return errors.New("context is missing")
+	}
+	if dataSet == nil {
+		return errors.New("data set is missing")
+	}
+	if dataSetData == nil {
+		return errors.New("data set data is missing")
+	}
+
+	dataSetData.SetUserID(dataSet.UserID)
+	dataSetData.SetDataSetID(dataSet.ID)
+
+	if err := AssignDataSetDataIdentityHashes(dataSetData, dataTypes.IdentityFieldsVersionDataSetID); err != nil {
+		return err
+	}
+
+	if selectors := MapDataSetDataToSelectors(dataSetData, d.getDatumSelector); selectors != nil {
+		existingSelectors, err := d.DataStore.ExistingDataSetData(ctx, dataSet, selectors)
+		if err != nil {
+			return err
+		}
+
+		existingSelectorsMap := make(map[string]*data.Selector, len(*existingSelectors))
+		for _, existingSelector := range *existingSelectors {
+			existingSelectorsMap[*existingSelector.Deduplicator.Hash] = existingSelector
+		}
+
+		dataSetData = dataSetData.Filter(func(datum data.Datum) bool {
+			if datumSelector := d.getDatumSelector(datum); datumSelector != nil {
+				_, ok := existingSelectorsMap[*datumSelector.Deduplicator.Hash]
+				return !ok
+			}
+			return true
+		})
+	}
+
+	return d.Base.AddData(ctx, dataSet, dataSetData)
+}
+
+func (d *DataSetDropHash) getDatumSelector(dataSetDatum data.Datum) *data.Selector {
+	if deduplicator := dataSetDatum.DeduplicatorDescriptor(); deduplicator != nil && deduplicator.Hash != nil {
+		return &data.Selector{
+			Deduplicator: &data.SelectorDeduplicator{
+				Hash: pointer.CloneString(deduplicator.Hash),
+			},
+		}
+	}
+	return nil
+}

--- a/data/deduplicator/deduplicator/device_deactivate_hash.go
+++ b/data/deduplicator/deduplicator/device_deactivate_hash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
+	dataTypes "github.com/tidepool-org/platform/data/types"
 	"github.com/tidepool-org/platform/errors"
 )
 
@@ -83,7 +84,7 @@ func (d *DeviceDeactivateHash) AddData(ctx context.Context, dataSet *data.DataSe
 		return errors.New("data set data is missing")
 	}
 
-	if err := AssignDataSetDataIdentityHashes(dataSetData); err != nil {
+	if err := AssignDataSetDataIdentityHashes(dataSetData, dataTypes.IdentityFieldsVersionDeviceID); err != nil {
 		return err
 	}
 

--- a/data/deduplicator/deduplicator/hash.go
+++ b/data/deduplicator/deduplicator/hash.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tidepool-org/platform/pointer"
 )
 
-func AssignDataSetDataIdentityHashes(dataSetData data.Data) error {
+func AssignDataSetDataIdentityHashes(dataSetData data.Data, identityFieldsVersion string) error {
 	for _, dataSetDatum := range dataSetData {
-		fields, err := dataSetDatum.IdentityFields()
+		fields, err := dataSetDatum.IdentityFields(identityFieldsVersion)
 		if err != nil {
 			return errors.Wrap(err, "unable to gather identity fields for datum")
 		}

--- a/data/deduplicator/deduplicator/hash_test.go
+++ b/data/deduplicator/deduplicator/hash_test.go
@@ -34,35 +34,35 @@ var _ = Describe("Hash", func() {
 		})
 
 		It("returns successfully when the data is nil", func() {
-			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(nil)).To(Succeed())
+			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(nil, "")).To(Succeed())
 		})
 
 		It("returns successfully when there is no data", func() {
-			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(data.Data{})).To(Succeed())
+			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(data.Data{}, "")).To(Succeed())
 		})
 
 		It("returns an error when any datum returns an error getting identity fields", func() {
 			dataSetDataTest[0].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: []string{userTest.RandomUserID(), dataTest.NewDeviceID()}, Error: nil}}
 			dataSetDataTest[1].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: nil, Error: errors.New("test error")}}
-			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData)).To(MatchError("unable to gather identity fields for datum; test error"))
+			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData, "")).To(MatchError("unable to gather identity fields for datum; test error"))
 		})
 
 		It("returns an error when any datum returns no identity fields", func() {
 			dataSetDataTest[0].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: []string{userTest.RandomUserID(), dataTest.NewDeviceID()}, Error: nil}}
 			dataSetDataTest[1].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: nil, Error: nil}}
-			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData)).To(MatchError("unable to generate identity hash for datum; identity fields are missing"))
+			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData, "")).To(MatchError("unable to generate identity hash for datum; identity fields are missing"))
 		})
 
 		It("returns an error when any datum returns empty identity fields", func() {
 			dataSetDataTest[0].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: []string{userTest.RandomUserID(), dataTest.NewDeviceID()}, Error: nil}}
 			dataSetDataTest[1].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: []string{}, Error: nil}}
-			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData)).To(MatchError("unable to generate identity hash for datum; identity fields are missing"))
+			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData, "")).To(MatchError("unable to generate identity hash for datum; identity fields are missing"))
 		})
 
 		It("returns an error when any datum returns any empty identity fields", func() {
 			dataSetDataTest[0].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: []string{userTest.RandomUserID(), dataTest.NewDeviceID()}, Error: nil}}
 			dataSetDataTest[1].IdentityFieldsOutputs = []dataTest.IdentityFieldsOutput{{IdentityFields: []string{userTest.RandomUserID(), ""}, Error: nil}}
-			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData)).To(MatchError("unable to generate identity hash for datum; identity field is empty"))
+			Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData, "")).To(MatchError("unable to generate identity hash for datum; identity field is empty"))
 		})
 
 		Context("with identity fields", func() {
@@ -79,7 +79,7 @@ var _ = Describe("Hash", func() {
 			})
 
 			It("returns successfully", func() {
-				Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData)).To(Succeed())
+				Expect(dataDeduplicatorDeduplicator.AssignDataSetDataIdentityHashes(dataSetData, "")).To(Succeed())
 			})
 		})
 	})

--- a/data/deduplicator/deduplicator/none.go
+++ b/data/deduplicator/deduplicator/none.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/tidepool-org/platform/data"
-	"github.com/tidepool-org/platform/errors"
 )
 
-const NoneName = "org.tidepool.deduplicator.none"
-const NoneVersion = "1.0.0"
+const (
+	NoneName    = "org.tidepool.deduplicator.none"
+	NoneVersion = "1.0.0"
+)
 
 type None struct {
 	*Base
@@ -35,52 +36,4 @@ func (n *None) Get(ctx context.Context, dataSet *data.DataSet) (bool, error) {
 	}
 
 	return dataSet.HasDeduplicatorNameMatch("org.tidepool.continuous"), nil // TODO: DEPRECATED
-}
-
-func (n *None) Open(ctx context.Context, dataSet *data.DataSet) (*data.DataSet, error) {
-	if ctx == nil {
-		return nil, errors.New("context is missing")
-	}
-	if dataSet == nil {
-		return nil, errors.New("data set is missing")
-	}
-
-	if dataSet.HasDataSetTypeContinuous() {
-		dataSet.Active = true
-	}
-
-	return n.Base.Open(ctx, dataSet)
-}
-
-func (n *None) AddData(ctx context.Context, dataSet *data.DataSet, dataSetData data.Data) error {
-	if ctx == nil {
-		return errors.New("context is missing")
-	}
-	if dataSet == nil {
-		return errors.New("data set is missing")
-	}
-	if dataSetData == nil {
-		return errors.New("data set data is missing")
-	}
-
-	if dataSet.HasDataSetTypeContinuous() {
-		dataSetData.SetActive(true)
-	}
-
-	return n.Base.AddData(ctx, dataSet, dataSetData)
-}
-
-func (n *None) Close(ctx context.Context, dataSet *data.DataSet) error {
-	if ctx == nil {
-		return errors.New("context is missing")
-	}
-	if dataSet == nil {
-		return errors.New("data set is missing")
-	}
-
-	if dataSet.HasDataSetTypeContinuous() {
-		return nil
-	}
-
-	return n.Base.Close(ctx, dataSet)
 }

--- a/data/deduplicator_test.go
+++ b/data/deduplicator_test.go
@@ -103,6 +103,17 @@ var _ = Describe("Deduplicator", func() {
 					func(datum *data.DeduplicatorDescriptor) { datum.Hash = pointer.FromString("") },
 					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/hash"),
 				),
+				Entry("hash length in range (upper)",
+					func(datum *data.DeduplicatorDescriptor) {
+						datum.Hash = pointer.FromString(test.RandomStringFromRange(data.DeduplicatorHashLengthMaximum, data.DeduplicatorHashLengthMaximum))
+					},
+				),
+				Entry("hash length out of range (upper)",
+					func(datum *data.DeduplicatorDescriptor) {
+						datum.Hash = pointer.FromString(test.RandomStringFromRange(data.DeduplicatorHashLengthMaximum+1, data.DeduplicatorHashLengthMaximum+1))
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorLengthNotLessThanOrEqualTo(data.DeduplicatorHashLengthMaximum+1, data.DeduplicatorHashLengthMaximum), "/hash"),
+				),
 				Entry("hash valid",
 					func(datum *data.DeduplicatorDescriptor) { datum.Hash = pointer.FromString(test.RandomString()) },
 				),

--- a/data/service/service/standard.go
+++ b/data/service/service/standard.go
@@ -429,6 +429,13 @@ func (s *Standard) initializeDataDeduplicatorFactory() error {
 		return errors.Wrap(err, "unable to create data set delete origin older deduplicator")
 	}
 
+	s.Logger().Debug("Creating data set drop hash deduplicator")
+
+	dataSetDropHashDeduplicator, err := dataDeduplicatorDeduplicator.NewDataSetDropHash(dependencies)
+	if err != nil {
+		return errors.Wrap(err, "unable to create data set drop hash deduplicator")
+	}
+
 	s.Logger().Debug("Creating none deduplicator")
 
 	noneDeduplicator, err := dataDeduplicatorDeduplicator.NewNone(dependencies)
@@ -443,6 +450,7 @@ func (s *Standard) initializeDataDeduplicatorFactory() error {
 		deviceTruncateDataSetDeduplicator,
 		dataSetDeleteOriginDeduplicator,
 		dataSetDeleteOriginOlderDeduplicator,
+		dataSetDropHashDeduplicator,
 		noneDeduplicator,
 	}
 

--- a/data/store/mongo/mongo_test.go
+++ b/data/store/mongo/mongo_test.go
@@ -1331,13 +1331,14 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.ActivateDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
 							Context("with selectors by id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeID)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID})
 									}
@@ -1347,8 +1348,21 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
+							Context("with selectors by deduplicator hash", func() {
+								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeDeduplicator)
+									for _, datum := range selectedDataSetData {
+										*selectors = append(*selectors, &data.Selector{Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}})
+									}
+								})
+
+								commonAssertions()
+								selectorAssertions()
+							})
+
 							Context("with selectors by origin id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeOrigin)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
@@ -1358,24 +1372,25 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
-							Context("with selectors by both id and origin id", func() {
+							Context("with selectors by id, deduplicator hash, and origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for _, datum := range selectedDataSetData {
-										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
+										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
 								})
 
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
-
+									err := repository.ActivateDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
-							Context("with selectors with neither id nor origin id", func() {
+							Context("with selectors with neither id, deduplicator hash, nor origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{})
 									}
@@ -1384,7 +1399,7 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.ActivateDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
@@ -1488,6 +1503,7 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 
 							Context("with selectors by id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeID)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID})
 									}
@@ -1497,8 +1513,21 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
+							Context("with selectors by deduplicator hash", func() {
+								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeDeduplicator)
+									for _, datum := range selectedDataSetData {
+										*selectors = append(*selectors, &data.Selector{Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}})
+									}
+								})
+
+								commonAssertions()
+								selectorAssertions()
+							})
+
 							Context("with selectors by origin id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeOrigin)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
@@ -1508,10 +1537,11 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
-							Context("with selectors by both id and origin id", func() {
+							Context("with selectors by id, deduplicator hash, and origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for _, datum := range selectedDataSetData {
-										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
+										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
 								})
 
@@ -1523,8 +1553,9 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								})
 							})
 
-							Context("with selectors with neither id nor origin id", func() {
+							Context("with selectors with neither id, deduplicator hash, nor origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{})
 									}
@@ -1619,13 +1650,14 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DeleteDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
 							Context("with selectors by id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeID)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID})
 									}
@@ -1635,8 +1667,21 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
+							Context("with selectors by deduplicator hash", func() {
+								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeDeduplicator)
+									for _, datum := range selectedDataSetData {
+										*selectors = append(*selectors, &data.Selector{Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}})
+									}
+								})
+
+								commonAssertions()
+								selectorAssertions()
+							})
+
 							Context("with selectors by origin id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeOrigin)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
@@ -1646,23 +1691,25 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
-							Context("with selectors by both id and origin id", func() {
+							Context("with selectors by id, deduplicator hash, and origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for _, datum := range selectedDataSetData {
-										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
+										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
 								})
 
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DeleteDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
-							Context("with selectors with neither id nor origin id", func() {
+							Context("with selectors with neither id, deduplicator hash, nor origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{})
 									}
@@ -1671,7 +1718,7 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DeleteDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
@@ -1757,13 +1804,14 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DestroyDeletedDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
 							Context("with selectors by id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeID)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID})
 									}
@@ -1773,8 +1821,21 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
+							Context("with selectors by deduplicator hash", func() {
+								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeDeduplicator)
+									for _, datum := range selectedDataSetData {
+										*selectors = append(*selectors, &data.Selector{Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}})
+									}
+								})
+
+								commonAssertions()
+								selectorAssertions()
+							})
+
 							Context("with selectors by origin id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeOrigin)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
@@ -1784,10 +1845,11 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
-							Context("with selectors by both id and origin id", func() {
+							Context("with selectors by id, deduplicator hash, and origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for _, datum := range selectedDataSetData {
-										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
+										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
 								})
 
@@ -1799,8 +1861,9 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								})
 							})
 
-							Context("with selectors with neither id nor origin id", func() {
+							Context("with selectors with neither id, deduplicator hash, nor origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{})
 									}
@@ -1809,7 +1872,7 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DestroyDeletedDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
@@ -1895,13 +1958,14 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DestroyDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
 							Context("with selectors by id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeID)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID})
 									}
@@ -1911,8 +1975,21 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
+							Context("with selectors by deduplicator hash", func() {
+								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeDeduplicator)
+									for _, datum := range selectedDataSetData {
+										*selectors = append(*selectors, &data.Selector{Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}})
+									}
+								})
+
+								commonAssertions()
+								selectorAssertions()
+							})
+
 							Context("with selectors by origin id", func() {
 								BeforeEach(func() {
+									selectors = dataTest.RandomSelectorsWithType(dataTest.SelectorTypeOrigin)
 									for _, datum := range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
@@ -1922,23 +1999,25 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								selectorAssertions()
 							})
 
-							Context("with selectors by both id and origin id", func() {
+							Context("with selectors by id, deduplicator hash, and origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for _, datum := range selectedDataSetData {
-										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
+										*selectors = append(*selectors, &data.Selector{ID: datum.(*types.Base).ID, Deduplicator: &data.SelectorDeduplicator{Hash: datum.(*types.Base).Deduplicator.Hash}, Origin: &data.SelectorOrigin{ID: datum.(*types.Base).Origin.ID}})
 									}
 								})
 
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DestroyDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})
 
-							Context("with selectors with neither id nor origin id", func() {
+							Context("with selectors with neither id, deduplicator hash, nor origin id", func() {
 								BeforeEach(func() {
+									selectors = data.NewSelectors()
 									for range selectedDataSetData {
 										*selectors = append(*selectors, &data.Selector{})
 									}
@@ -1947,7 +2026,7 @@ var _ = Describe("Mongo", Label("mongodb", "slow", "integration"), func() {
 								commonAssertions()
 
 								It("returns an error", func() {
-									err := repository.ArchiveDataSetData(ctx, dataSet, selectors)
+									err := repository.DestroyDataSetData(ctx, dataSet, selectors)
 									Expect(err).To(MatchError(dataStoreMongo.ErrSelectorsInvalid))
 								})
 							})

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -52,7 +52,7 @@ type DatumRepository interface {
 	EnsureIndexes() error
 
 	CreateDataSetData(ctx context.Context, dataSet *data.DataSet, dataSetData []data.Datum) error
-	NewerDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) (*data.Selectors, error)
+	ExistingDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) (*data.Selectors, error)
 	ActivateDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
 	ArchiveDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error
 	DeleteDataSetData(ctx context.Context, dataSet *data.DataSet, selectors *data.Selectors) error

--- a/data/test/data.go
+++ b/data/test/data.go
@@ -1,10 +1,30 @@
 package test
 
 import (
+	"time"
+
 	"github.com/tidepool-org/platform/data"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/test"
 )
+
+const (
+	SelectorTypeID           = "id"
+	SelectorTypeDeduplicator = "deduplicator"
+	SelectorTypeOrigin       = "origin"
+)
+
+func SelectorTypes() []string {
+	return []string{
+		SelectorTypeID,
+		SelectorTypeDeduplicator,
+		SelectorTypeOrigin,
+	}
+}
+
+func RandomSelectorType() string {
+	return test.RandomStringFromArray(SelectorTypes())
+}
 
 func RandomDatumID() string {
 	return data.NewID()
@@ -18,9 +38,25 @@ func NewDeviceID() string {
 	return test.RandomStringFromRangeAndCharset(32, 32, test.CharsetText)
 }
 
+func RandomSelectorDeduplicator() *data.SelectorDeduplicator {
+	datum := data.NewSelectorDeduplicator()
+	datum.Hash = pointer.FromString(test.RandomStringFromRangeAndCharset(32, 32, test.CharsetHexadecimalLowercase))
+	return datum
+}
+
+func CloneSelectorDeduplicator(datum *data.SelectorDeduplicator) *data.SelectorDeduplicator {
+	if datum == nil {
+		return nil
+	}
+	clone := data.NewSelectorDeduplicator()
+	clone.Hash = pointer.CloneString(datum.Hash)
+	return clone
+}
+
 func RandomSelectorOrigin() *data.SelectorOrigin {
 	datum := data.NewSelectorOrigin()
 	datum.ID = pointer.FromString(test.RandomStringFromRangeAndCharset(1, 100, test.CharsetText))
+	datum.Time = pointer.FromString(test.RandomTimeBeforeNow().Format(time.RFC3339))
 	return datum
 }
 
@@ -30,14 +66,23 @@ func CloneSelectorOrigin(datum *data.SelectorOrigin) *data.SelectorOrigin {
 	}
 	clone := data.NewSelectorOrigin()
 	clone.ID = pointer.CloneString(datum.ID)
+	clone.Time = pointer.CloneString(datum.Time)
 	return clone
 }
 
 func RandomSelector() *data.Selector {
+	return RandomSelectorWithType(RandomSelectorType())
+}
+
+func RandomSelectorWithType(selectorType string) *data.Selector {
 	datum := data.NewSelector()
-	if test.RandomBool() {
+	switch selectorType {
+	case SelectorTypeID:
 		datum.ID = pointer.FromString(RandomDatumID())
-	} else {
+		datum.Time = pointer.FromTime(test.RandomTimeBeforeNow())
+	case SelectorTypeDeduplicator:
+		datum.Deduplicator = RandomSelectorDeduplicator()
+	case SelectorTypeOrigin:
 		datum.Origin = RandomSelectorOrigin()
 	}
 	return datum
@@ -49,14 +94,20 @@ func CloneSelector(datum *data.Selector) *data.Selector {
 	}
 	clone := data.NewSelector()
 	clone.ID = pointer.CloneString(datum.ID)
+	clone.Time = pointer.CloneTime(datum.Time)
+	clone.Deduplicator = CloneSelectorDeduplicator(datum.Deduplicator)
 	clone.Origin = CloneSelectorOrigin(datum.Origin)
 	return clone
 }
 
 func RandomSelectors() *data.Selectors {
+	return RandomSelectorsWithType(RandomSelectorType())
+}
+
+func RandomSelectorsWithType(selectorType string) *data.Selectors {
 	datum := data.NewSelectors()
 	for index := test.RandomIntFromRange(1, 3); index > 0; index-- {
-		*datum = append(*datum, RandomSelector())
+		*datum = append(*datum, RandomSelectorWithType(selectorType))
 	}
 	return datum
 }

--- a/data/test/datum.go
+++ b/data/test/datum.go
@@ -30,6 +30,7 @@ type Datum struct {
 	NormalizeInvocations                 int
 	NormalizeInputs                      []data.Normalizer
 	IdentityFieldsInvocations            int
+	IdentityFieldsInputs                 []string
 	IdentityFieldsOutputs                []IdentityFieldsOutput
 	GetPayloadInvocations                int
 	GetPayloadOutputs                    []*metadata.Metadata
@@ -110,8 +111,10 @@ func (d *Datum) Normalize(normalizer data.Normalizer) {
 	d.NormalizeInputs = append(d.NormalizeInputs, normalizer)
 }
 
-func (d *Datum) IdentityFields() ([]string, error) {
+func (d *Datum) IdentityFields(version string) ([]string, error) {
 	d.IdentityFieldsInvocations++
+
+	d.IdentityFieldsInputs = append(d.IdentityFieldsInputs, version)
 
 	gomega.Expect(d.IdentityFieldsOutputs).ToNot(gomega.BeEmpty())
 

--- a/data/types/basal/basal.go
+++ b/data/types/basal/basal.go
@@ -50,17 +50,21 @@ func (b *Basal) Validate(validator structure.Validator) {
 	validator.String("deliveryType", &b.DeliveryType).Exists().NotEmpty()
 }
 
-func (b *Basal) IdentityFields() ([]string, error) {
-	identityFields, err := b.Base.IdentityFields()
+func (b *Basal) IdentityFields(version string) ([]string, error) {
+	identityFields, err := b.Base.IdentityFields(version)
 	if err != nil {
 		return nil, err
 	}
 
-	if b.DeliveryType == "" {
-		return nil, errors.New("delivery type is empty")
+	switch version {
+	case types.IdentityFieldsVersionDeviceID, types.IdentityFieldsVersionDataSetID:
+		if b.DeliveryType == "" {
+			return nil, errors.New("delivery type is empty")
+		}
+		return append(identityFields, b.DeliveryType), nil
+	default:
+		return nil, errors.New("version is invalid")
 	}
-
-	return append(identityFields, b.DeliveryType), nil
 }
 
 func ParseDeliveryType(parser structure.ObjectParser) *string {

--- a/data/types/base.go
+++ b/data/types/base.go
@@ -23,6 +23,9 @@ const (
 	TagLengthMaximum   = 100
 	TagsLengthMaximum  = 100
 	TimeFormat         = time.RFC3339Nano
+
+	IdentityFieldsVersionDeviceID  = "device-id"
+	IdentityFieldsVersionDataSetID = "data-set-id"
 )
 
 type Base struct {
@@ -225,30 +228,57 @@ func (b *Base) Normalize(normalizer data.Normalizer) {
 	}
 }
 
-func (b *Base) IdentityFields() ([]string, error) {
-	if b.UserID == nil {
-		return nil, errors.New("user id is missing")
+func (b *Base) IdentityFields(version string) ([]string, error) {
+	switch version {
+	case IdentityFieldsVersionDeviceID:
+		if b.UserID == nil {
+			return nil, errors.New("user id is missing")
+		}
+		if *b.UserID == "" {
+			return nil, errors.New("user id is empty")
+		}
+		if b.DeviceID == nil {
+			return nil, errors.New("device id is missing")
+		}
+		if *b.DeviceID == "" {
+			return nil, errors.New("device id is empty")
+		}
+		if b.Time == nil {
+			return nil, errors.New("time is missing")
+		}
+		if (*b.Time).IsZero() {
+			return nil, errors.New("time is empty")
+		}
+		if b.Type == "" {
+			return nil, errors.New("type is empty")
+		}
+		return []string{*b.UserID, *b.DeviceID, (*b.Time).Format(TimeFormat), b.Type}, nil
+	case IdentityFieldsVersionDataSetID:
+		if b.UserID == nil {
+			return nil, errors.New("user id is missing")
+		}
+		if *b.UserID == "" {
+			return nil, errors.New("user id is empty")
+		}
+		if b.UploadID == nil {
+			return nil, errors.New("data set id is missing")
+		}
+		if *b.UploadID == "" {
+			return nil, errors.New("data set id is empty")
+		}
+		if b.Time == nil {
+			return nil, errors.New("time is missing")
+		}
+		if (*b.Time).IsZero() {
+			return nil, errors.New("time is empty")
+		}
+		if b.Type == "" {
+			return nil, errors.New("type is empty")
+		}
+		return []string{*b.UserID, *b.UploadID, (*b.Time).Format(TimeFormat), b.Type}, nil
+	default:
+		return nil, errors.New("version is invalid")
 	}
-	if *b.UserID == "" {
-		return nil, errors.New("user id is empty")
-	}
-	if b.DeviceID == nil {
-		return nil, errors.New("device id is missing")
-	}
-	if *b.DeviceID == "" {
-		return nil, errors.New("device id is empty")
-	}
-	if b.Time == nil {
-		return nil, errors.New("time is missing")
-	}
-	if (*b.Time).IsZero() {
-		return nil, errors.New("time is empty")
-	}
-	if b.Type == "" {
-		return nil, errors.New("type is empty")
-	}
-
-	return []string{*b.UserID, *b.DeviceID, (*b.Time).Format(TimeFormat), b.Type}, nil
 }
 
 func (b *Base) GetOrigin() *origin.Origin {

--- a/data/types/base_test.go
+++ b/data/types/base_test.go
@@ -918,59 +918,126 @@ var _ = Describe("Base", func() {
 		})
 
 		Context("IdentityFields", func() {
-			It("returns error if user id is missing", func() {
-				datumBase.UserID = nil
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("user id is missing"))
-				Expect(identityFields).To(BeEmpty())
+			When("version is IdentityFieldsVersionDefault", func() {
+				It("returns error if user id is missing", func() {
+					datumBase.UserID = nil
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("user id is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if user id is empty", func() {
+					datumBase.UserID = pointer.FromString("")
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("user id is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if device id is missing", func() {
+					datumBase.DeviceID = nil
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("device id is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if device id is empty", func() {
+					datumBase.DeviceID = pointer.FromString("")
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("device id is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if time is missing", func() {
+					datumBase.Time = nil
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("time is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if time is empty", func() {
+					datumBase.Time = pointer.FromTime(time.Time{})
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("time is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if type is empty", func() {
+					datumBase.Type = ""
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).To(MatchError("type is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns the expected identity fields", func() {
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDeviceID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(identityFields).To(Equal([]string{*datumBase.UserID, *datumBase.DeviceID, (*datumBase.Time).Format(ExpectedTimeFormat), datumBase.Type}))
+				})
 			})
 
-			It("returns error if user id is empty", func() {
-				datumBase.UserID = pointer.FromString("")
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("user id is empty"))
-				Expect(identityFields).To(BeEmpty())
+			When("version is IdentityFieldsVersionDataSetID", func() {
+				It("returns error if user id is missing", func() {
+					datumBase.UserID = nil
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("user id is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if user id is empty", func() {
+					datumBase.UserID = pointer.FromString("")
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("user id is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if data set id is missing", func() {
+					datumBase.UploadID = nil
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("data set id is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if data set id is empty", func() {
+					datumBase.UploadID = pointer.FromString("")
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("data set id is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if time is missing", func() {
+					datumBase.Time = nil
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("time is missing"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if time is empty", func() {
+					datumBase.Time = pointer.FromTime(time.Time{})
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("time is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns error if type is empty", func() {
+					datumBase.Type = ""
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).To(MatchError("type is empty"))
+					Expect(identityFields).To(BeEmpty())
+				})
+
+				It("returns the expected identity fields", func() {
+					identityFields, err := datum.IdentityFields(types.IdentityFieldsVersionDataSetID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(identityFields).To(Equal([]string{*datumBase.UserID, *datumBase.UploadID, (*datumBase.Time).Format(ExpectedTimeFormat), datumBase.Type}))
+				})
 			})
 
-			It("returns error if device id is missing", func() {
-				datumBase.DeviceID = nil
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("device id is missing"))
-				Expect(identityFields).To(BeEmpty())
-			})
-
-			It("returns error if device id is empty", func() {
-				datumBase.DeviceID = pointer.FromString("")
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("device id is empty"))
-				Expect(identityFields).To(BeEmpty())
-			})
-
-			It("returns error if time is missing", func() {
-				datumBase.Time = nil
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("time is missing"))
-				Expect(identityFields).To(BeEmpty())
-			})
-
-			It("returns error if time is empty", func() {
-				datumBase.Time = pointer.FromTime(time.Time{})
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("time is empty"))
-				Expect(identityFields).To(BeEmpty())
-			})
-
-			It("returns error if type is empty", func() {
-				datumBase.Type = ""
-				identityFields, err := datum.IdentityFields()
-				Expect(err).To(MatchError("type is empty"))
-				Expect(identityFields).To(BeEmpty())
-			})
-
-			It("returns the expected identity fields", func() {
-				identityFields, err := datum.IdentityFields()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(identityFields).To(Equal([]string{*datumBase.UserID, *datumBase.DeviceID, (*datumBase.Time).Format(ExpectedTimeFormat), datumBase.Type}))
+			When("version is invalid", func() {
+				It("returns an error", func() {
+					identityFields, err := datum.IdentityFields("invalid")
+					Expect(err).To(MatchError("version is invalid"))
+					Expect(identityFields).To(BeEmpty())
+				})
 			})
 		})
 

--- a/data/types/blood/blood.go
+++ b/data/types/blood/blood.go
@@ -28,18 +28,22 @@ func (b *Blood) Parse(parser structure.ObjectParser) {
 	b.Value = parser.Float64("value")
 }
 
-func (b *Blood) IdentityFields() ([]string, error) {
-	identityFields, err := b.Base.IdentityFields()
+func (b *Blood) IdentityFields(version string) ([]string, error) {
+	identityFields, err := b.Base.IdentityFields(version)
 	if err != nil {
 		return nil, err
 	}
 
-	if b.Units == nil {
-		return nil, errors.New("units is missing")
+	switch version {
+	case types.IdentityFieldsVersionDeviceID, types.IdentityFieldsVersionDataSetID:
+		if b.Units == nil {
+			return nil, errors.New("units is missing")
+		}
+		if b.Value == nil {
+			return nil, errors.New("value is missing")
+		}
+		return append(identityFields, *b.Units, strconv.FormatFloat(*b.Value, 'f', -1, 64)), nil
+	default:
+		return nil, errors.New("version is invalid")
 	}
-	if b.Value == nil {
-		return nil, errors.New("value is missing")
-	}
-
-	return append(identityFields, *b.Units, strconv.FormatFloat(*b.Value, 'f', -1, 64)), nil
 }

--- a/data/types/bolus/bolus.go
+++ b/data/types/bolus/bolus.go
@@ -88,15 +88,19 @@ func (b *Bolus) Normalize(normalizer data.Normalizer) {
 	}
 }
 
-func (b *Bolus) IdentityFields() ([]string, error) {
-	identityFields, err := b.Base.IdentityFields()
+func (b *Bolus) IdentityFields(version string) ([]string, error) {
+	identityFields, err := b.Base.IdentityFields(version)
 	if err != nil {
 		return nil, err
 	}
 
-	if b.SubType == "" {
-		return nil, errors.New("sub type is empty")
+	switch version {
+	case types.IdentityFieldsVersionDeviceID, types.IdentityFieldsVersionDataSetID:
+		if b.SubType == "" {
+			return nil, errors.New("sub type is empty")
+		}
+		return append(identityFields, b.SubType), nil
+	default:
+		return nil, errors.New("version is invalid")
 	}
-
-	return append(identityFields, b.SubType), nil
 }

--- a/data/types/device/device.go
+++ b/data/types/device/device.go
@@ -45,15 +45,19 @@ func (d *Device) Validate(validator structure.Validator) {
 	validator.String("subType", &d.SubType).Exists().NotEmpty()
 }
 
-func (d *Device) IdentityFields() ([]string, error) {
-	identityFields, err := d.Base.IdentityFields()
+func (d *Device) IdentityFields(version string) ([]string, error) {
+	identityFields, err := d.Base.IdentityFields(version)
 	if err != nil {
 		return nil, err
 	}
 
-	if d.SubType == "" {
-		return nil, errors.New("sub type is empty")
+	switch version {
+	case types.IdentityFieldsVersionDeviceID, types.IdentityFieldsVersionDataSetID:
+		if d.SubType == "" {
+			return nil, errors.New("sub type is empty")
+		}
+		return append(identityFields, d.SubType), nil
+	default:
+		return nil, errors.New("version is invalid")
 	}
-
-	return append(identityFields, d.SubType), nil
 }


### PR DESCRIPTION
- Add DataSetDropHash deduplicator
- Refactor deduplicators to remove duplicate code
- Add data selector using deduplicator hash
- Update data selector to match and detect newer separately
- Allow different versions of datum IdentityFields
- Make setting data set and data active common in deduplicator
- Add deduplicator hash maximum length
- Rename NewerDataSetData to ExistingDataSetData
- https://tidepool.atlassian.net/browse/BACK-3603