### PR TITLE
[BACK-3921] Temporarily restore twiist use of TidepoolLinkId

### DIFF
--- a/twiist/provider/provider.go
+++ b/twiist/provider/provider.go
@@ -274,7 +274,7 @@ func (p *Provider) extractExternalIDsFromProviderSession(providerSession *auth.P
 	} else if claims.TidepoolLinkID == "" {
 		return "", "", errors.New("tidepool link id is missing from claims from id token")
 	} else {
-		return claims.TidepoolLinkID, claims.Subject, nil
+		return claims.TidepoolLinkID, claims.TidepoolLinkID, nil
 	}
 }
 


### PR DESCRIPTION
- Temporarily restore twiist use of TidepoolLinkId
- https://tidepool.atlassian.net/browse/BACK-3921