### PR TITLE
Add Oura webhook subscriptions

### DIFF
--- a/auth/provider_session.go
+++ b/auth/provider_session.go
@@ -36,10 +36,10 @@ type ProviderSessionClient interface {
 }
 
 type ProviderSessionFilter struct {
-	UserID     *string `json:"userId,omitempty"`
-	Type       *string `json:"type,omitempty"`
-	Name       *string `json:"name,omitempty"`
-	ExternalID *string `json:"externalId,omitempty"`
+	UserID     *string `json:"userId,omitempty" bson:"userId,omitempty"`
+	Type       *string `json:"type,omitempty" bson:"type,omitempty"`
+	Name       *string `json:"name,omitempty" bson:"name,omitempty"`
+	ExternalID *string `json:"externalId,omitempty" bson:"externalId,omitempty"`
 }
 
 func NewProviderSessionFilter() *ProviderSessionFilter {

--- a/auth/service/service/service.go
+++ b/auth/service/service/service.go
@@ -898,17 +898,6 @@ func (s *Service) initializeWorkCoordinator() error {
 	}
 	s.workCoordinator = coordinator
 
-	s.Logger().Info("Ensuring reconciler work item exists")
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	ctx = log.NewContextWithLogger(ctx, s.Logger())
-	err = jotformWork.EnsureReconcilerWorkItemExists(ctx, s.workClient)
-	if err != nil {
-		return errors.Wrap(err, "unable to ensure reconciler work item exists")
-	}
-
 	var factories []work.ProcessorFactory
 
 	dependencies := workBase.Dependencies{
@@ -935,6 +924,17 @@ func (s *Service) initializeWorkCoordinator() error {
 
 	if err := s.workCoordinator.RegisterProcessorFactories(factories); err != nil {
 		return errors.Wrapf(err, "unable to register work processor factories")
+	}
+
+	s.Logger().Info("Ensuring reconciler work item exists")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	ctx = log.NewContextWithLogger(ctx, s.Logger())
+	err = jotformWork.EnsureReconcilerWorkItemExists(ctx, s.workClient)
+	if err != nil {
+		return errors.Wrap(err, "unable to ensure reconciler work item exists")
 	}
 
 	s.Logger().Info("Starting work coordinator")

--- a/data/raw/raw.go
+++ b/data/raw/raw.go
@@ -22,11 +22,11 @@ const (
 )
 
 type Filter struct {
-	CreatedDate *string `json:"createdDate,omitempty"`
-	DataSetID   *string `json:"dataSetId,omitempty"`
-	Processed   *bool   `json:"processed,omitempty"`
-	Archivable  *bool   `json:"archivable,omitempty"`
-	Archived    *bool   `json:"archived,omitempty"`
+	CreatedDate *string `json:"createdDate,omitempty" bson:"createdDate,omitempty"`
+	DataSetID   *string `json:"dataSetId,omitempty" bson:"dataSetId,omitempty"`
+	Processed   *bool   `json:"processed,omitempty" bson:"processed,omitempty"`
+	Archivable  *bool   `json:"archivable,omitempty" bson:"archivable,omitempty"`
+	Archived    *bool   `json:"archived,omitempty" bson:"archived,omitempty"`
 }
 
 func (f *Filter) Parse(parser structure.ObjectParser) {
@@ -54,10 +54,10 @@ func (f *Filter) CreatedTime() *time.Time {
 }
 
 type Create struct {
-	Metadata       map[string]any `json:"metadata,omitempty"`
-	DigestMD5      *string        `json:"digestMD5,omitempty"`
-	MediaType      *string        `json:"mediaType,omitempty"`
-	ArchivableTime *time.Time     `json:"archivableTime,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty" bson:"metadata,omitempty"`
+	DigestMD5      *string        `json:"digestMD5,omitempty" bson:"digestMD5,omitempty"`
+	MediaType      *string        `json:"mediaType,omitempty" bson:"mediaType,omitempty"`
+	ArchivableTime *time.Time     `json:"archivableTime,omitempty" bson:"archivableTime,omitempty"`
 }
 
 func (c *Create) Parse(parser structure.ObjectParser) {
@@ -77,9 +77,9 @@ func (c *Create) Validate(validator structure.Validator) {
 }
 
 type Content struct {
-	DigestMD5  string        `json:"digestMD5"`
-	MediaType  string        `json:"mediaType"`
-	ReadCloser io.ReadCloser `json:"-"`
+	DigestMD5  string        `json:"digestMD5" bson:"digestMD5"`
+	MediaType  string        `json:"mediaType" bson:"mediaType"`
+	ReadCloser io.ReadCloser `json:"-" bson:"-"`
 }
 
 func (c *Content) Validate(validator structure.Validator) {
@@ -91,10 +91,10 @@ func (c *Content) Validate(validator structure.Validator) {
 }
 
 type Update struct {
-	ProcessedTime  *time.Time      `json:"processedTime,omitempty"`
-	ArchivableTime *time.Time      `json:"archivableTime,omitempty"`
-	ArchivedTime   *time.Time      `json:"archivedTime,omitempty"`
-	Metadata       *map[string]any `json:"metadata,omitempty"`
+	ProcessedTime  *time.Time      `json:"processedTime,omitempty" bson:"processedTime,omitempty"`
+	ArchivableTime *time.Time      `json:"archivableTime,omitempty" bson:"archivableTime,omitempty"`
+	ArchivedTime   *time.Time      `json:"archivedTime,omitempty" bson:"archivedTime,omitempty"`
+	Metadata       *map[string]any `json:"metadata,omitempty" bson:"metadata,omitempty"`
 }
 
 func (u *Update) Parse(parser structure.ObjectParser) {
@@ -116,19 +116,19 @@ func (u *Update) Validate(validator structure.Validator) {
 }
 
 type Raw struct {
-	ID             string         `json:"id"`
-	UserID         string         `json:"userId"`
-	DataSetID      string         `json:"dataSetId"`
-	Metadata       map[string]any `json:"metadata,omitempty"`
-	DigestMD5      string         `json:"digestMD5"`
-	MediaType      string         `json:"mediaType"`
-	Size           int            `json:"size"`
-	ProcessedTime  *time.Time     `json:"processedTime,omitempty"`
-	ArchivableTime *time.Time     `json:"archivableTime,omitempty"`
-	ArchivedTime   *time.Time     `json:"archivedTime,omitempty"`
-	CreatedTime    time.Time      `json:"createdTime"`
-	ModifiedTime   *time.Time     `json:"modifiedTime,omitempty"`
-	Revision       int            `json:"revision"`
+	ID             string         `json:"id" bson:"id"`
+	UserID         string         `json:"userId" bson:"userId"`
+	DataSetID      string         `json:"dataSetId" bson:"dataSetId"`
+	Metadata       map[string]any `json:"metadata,omitempty" bson:"metadata,omitempty"`
+	DigestMD5      string         `json:"digestMD5" bson:"digestMD5"`
+	MediaType      string         `json:"mediaType" bson:"mediaType"`
+	Size           int            `json:"size" bson:"size"`
+	ProcessedTime  *time.Time     `json:"processedTime,omitempty" bson:"processedTime,omitempty"`
+	ArchivableTime *time.Time     `json:"archivableTime,omitempty" bson:"archivableTime,omitempty"`
+	ArchivedTime   *time.Time     `json:"archivedTime,omitempty" bson:"archivedTime,omitempty"`
+	CreatedTime    time.Time      `json:"createdTime" bson:"createdTime"`
+	ModifiedTime   *time.Time     `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	Revision       int            `json:"revision" bson:"revision"`
 }
 
 func (r *Raw) Parse(parser structure.ObjectParser) {

--- a/data/raw/raw_test.go
+++ b/data/raw/raw_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Raw", func() {
 				datum := dataRawTest.RandomFilter(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataRawTest.NewObjectFromFilter(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataRawTest.NewObjectFromFilter(datum, test.ObjectFormatJSON))
 			},
 			Entry("succeeds",
 				func(datum *dataRaw.Filter) {},
@@ -177,6 +178,7 @@ var _ = Describe("Raw", func() {
 				datum := dataRawTest.RandomCreate(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataRawTest.NewObjectFromCreate(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataRawTest.NewObjectFromCreate(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *dataRaw.Create) {},
@@ -301,6 +303,7 @@ var _ = Describe("Raw", func() {
 				datum := dataRawTest.RandomContent(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataRawTest.NewObjectFromContent(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataRawTest.NewObjectFromContent(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *dataRaw.Content) {},
@@ -364,6 +367,7 @@ var _ = Describe("Raw", func() {
 				datum := dataRawTest.RandomUpdate(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataRawTest.NewObjectFromUpdate(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataRawTest.NewObjectFromUpdate(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *dataRaw.Update) {},
@@ -483,6 +487,7 @@ var _ = Describe("Raw", func() {
 				datum := dataRawTest.RandomRaw(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataRawTest.NewObjectFromRaw(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataRawTest.NewObjectFromRaw(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *dataRaw.Raw) {},

--- a/data/service/api/standard.go
+++ b/data/service/api/standard.go
@@ -15,6 +15,7 @@ import (
 	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/metric"
+	"github.com/tidepool-org/platform/oura"
 	"github.com/tidepool-org/platform/permission"
 	"github.com/tidepool-org/platform/service"
 	serviceApi "github.com/tidepool-org/platform/service/api"
@@ -33,6 +34,7 @@ type Standard struct {
 	dataRawClient                  dataRaw.Client
 	dataSourceClient               dataSource.Client
 	workClient                     work.Client
+	ouraClient                     oura.Client
 	abbottServiceRequestAuthorizer abbottService.RequestAuthorizer
 	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer
 }
@@ -40,7 +42,7 @@ type Standard struct {
 func NewStandard(svc service.Service, metricClient metric.Client, permissionClient permission.Client,
 	dataDeduplicatorFactory dataDuplicator.Factory,
 	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client,
-	dataRawClient dataRaw.Client, dataSourceClient dataSource.Client, workClient work.Client,
+	dataRawClient dataRaw.Client, dataSourceClient dataSource.Client, workClient work.Client, ouraClient oura.Client,
 	abbottServiceRequestAuthorizer abbottService.RequestAuthorizer,
 	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer) (*Standard, error) {
 	if metricClient == nil {
@@ -70,6 +72,9 @@ func NewStandard(svc service.Service, metricClient metric.Client, permissionClie
 	if workClient == nil {
 		return nil, errors.New("work client is missing")
 	}
+	if ouraClient == nil {
+		return nil, errors.New("oura client is missing")
+	}
 	if abbottServiceRequestAuthorizer == nil {
 		return nil, errors.New("abbott service request authorizer is missing")
 	}
@@ -93,6 +98,7 @@ func NewStandard(svc service.Service, metricClient metric.Client, permissionClie
 		dataRawClient:                  dataRawClient,
 		dataSourceClient:               dataSourceClient,
 		workClient:                     workClient,
+		ouraClient:                     ouraClient,
 		abbottServiceRequestAuthorizer: abbottServiceRequestAuthorizer,
 		twiistServiceAccountAuthorizer: twiistServiceAccountAuthorizer,
 	}, nil
@@ -125,6 +131,6 @@ func (s *Standard) withContext(handler dataService.HandlerFunc) rest.HandlerFunc
 	return dataServiceContext.WithContext(s.AuthClient(), s.metricClient, s.permissionClient,
 		s.dataDeduplicatorFactory,
 		s.dataStore, s.syncTaskStore, s.dataClient,
-		s.dataRawClient, s.dataSourceClient, s.workClient,
+		s.dataRawClient, s.dataSourceClient, s.workClient, s.ouraClient,
 		s.abbottServiceRequestAuthorizer, s.twiistServiceAccountAuthorizer, handler)
 }

--- a/data/service/api/v1/users_datasets_create_test.go
+++ b/data/service/api/v1/users_datasets_create_test.go
@@ -31,6 +31,7 @@ import (
 	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/metric"
 	metricTest "github.com/tidepool-org/platform/metric/test"
+	"github.com/tidepool-org/platform/oura"
 	"github.com/tidepool-org/platform/permission"
 	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/request"
@@ -229,6 +230,10 @@ func (c *mockDataServiceContext) DataSourceClient() dataSource.Client {
 }
 
 func (c *mockDataServiceContext) WorkClient() work.Client {
+	panic("not implemented")
+}
+
+func (c *mockDataServiceContext) OuraClient() oura.Client {
 	panic("not implemented")
 }
 

--- a/data/service/api/v1/v1.go
+++ b/data/service/api/v1/v1.go
@@ -4,6 +4,7 @@ import (
 	abbottServiceApiV1 "github.com/tidepool-org/platform-plugin-abbott/abbott/service/api/v1"
 
 	"github.com/tidepool-org/platform/data/service"
+	ouraServiceApiV1 "github.com/tidepool-org/platform/oura/service/api/v1"
 	"github.com/tidepool-org/platform/service/api"
 )
 
@@ -34,6 +35,7 @@ func Routes() []service.Route {
 	routes = append(routes, SummaryRoutes()...)
 	routes = append(routes, AlertsRoutes()...)
 	routes = append(routes, abbottServiceApiV1.Routes()...)
+	routes = append(routes, ouraServiceApiV1.Routes()...)
 
 	return routes
 }

--- a/data/service/context.go
+++ b/data/service/context.go
@@ -12,6 +12,7 @@ import (
 	dataSource "github.com/tidepool-org/platform/data/source"
 	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/metric"
+	"github.com/tidepool-org/platform/oura"
 	"github.com/tidepool-org/platform/permission"
 	"github.com/tidepool-org/platform/service"
 	"github.com/tidepool-org/platform/summary"
@@ -41,6 +42,7 @@ type Context interface {
 	ClinicsClient() clinics.Client
 	DataRawClient() dataRaw.Client
 	DataSourceClient() dataSource.Client
+	OuraClient() oura.Client
 	WorkClient() work.Client
 
 	AbbottServiceRequestAuthorizer() abbottService.RequestAuthorizer

--- a/data/service/context/standard.go
+++ b/data/service/context/standard.go
@@ -19,6 +19,7 @@ import (
 	dataStore "github.com/tidepool-org/platform/data/store"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/metric"
+	"github.com/tidepool-org/platform/oura"
 	"github.com/tidepool-org/platform/permission"
 	serviceContext "github.com/tidepool-org/platform/service/context"
 	"github.com/tidepool-org/platform/summary"
@@ -46,6 +47,7 @@ type Standard struct {
 	dataRawClient                  dataRaw.Client
 	dataSourceClient               dataSource.Client
 	workClient                     work.Client
+	ouraClient                     oura.Client
 	alertsRepository               alerts.Repository
 	abbottServiceRequestAuthorizer abbottService.RequestAuthorizer
 	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer
@@ -54,14 +56,14 @@ type Standard struct {
 func WithContext(authClient auth.Client, metricClient metric.Client, permissionClient permission.Client,
 	dataDeduplicatorFactory dataDeduplicator.Factory,
 	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client,
-	dataRawClient dataRaw.Client, dataSourceClient dataSource.Client, workClient work.Client,
+	dataRawClient dataRaw.Client, dataSourceClient dataSource.Client, workClient work.Client, ouraClient oura.Client,
 	abbottServiceRequestAuthorizer abbottService.RequestAuthorizer,
 	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer,
 	handler dataService.HandlerFunc) rest.HandlerFunc {
 	return func(response rest.ResponseWriter, request *rest.Request) {
 		standard, standardErr := NewStandard(response, request, authClient, metricClient, permissionClient,
 			dataDeduplicatorFactory, store, syncTaskStore, dataClient, dataRawClient, dataSourceClient,
-			workClient, abbottServiceRequestAuthorizer, twiistServiceAccountAuthorizer)
+			workClient, ouraClient, abbottServiceRequestAuthorizer, twiistServiceAccountAuthorizer)
 		if standardErr != nil {
 			if responder, responderErr := serviceContext.NewResponder(response, request); responderErr != nil {
 				response.WriteHeader(http.StatusInternalServerError)
@@ -80,7 +82,7 @@ func NewStandard(response rest.ResponseWriter, request *rest.Request,
 	authClient auth.Client, metricClient metric.Client, permissionClient permission.Client,
 	dataDeduplicatorFactory dataDeduplicator.Factory,
 	store dataStore.Store, syncTaskStore syncTaskStore.Store, dataClient dataClient.Client,
-	dataRawClient dataRaw.Client, dataSourceClient dataSource.Client, workClient work.Client,
+	dataRawClient dataRaw.Client, dataSourceClient dataSource.Client, workClient work.Client, ouraClient oura.Client,
 	abbottServiceRequestAuthorizer abbottService.RequestAuthorizer,
 	twiistServiceAccountAuthorizer auth.ServiceAccountAuthorizer) (*Standard, error) {
 	if authClient == nil {
@@ -113,6 +115,9 @@ func NewStandard(response rest.ResponseWriter, request *rest.Request,
 	if workClient == nil {
 		return nil, errors.New("work client is missing")
 	}
+	if ouraClient == nil {
+		return nil, errors.New("oura client is missing")
+	}
 	if abbottServiceRequestAuthorizer == nil {
 		return nil, errors.New("abbott service request authorizer is missing")
 	}
@@ -137,6 +142,7 @@ func NewStandard(response rest.ResponseWriter, request *rest.Request,
 		dataRawClient:                  dataRawClient,
 		dataSourceClient:               dataSourceClient,
 		workClient:                     workClient,
+		ouraClient:                     ouraClient,
 		abbottServiceRequestAuthorizer: abbottServiceRequestAuthorizer,
 		twiistServiceAccountAuthorizer: twiistServiceAccountAuthorizer,
 	}, nil
@@ -146,6 +152,7 @@ func (s *Standard) Close() {
 	s.twiistServiceAccountAuthorizer = nil
 	s.abbottServiceRequestAuthorizer = nil
 	s.alertsRepository = nil
+	s.ouraClient = nil
 	s.workClient = nil
 	s.dataSourceClient = nil
 	s.dataRawClient = nil
@@ -249,6 +256,10 @@ func (s *Standard) DataSourceClient() dataSource.Client {
 
 func (s *Standard) WorkClient() work.Client {
 	return s.workClient
+}
+
+func (s *Standard) OuraClient() oura.Client {
+	return s.ouraClient
 }
 
 func (s *Standard) AbbottServiceRequestAuthorizer() abbottService.RequestAuthorizer {

--- a/data/service/service/standard.go
+++ b/data/service/service/standard.go
@@ -686,7 +686,8 @@ func (s *Standard) initializeWorkCoordinator() error {
 
 		s.Logger().Debug("Ensuring oura work")
 
-		if err := ouraWorkProcessors.EnsureWork(ouraDependencies); err != nil {
+		ctx := logInternal.NewContextWithLogger(context.Background(), s.Logger())
+		if err := ouraWorkProcessors.EnsureWork(ctx, ouraDependencies.WorkClient); err != nil {
 			return errors.Wrap(err, "unable to ensure oura work")
 		}
 	}
@@ -733,7 +734,7 @@ func (s *Standard) initializeAPI() error {
 	newAPI, err := api.NewStandard(s, s.metricClient, s.permissionClient,
 		s.dataDeduplicatorFactory,
 		s.dataStore, s.syncTaskStore, s.dataClient,
-		s.dataRawClient, s.dataSourceClient, s.workClient,
+		s.dataRawClient, s.dataSourceClient, s.workClient, s.ouraClient,
 		s.abbottClient, s.twiistServiceAccountAuthorizer)
 	if err != nil {
 		return errors.Wrap(err, "unable to create api")

--- a/data/source/source.go
+++ b/data/source/source.go
@@ -48,9 +48,9 @@ type Client interface {
 }
 
 type Filter struct {
-	ProviderType       *string `json:"providerType,omitempty"`
-	ProviderName       *string `json:"providerName,omitempty"`
-	ProviderExternalID *string `json:"providerExternalId,omitempty"`
+	ProviderType       *string `json:"providerType,omitempty" bson:"providerType,omitempty"`
+	ProviderName       *string `json:"providerName,omitempty" bson:"providerName,omitempty"`
+	ProviderExternalID *string `json:"providerExternalId,omitempty" bson:"providerExternalId,omitempty"`
 }
 
 func NewFilter() *Filter {
@@ -84,10 +84,10 @@ func (f *Filter) MutateRequest(req *http.Request) error {
 }
 
 type Create struct {
-	ProviderType       string         `json:"providerType"`
-	ProviderName       string         `json:"providerName"`
-	ProviderExternalID *string        `json:"providerExternalId,omitempty"`
-	Metadata           map[string]any `json:"metadata,omitempty"`
+	ProviderType       string         `json:"providerType" bson:"providerType"`
+	ProviderName       string         `json:"providerName" bson:"providerName"`
+	ProviderExternalID *string        `json:"providerExternalId,omitempty" bson:"providerExternalId,omitempty"`
+	Metadata           map[string]any `json:"metadata,omitempty" bson:"metadata,omitempty"`
 }
 
 func NewCreate() *Create {
@@ -115,15 +115,15 @@ func (c *Create) Validate(validator structure.Validator) {
 }
 
 type Update struct {
-	ProviderSessionID  *string              `json:"providerSessionId,omitempty"`
-	ProviderExternalID *string              `json:"providerExternalId,omitempty"`
-	State              *string              `json:"state,omitempty"`
-	Metadata           *map[string]any      `json:"metadata,omitempty"`
-	Error              *errors.Serializable `json:"error,omitempty"`
-	DataSetID          *string              `json:"dataSetId,omitempty"`
-	EarliestDataTime   *time.Time           `json:"earliestDataTime,omitempty"`
-	LatestDataTime     *time.Time           `json:"latestDataTime,omitempty"`
-	LastImportTime     *time.Time           `json:"lastImportTime,omitempty"`
+	ProviderSessionID  *string              `json:"providerSessionId,omitempty" bson:"providerSessionId,omitempty"`
+	ProviderExternalID *string              `json:"providerExternalId,omitempty" bson:"providerExternalId,omitempty"`
+	State              *string              `json:"state,omitempty" bson:"state,omitempty"`
+	Metadata           *map[string]any      `json:"metadata,omitempty" bson:"metadata,omitempty"`
+	Error              *errors.Serializable `json:"error,omitempty" bson:"error,omitempty"`
+	DataSetID          *string              `json:"dataSetId,omitempty" bson:"dataSetId,omitempty"`
+	EarliestDataTime   *time.Time           `json:"earliestDataTime,omitempty" bson:"earliestDataTime,omitempty"`
+	LatestDataTime     *time.Time           `json:"latestDataTime,omitempty" bson:"latestDataTime,omitempty"`
+	LastImportTime     *time.Time           `json:"lastImportTime,omitempty" bson:"lastImportTime,omitempty"`
 }
 
 func NewUpdate() *Update {

--- a/data/source/source_test.go
+++ b/data/source/source_test.go
@@ -56,6 +56,21 @@ var _ = Describe("Source", func() {
 	})
 
 	Context("Filter", func() {
+		DescribeTable("serializes the datum as expected",
+			func(mutator func(datum *dataSource.Filter)) {
+				datum := dataSourceTest.RandomFilter(test.AllowOptional())
+				mutator(datum)
+				test.ExpectSerializedObjectJSON(datum, dataSourceTest.NewObjectFromFilter(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataSourceTest.NewObjectFromFilter(datum, test.ObjectFormatBSON))
+			},
+			Entry("succeeds",
+				func(datum *dataSource.Filter) {},
+			),
+			Entry("empty",
+				func(datum *dataSource.Filter) { *datum = dataSource.Filter{} },
+			),
+		)
+
 		Context("Parse", func() {
 			DescribeTable("parses the datum",
 				func(mutator func(object map[string]any, expectedDatum *dataSource.Filter), expectedErrors ...error) {
@@ -276,6 +291,7 @@ var _ = Describe("Source", func() {
 				datum := dataSourceTest.RandomCreate(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataSourceTest.NewObjectFromCreate(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataSourceTest.NewObjectFromCreate(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *dataSource.Create) {},
@@ -484,6 +500,7 @@ var _ = Describe("Source", func() {
 				datum := dataSourceTest.RandomUpdate(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, dataSourceTest.NewObjectFromUpdate(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, dataSourceTest.NewObjectFromUpdate(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *dataSource.Update) {},

--- a/data/work/mixin.go
+++ b/data/work/mixin.go
@@ -175,6 +175,13 @@ func (d *dataSourceReplacerMixin) ReplaceDataSource(replacementDataSource *dataS
 		return result
 	}
 
+	// Delete any existing data source (do not disconnect first, just delete, the replacement already assumed the provider session)
+	if originalDataSource != nil {
+		if _, err := d.DataSourceClient().Delete(ctx, originalDataSource.ID, nil); err != nil {
+			log.LoggerFromContext(ctx).WithError(err).WithField("dataSourceId", originalDataSource.ID).Warn("unable to delete existing data source")
+		}
+	}
+
 	// Update the replacement data source
 	if replacementDataSourceUpdate != nil {
 		if result := d.UpdateDataSource(replacementDataSourceUpdate); result != nil {
@@ -186,13 +193,6 @@ func (d *dataSourceReplacerMixin) ReplaceDataSource(replacementDataSource *dataS
 	if dataSourceMixinFromWork, ok := d.dataSourceMixin.(dataSourceWork.MixinFromWork); ok && dataSourceMixinFromWork.HasWorkMetadata() {
 		if result := dataSourceMixinFromWork.UpdateWorkMetadataFromDataSource(); result != nil {
 			return result
-		}
-	}
-
-	// Delete any existing data source (do not disconnect first, just delete, the replacement already assumed the provider session)
-	if originalDataSource != nil {
-		if _, err := d.DataSourceClient().Delete(ctx, originalDataSource.ID, nil); err != nil {
-			log.LoggerFromContext(ctx).WithError(err).WithField("dataSourceId", originalDataSource.ID).Warn("unable to delete existing data source")
 		}
 	}
 

--- a/data/work/mixin_test.go
+++ b/data/work/mixin_test.go
@@ -266,7 +266,17 @@ var _ = Describe("mixin", func() {
 					Expect(mixin.ReplaceDataSource(replacementDataSource)).To(workTest.MatchFailedProcessResultError(MatchError("replacement data source is missing")))
 				})
 
-				assertWithWorkMetadata := func(inner func()) {
+				assertWorkMetadata := func() {
+					Context("without work metadata", func() {
+						BeforeEach(func() {
+							mockDataSourceMixin.EXPECT().HasWorkMetadata().Return(false)
+						})
+
+						It("returns successfully", func() {
+							Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
+						})
+					})
+
 					Context("with work metadata", func() {
 						BeforeEach(func() {
 							mockDataSourceMixin.EXPECT().HasWorkMetadata().Return(true)
@@ -283,8 +293,56 @@ var _ = Describe("mixin", func() {
 								mockDataSourceMixin.EXPECT().UpdateWorkMetadataFromDataSource().Return(nil)
 							})
 
+							It("returns successfully", func() {
+								Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
+							})
+						})
+					})
+				}
+
+				assertDataSourceUpdate := func() {
+					Context("with data source update", func() {
+						It("returns result if unable to update replacement data source", func() {
+							expectedResult := workTest.RandomFailedProcessResult()
+							mockDataSourceMixin.EXPECT().UpdateDataSource(replacementDataSourceUpdate).Return(expectedResult)
+							Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
+						})
+
+						Context("replacement data source updated successfully", func() {
+							BeforeEach(func() {
+								mockDataSourceMixin.EXPECT().UpdateDataSource(replacementDataSourceUpdate).Return(nil)
+							})
+
+							assertWorkMetadata()
+						})
+					})
+				}
+
+				assertDataSourceSet := func(inner func()) {
+					Context("with replacement data source", func() {
+						It("returns result if unable to set replacement data source", func() {
+							expectedResult := workTest.RandomFailedProcessResult()
+							mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(expectedResult)
+							Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
+						})
+
+						Context("replacement data source set successfully", func() {
+							BeforeEach(func() {
+								mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(nil)
+							})
+
 							inner()
 						})
+					})
+				}
+
+				assertWithoutOriginalDataSource := func(inner func()) {
+					Context("without original data source", func() {
+						BeforeEach(func() {
+							mockDataSourceMixin.EXPECT().DataSource().Return(nil)
+						})
+
+						assertDataSourceSet(inner)
 					})
 				}
 
@@ -301,46 +359,28 @@ var _ = Describe("mixin", func() {
 							}
 						})
 
-						It("returns result if unable to set replacement data source", func() {
-							expectedResult := workTest.RandomFailedProcessResult()
-							mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(expectedResult)
-							Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
-						})
+						assertDataSourceSet(func() {
+							Context("original data source delete returns error", func() {
+								var testErr error
 
-						Context("replacement data source set successfully", func() {
-							BeforeEach(func() {
-								mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(nil)
-							})
-
-							It("returns result if unable to update replacement data source", func() {
-								expectedResult := workTest.RandomFailedProcessResult()
-								mockDataSourceMixin.EXPECT().UpdateDataSource(replacementDataSourceUpdate).Return(expectedResult)
-								Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
-							})
-
-							Context("replacement data source updated successfully", func() {
 								BeforeEach(func() {
-									mockDataSourceMixin.EXPECT().UpdateDataSource(replacementDataSourceUpdate).Return(nil)
+									testErr = errorsTest.RandomError()
+									mockDataSourceClient.EXPECT().Delete(gomock.Any(), originalDataSource.ID, nil).Return(false, testErr)
 								})
 
-								assertWithWorkMetadata(func() {
-									It("logs warning if original data source cannot be deleted", func() {
-										testErr := errorsTest.RandomError()
-										mockDataSourceClient.EXPECT().Delete(gomock.Any(), originalDataSource.ID, nil).Return(false, testErr)
-										Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
-										mockLogger.AssertWarn("unable to delete existing data source", log.Fields{"dataSourceId": originalDataSource.ID, "error": errors.NewSerializable(testErr)})
-									})
-
-									Context("original data source deleted successfully", func() {
-										BeforeEach(func() {
-											mockDataSourceClient.EXPECT().Delete(gomock.Any(), originalDataSource.ID, nil).Return(true, nil)
-										})
-
-										It("returns successfully", func() {
-											Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
-										})
-									})
+								AfterEach(func() {
+									mockLogger.AssertWarn("unable to delete existing data source", log.Fields{"dataSourceId": originalDataSource.ID, "error": errors.NewSerializable(testErr)})
 								})
+
+								assertDataSourceUpdate()
+							})
+
+							Context("original data source deleted successfully", func() {
+								BeforeEach(func() {
+									mockDataSourceClient.EXPECT().Delete(gomock.Any(), originalDataSource.ID, nil).Return(true, nil)
+								})
+
+								assertDataSourceUpdate()
 							})
 						})
 					})
@@ -381,30 +421,7 @@ var _ = Describe("mixin", func() {
 									mockDataSourceClient.EXPECT().Get(gomock.Any(), replacementDataSource.ID).Return(replacementDataSource, nil)
 								})
 
-								Context("without original data source", func() {
-									BeforeEach(func() {
-										mockDataSourceMixin.EXPECT().DataSource().Return(nil)
-									})
-
-									It("returns result if unable to set replacement data source", func() {
-										expectedResult := workTest.RandomFailedProcessResult()
-										mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(expectedResult)
-										Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
-									})
-
-									Context("replacement data source set successfully", func() {
-										BeforeEach(func() {
-											mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(nil)
-										})
-
-										assertWithWorkMetadata(func() {
-											It("returns successfully", func() {
-												Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
-											})
-										})
-									})
-								})
-
+								assertWithoutOriginalDataSource(assertWorkMetadata)
 								assertWithOriginalDataSource()
 							})
 						})
@@ -422,42 +439,7 @@ var _ = Describe("mixin", func() {
 							mockLogger.AssertWarn("replacement data source not disconnected and without provider session id", log.Fields{"replacementDataSourceId": replacementDataSource.ID})
 						})
 
-						Context("without original data source", func() {
-							BeforeEach(func() {
-								mockDataSourceMixin.EXPECT().DataSource().Return(nil)
-							})
-
-							It("returns result if unable to set replacement data source", func() {
-								expectedResult := workTest.RandomFailedProcessResult()
-								mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(expectedResult)
-								Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
-							})
-
-							Context("replacement data source set successfully", func() {
-								BeforeEach(func() {
-									mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(nil)
-								})
-
-								It("returns result if unable to update replacement data source", func() {
-									expectedResult := workTest.RandomFailedProcessResult()
-									mockDataSourceMixin.EXPECT().UpdateDataSource(replacementDataSourceUpdate).Return(expectedResult)
-									Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
-								})
-
-								Context("replacement data source updated successfully", func() {
-									BeforeEach(func() {
-										mockDataSourceMixin.EXPECT().UpdateDataSource(replacementDataSourceUpdate).Return(nil)
-									})
-
-									assertWithWorkMetadata(func() {
-										It("returns successfully", func() {
-											Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
-										})
-									})
-								})
-							})
-						})
-
+						assertWithoutOriginalDataSource(assertDataSourceUpdate)
 						assertWithOriginalDataSource()
 					})
 				})
@@ -468,30 +450,7 @@ var _ = Describe("mixin", func() {
 						replacementDataSource.ProviderSessionID = nil
 					})
 
-					Context("without original data source", func() {
-						BeforeEach(func() {
-							mockDataSourceMixin.EXPECT().DataSource().Return(nil)
-						})
-
-						It("returns result if unable to set replacement data source", func() {
-							expectedResult := workTest.RandomFailedProcessResult()
-							mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(expectedResult)
-							Expect(mixin.ReplaceDataSource(replacementDataSource)).To(Equal(expectedResult))
-						})
-
-						Context("replacement data source set successfully", func() {
-							BeforeEach(func() {
-								mockDataSourceMixin.EXPECT().SetDataSource(replacementDataSource).Return(nil)
-							})
-
-							assertWithWorkMetadata(func() {
-								It("returns successfully", func() {
-									Expect(mixin.ReplaceDataSource(replacementDataSource)).To(BeNil())
-								})
-							})
-						})
-					})
-
+					assertWithoutOriginalDataSource(assertWorkMetadata)
 					assertWithOriginalDataSource()
 				})
 			})

--- a/oura/client/client.go
+++ b/oura/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/tidepool-org/platform/auth"
@@ -14,27 +13,23 @@ import (
 	oauthClient "github.com/tidepool-org/platform/oauth/client"
 	"github.com/tidepool-org/platform/oura"
 	"github.com/tidepool-org/platform/request"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/times"
 )
 
 type Provider interface {
 	oauth.TokenSourceSource
-
-	ClientID() string
-	ClientSecret() string
-
-	PartnerURL() *url.URL
-	PartnerSecret() string
+	oura.BaseClient
 }
 
 type Client struct {
-	client   *oauthClient.Client
-	provider Provider
+	client *oauthClient.Client
+	Provider
 }
 
 func NewWithClient(client *oauthClient.Client, provider Provider) (*Client, error) {
 	if client == nil {
-		return nil, errors.New("oauth client is missing")
+		return nil, errors.New("client is missing")
 	}
 	if provider == nil {
 		return nil, errors.New("provider is missing")
@@ -42,47 +37,117 @@ func NewWithClient(client *oauthClient.Client, provider Provider) (*Client, erro
 
 	return &Client{
 		client:   client,
-		provider: provider,
+		Provider: provider,
 	}, nil
 }
 
-func (c *Client) GetPersonalInfo(ctx context.Context, tokenSource oauth.TokenSource) (*oura.PersonalInfo, error) {
-	url := c.client.ConstructURL("v2", "usercollection", "personal_info")
-	responseBody := &oura.PersonalInfo{}
-
-	if err := c.sendOuraRequest(ctx, http.MethodGet, url, nil, responseBody, tokenSource); err != nil {
-		return nil, errors.Wrap(err, "unable to get user personal info")
+func (c *Client) ListSubscriptions(ctx context.Context) (oura.Subscriptions, error) {
+	// Possible response status codes (see below for details): 200 ([]Subscription)
+	url := c.client.ConstructURL("v2", "webhook", "subscription")
+	subscriptions := oura.Subscriptions{}
+	if err := c.sendClientRequest(ctx, http.MethodGet, url, nil, &subscriptions); err != nil {
+		return nil, errors.Wrap(err, "unable to list subscriptions")
 	}
 
-	return responseBody, nil
-}
-
-func (c *Client) GetDatum(ctx context.Context, dataType string, dataID string, tokenSource oauth.TokenSource) (*oura.Datum, error) {
-	return nil, nil
-}
-
-func (c *Client) GetData(ctx context.Context, dataType string, timeRange times.TimeRange, tokenSource oauth.TokenSource) (oura.Data, error) {
-	return nil, nil
-}
-
-func (c *Client) ListSubscriptions(ctx context.Context) (oura.Subscriptions, error) {
-	return nil, nil
+	return subscriptions, nil
 }
 
 func (c *Client) CreateSubscription(ctx context.Context, create *oura.CreateSubscription) (*oura.Subscription, error) {
 	if create == nil {
 		return nil, errors.New("create is missing")
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(create); err != nil {
+		return nil, errors.Wrap(err, "create is invalid")
 	}
 
-	return nil, nil
+	// Possible response status codes (see below for details): 201 (Subscription), 422
+	url := c.client.ConstructURL("v2", "webhook", "subscription")
+	subscription := &oura.Subscription{}
+	if err := c.sendClientRequest(ctx, http.MethodPost, url, create, subscription); err != nil {
+		return nil, errors.Wrap(err, "unable to create subscription")
+	}
+
+	return subscription, nil
+}
+
+func (c *Client) UpdateSubscription(ctx context.Context, id string, update *oura.UpdateSubscription) (*oura.Subscription, error) {
+	if id == "" {
+		return nil, errors.New("id is missing")
+	}
+	if update == nil {
+		return nil, errors.New("update is missing")
+	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(update); err != nil {
+		return nil, errors.Wrap(err, "update is invalid")
+	}
+
+	// Possible response status codes (see below for details): 200 (Subscription), 403, 422
+	url := c.client.ConstructURL("v2", "webhook", "subscription", id)
+	subscription := &oura.Subscription{}
+	if err := c.sendClientRequest(ctx, http.MethodPut, url, update, subscription); err != nil {
+		if request.StatusCodeForError(err) == http.StatusForbidden {
+			return nil, request.ErrorResourceNotFound() // Map unusual 403 used to indicate 404
+		}
+		return nil, errors.Wrap(err, "unable to update subscription")
+	}
+
+	return subscription, nil
 }
 
 func (c *Client) RenewSubscription(ctx context.Context, id string) (*oura.Subscription, error) {
-	return nil, nil
+	if id == "" {
+		return nil, errors.New("id is missing")
+	}
+
+	// Possible response status codes (see below for details): 200 (Subscription), 403, 422
+	url := c.client.ConstructURL("v2", "webhook", "subscription", "renew", id)
+	subscription := &oura.Subscription{}
+	if err := c.sendClientRequest(ctx, http.MethodPut, url, nil, subscription); err != nil {
+		if request.StatusCodeForError(err) == http.StatusForbidden {
+			return nil, request.ErrorResourceNotFound() // Map unusual 403 used to indicate 404
+		}
+		return nil, errors.Wrap(err, "unable to update subscription")
+	}
+
+	return subscription, nil
 }
 
 func (c *Client) DeleteSubscription(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("id is missing")
+	}
+
+	// Possible response status codes (see below for details): 204, 403, 422
+	url := c.client.ConstructURL("v2", "webhook", "subscription", id)
+	if err := c.sendClientRequest(ctx, http.MethodDelete, url, nil, nil); err != nil {
+		if request.StatusCodeForError(err) == http.StatusForbidden {
+			return request.ErrorResourceNotFound() // Map unusual 403 used to indicate 404
+		}
+		return errors.Wrap(err, "unable to delete subscription")
+	}
+
 	return nil
+}
+
+func (c *Client) GetPersonalInfo(ctx context.Context, tokenSource oauth.TokenSource) (*oura.PersonalInfo, error) {
+	if tokenSource == nil {
+		return nil, errors.New("token source is missing")
+	}
+
+	// Possible response status codes (see below for details): 200 (PersonalInfo), 400, 401, 403, 429
+	url := c.client.ConstructURL("v2", "usercollection", "personal_info")
+	personalInfo := &oura.PersonalInfo{}
+	if err := c.sendOAuthRequest(ctx, http.MethodGet, url, nil, personalInfo, tokenSource); err != nil {
+		return nil, errors.Wrap(err, "unable to get personal info")
+	}
+
+	return personalInfo, nil
+}
+
+func (c *Client) GetData(ctx context.Context, dataType string, timeRange times.TimeRange, tokenSource oauth.TokenSource) (*oura.Data, error) {
+	return nil, nil
+}
+
+func (c *Client) GetDatum(ctx context.Context, dataType string, dataID string, tokenSource oauth.TokenSource) (*oura.Datum, error) {
+	return nil, nil
 }
 
 func (c *Client) RevokeOAuthToken(ctx context.Context, oauthToken *auth.OAuthToken) error {
@@ -92,12 +157,25 @@ func (c *Client) RevokeOAuthToken(ctx context.Context, oauthToken *auth.OAuthTok
 
 	url := c.client.ConstructURL("oauth", "revoke")
 	mutators := []request.RequestMutator{request.NewHeaderMutator("Authorization", fmt.Sprintf("%s %s", oauthToken.TokenType, oauthToken.RefreshToken))}
-
 	if err := c.sendBaseRequest(ctx, http.MethodPost, url, mutators, nil, nil, nil); err != nil {
 		return errors.Wrap(err, "unable to revoke oauth token")
 	}
 
 	return nil
+}
+
+func (c *Client) sendOAuthRequest(ctx context.Context, method string, url string, requestBody any, responseBody any, tokenSource oauth.TokenSource) error {
+	return log.WarnIfDurationExceedsMaximum(ctx, requestDurationMaximum, url, func(ctx context.Context) error {
+		return c.client.SendOAuthRequest(ctx, method, url, nil, requestBody, responseBody, []request.ResponseInspector{prometheusCodePathResponseInspector}, tokenSource)
+	})
+}
+
+func (c *Client) sendClientRequest(ctx context.Context, method string, url string, requestBody any, responseBody any) error {
+	mutators := []request.RequestMutator{
+		request.NewHeaderMutator("x-client-id", c.ClientID()),
+		request.NewHeaderMutator("x-client-secret", c.ClientSecret()),
+	}
+	return c.sendBaseRequest(ctx, method, url, mutators, requestBody, responseBody, nil)
 }
 
 func (c *Client) sendBaseRequest(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody any, responseBody any, inspectors []request.ResponseInspector) error {
@@ -106,15 +184,39 @@ func (c *Client) sendBaseRequest(ctx context.Context, method string, url string,
 	})
 }
 
-func (c *Client) sendOuraRequest(ctx context.Context, method string, url string, requestBody any, responseBody any, tokenSource oauth.TokenSource) error {
-	return log.WarnIfDurationExceedsMaximum(ctx, requestDurationMaximum, url, func(ctx context.Context) error {
-		return c.client.SendOAuthRequest(ctx, method, url, nil, requestBody, responseBody, []request.ResponseInspector{prometheusCodePathResponseInspector}, tokenSource)
-	})
-}
-
 const requestDurationMaximum = 30 * time.Second
 
 var (
-	prometheusCodePathPatterns          = []string{"/oauth/revoke", "/v2/usercollection/personal_info"}
+	prometheusCodePathPatterns = []string{
+		"/v2/usercollection/daily_activity/{document_id}",
+		"/v2/usercollection/daily_cardiovascular_age/{document_id}",
+		"/v2/usercollection/daily_readiness/{document_id}",
+		"/v2/usercollection/daily_resilience/{document_id}",
+		"/v2/usercollection/daily_sleep/{document_id}",
+		"/v2/usercollection/daily_spo2/{document_id}",
+		"/v2/usercollection/daily_stress/{document_id}",
+		"/v2/usercollection/enhanced_tag/{document_id}",
+		"/v2/usercollection/rest_mode_period/{document_id}",
+		"/v2/usercollection/ring_configuration/{document_id}",
+		"/v2/usercollection/session/{document_id}",
+		"/v2/usercollection/sleep/{document_id}",
+		"/v2/usercollection/sleep_time/{document_id}",
+		"/v2/usercollection/vo2_max/{document_id}",
+		"/v2/usercollection/workout/{document_id}",
+		"/v2/webhook/subscription/{id}",
+		"/v2/webhook/subscription/renew/{id}",
+		request.PatternAny,
+	}
 	prometheusCodePathResponseInspector = request.NewPrometheusCodePathResponseInspectorWithPatterns("tidepool_oura_api_client_requests", "Oura API client requests", prometheusCodePathPatterns...)
 )
+
+// Possible response status codes from Oura API:
+// 	200: successful get/list; response body contains the requested resource(s)
+// 	201: successful creation; response body contains the created resource
+// 	204: successful deletion; response body empty
+// 	400: invalid query parameter(s) (only on multiple document request); response body empty
+// 	401: invalid or expired OAuth token; response body empty
+// 	403: missing permissions or user's Oura subscription expired; response body empty
+// 	404: resource id not found (only on single document request); response body empty
+// 	422: request body validation error; response body is custom error (see ouraClient.ErrorParser)
+// 	429: more than 5000 requests in a 5 minute period; response body empty

--- a/oura/client/error_parser.go
+++ b/oura/client/error_parser.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/tidepool-org/platform/client"
+	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/request"
+)
+
+type errorResponseParser struct{}
+
+func NewErrorResponseParser() client.ErrorResponseParser {
+	return &errorResponseParser{}
+}
+
+func (e *errorResponseParser) ParseErrorResponse(ctx context.Context, res *http.Response, req *http.Request) error {
+
+	// Capture full response body for 422 Unprocessable Entity which indicates a request body validation error
+	// Equivalent to our use of 400 Bad Request
+	if res.StatusCode == http.StatusUnprocessableEntity {
+		var errorResponse validationErrorResponse
+		if err := json.NewDecoder(res.Body).Decode(&errorResponse); err == nil {
+			return errors.WithMeta(request.ErrorBadRequest(), errorResponse)
+		}
+	}
+
+	// Let caller handle
+	return nil
+}
+
+type validationErrorResponse struct {
+	Detail []struct {
+		Location []string `json:"loc,omitempty" bson:"loc,omitempty"`
+		Message  string   `json:"msg,omitempty" bson:"msg,omitempty"`
+		Type     string   `json:"type,omitempty" bson:"type,omitempty"`
+	} `json:"detail,omitempty" bson:"detail,omitempty"`
+}

--- a/oura/data/work/event/processor.go
+++ b/oura/data/work/event/processor.go
@@ -26,8 +26,8 @@ type (
 )
 
 type Metadata struct {
-	ProviderSessionMetadata `json:",inline"`
-	EventMetadata           `json:",inline"`
+	ProviderSessionMetadata `json:",inline" bson:",inline"`
+	EventMetadata           `json:",inline" bson:",inline"`
 }
 
 func (m *Metadata) Parse(parser structure.ObjectParser) {

--- a/oura/data/work/event/processor_test.go
+++ b/oura/data/work/event/processor_test.go
@@ -49,6 +49,7 @@ var _ = Describe("processor", func() {
 				datum := ouraDataWorkEventTest.RandomMetadata(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraDataWorkEventTest.NewObjectFromMetadata(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraDataWorkEventTest.NewObjectFromMetadata(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *ouraDataWorkEvent.Metadata) {},

--- a/oura/data/work/historic/processor.go
+++ b/oura/data/work/historic/processor.go
@@ -29,8 +29,8 @@ type (
 )
 
 type Metadata struct {
-	ProviderSessionMetadata `json:",inline"`
-	TimeRangeMetadata       `json:",inline"`
+	ProviderSessionMetadata `json:",inline" bson:",inline"`
+	TimeRangeMetadata       `json:",inline" bson:",inline"`
 }
 
 func (m *Metadata) Parse(parser structure.ObjectParser) {

--- a/oura/data/work/historic/processor_test.go
+++ b/oura/data/work/historic/processor_test.go
@@ -49,6 +49,7 @@ var _ = Describe("processor", func() {
 				datum := ouraDataWorkHistoricTest.RandomMetadata(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraDataWorkHistoricTest.NewObjectFromMetadata(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraDataWorkHistoricTest.NewObjectFromMetadata(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *ouraDataWorkHistoric.Metadata) {},

--- a/oura/data/work/setup/processor_test.go
+++ b/oura/data/work/setup/processor_test.go
@@ -301,6 +301,7 @@ var _ = Describe("processor", func() {
 
 									It("returns failing process result if unable to update replacement data source", func() {
 										testErr := errorsTest.RandomError()
+										mockDataSourceClient.EXPECT().Delete(gomock.Any(), dataSrcID, nil).Return(true, nil)
 										mockDataSourceClient.EXPECT().Update(gomock.Any(), existingDataSrc.ID, nil, expectedDataSrcUpdate).Return(nil, testErr)
 										Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchFailingProcessResultError(MatchError(testErr)))
 									})
@@ -310,8 +311,8 @@ var _ = Describe("processor", func() {
 											updatedDataSrc := dataSourceTest.CloneSource(existingDataSrc)
 											updatedDataSrc.ProviderSessionID = pointer.FromString(providerSessionID)
 											updatedDataSrc.State = dataSource.StateConnected
-											mockDataSourceClient.EXPECT().Update(gomock.Any(), existingDataSrc.ID, nil, expectedDataSrcUpdate).Return(updatedDataSrc, nil)
 											mockDataSourceClient.EXPECT().Delete(gomock.Any(), dataSrcID, nil).Return(true, nil)
+											mockDataSourceClient.EXPECT().Update(gomock.Any(), existingDataSrc.ID, nil, expectedDataSrcUpdate).Return(updatedDataSrc, nil)
 										})
 
 										assertProviderSessionUpdateAndWorkCreate()

--- a/oura/oura.go
+++ b/oura/oura.go
@@ -2,11 +2,14 @@ package oura
 
 import (
 	"context"
+	"slices"
+	"strconv"
 	"time"
 
 	"github.com/tidepool-org/platform/auth"
 	"github.com/tidepool-org/platform/oauth"
 	"github.com/tidepool-org/platform/structure"
+	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/times"
 )
 
@@ -36,6 +39,9 @@ const (
 	PartnerName  = ProviderName
 
 	PartnerPathPrefix = "/v1/partners/" + PartnerName
+
+	SubscriptionArrayLengthMaximum   = 100
+	SubscriptionExpirationTimeFormat = "2006-01-02T15:04:05.999999999" // Assume location UTC
 
 	TimeRangeFormat            = time.RFC3339
 	TimeRangeTruncatedDuration = time.Second
@@ -71,75 +77,146 @@ func EventTypes() []string {
 	}
 }
 
+type BaseClient interface {
+	ClientID() string
+	ClientSecret() string
+
+	PartnerURL() string
+	PartnerSecret() string
+}
+
 //go:generate mockgen -source=oura.go -destination=test/oura_mocks.go -package=test Client
 type Client interface {
+	BaseClient
+
 	ListSubscriptions(ctx context.Context) (Subscriptions, error)
 	CreateSubscription(ctx context.Context, create *CreateSubscription) (*Subscription, error)
+	UpdateSubscription(ctx context.Context, id string, update *UpdateSubscription) (*Subscription, error)
 	RenewSubscription(ctx context.Context, id string) (*Subscription, error)
 	DeleteSubscription(ctx context.Context, id string) error
 
-	RevokeOAuthToken(ctx context.Context, oauthToken *auth.OAuthToken) error
-
 	GetPersonalInfo(ctx context.Context, tokenSource oauth.TokenSource) (*PersonalInfo, error)
 
+	GetData(ctx context.Context, dataType string, timeRange times.TimeRange, tokenSource oauth.TokenSource) (*Data, error)
 	GetDatum(ctx context.Context, dataType string, dataID string, tokenSource oauth.TokenSource) (*Datum, error)
-	GetData(ctx context.Context, dataType string, timeRange times.TimeRange, tokenSource oauth.TokenSource) (Data, error)
+
+	RevokeOAuthToken(ctx context.Context, oauthToken *auth.OAuthToken) error
 }
 
 type CreateSubscription struct {
-	CallbackURL       *string `json:"callback_url,omitempty"`
-	VerificationToken *string `json:"verification_token,omitempty"`
-	EventType         *string `json:"event_type,omitempty"`
-	DataType          *string `json:"data_type,omitempty"`
+	CallbackURL       *string `json:"callback_url,omitempty" bson:"callback_url,omitempty"`
+	VerificationToken *string `json:"verification_token,omitempty" bson:"verification_token,omitempty"`
+	DataType          *string `json:"data_type,omitempty" bson:"data_type,omitempty"`
+	EventType         *string `json:"event_type,omitempty" bson:"event_type,omitempty"`
 }
 
 func (c *CreateSubscription) Parse(parser structure.ObjectParser) {
 	c.CallbackURL = parser.String("callback_url")
 	c.VerificationToken = parser.String("verification_token")
-	c.EventType = parser.String("event_type")
 	c.DataType = parser.String("data_type")
+	c.EventType = parser.String("event_type")
 }
 
 func (c *CreateSubscription) Validate(validator structure.Validator) {
 	validator.String("callback_url", c.CallbackURL).Exists().NotEmpty()
 	validator.String("verification_token", c.VerificationToken).Exists().NotEmpty()
-	validator.String("event_type", c.EventType).Exists().OneOf(EventTypes()...)
-	validator.String("data_type", c.DataType).Exists().OneOf(DataTypes()...)
+	validator.String("data_type", c.DataType).Exists().Using(DataTypeValidator)
+	validator.String("event_type", c.EventType).Exists().Using(EventTypeValidator)
+}
+
+type UpdateSubscription struct {
+	CallbackURL       *string `json:"callback_url,omitempty" bson:"callback_url,omitempty"`
+	VerificationToken *string `json:"verification_token,omitempty" bson:"verification_token,omitempty"`
+	DataType          *string `json:"data_type,omitempty" bson:"data_type,omitempty"`
+	EventType         *string `json:"event_type,omitempty" bson:"event_type,omitempty"`
+}
+
+func (u *UpdateSubscription) Parse(parser structure.ObjectParser) {
+	u.CallbackURL = parser.String("callback_url")
+	u.VerificationToken = parser.String("verification_token")
+	u.DataType = parser.String("data_type")
+	u.EventType = parser.String("event_type")
+}
+
+func (u *UpdateSubscription) Validate(validator structure.Validator) {
+	validator.String("callback_url", u.CallbackURL).Exists().NotEmpty()
+	validator.String("verification_token", u.VerificationToken).Exists().NotEmpty()
+	validator.String("data_type", u.DataType).Exists().Using(DataTypeValidator)
+	validator.String("event_type", u.EventType).Exists().Using(EventTypeValidator)
+}
+
+func ParseSubscription(parser structure.ObjectParser) *Subscription {
+	if !parser.Exists() {
+		return nil
+	}
+	datum := &Subscription{}
+	datum.Parse(parser)
+	return datum
 }
 
 type Subscription struct {
-	ID             *string    `json:"id,omitempty"`
-	CallbackURL    *string    `json:"callback_url,omitempty"`
-	EventType      *string    `json:"event_type,omitempty"`
-	DataType       *string    `json:"data_type,omitempty"`
-	ExpirationTime *time.Time `json:"expiration_time,omitempty"`
+	ID             *string    `json:"id,omitempty" bson:"id,omitempty"`
+	CallbackURL    *string    `json:"callback_url,omitempty" bson:"callback_url,omitempty"`
+	DataType       *string    `json:"data_type,omitempty" bson:"data_type,omitempty"`
+	EventType      *string    `json:"event_type,omitempty" bson:"event_type,omitempty"`
+	ExpirationTime *time.Time `json:"expiration_time,omitempty" bson:"expiration_time,omitempty"`
 }
 
 func (s *Subscription) Parse(parser structure.ObjectParser) {
 	s.ID = parser.String("id")
 	s.CallbackURL = parser.String("callback_url")
-	s.EventType = parser.String("event_type")
 	s.DataType = parser.String("data_type")
-	s.ExpirationTime = parser.Time("expiration_time", time.RFC3339Nano)
+	s.EventType = parser.String("event_type")
+	s.ExpirationTime = parser.Time("expiration_time", SubscriptionExpirationTimeFormat)
 }
 
 func (s *Subscription) Validate(validator structure.Validator) {
-	validator.String("id", s.ID).Exists().NotEmpty()
+	validator.String("id", s.ID).Exists().Using(DataIDValidator)
 	validator.String("callback_url", s.CallbackURL).Exists().NotEmpty()
-	validator.String("event_type", s.EventType).Exists().OneOf(EventTypes()...)
-	validator.String("data_type", s.DataType).Exists().OneOf(DataTypes()...)
+	validator.String("data_type", s.DataType).Exists().Using(DataTypeValidator)
+	validator.String("event_type", s.EventType).Exists().Using(EventTypeValidator)
 	validator.Time("expiration_time", s.ExpirationTime).Exists().NotZero()
 }
 
 type Subscriptions []*Subscription
 
+func (s *Subscriptions) Parse(parser structure.ArrayParser) {
+	for _, reference := range parser.References() {
+		*s = append(*s, ParseSubscription(parser.WithReferenceObjectParser(reference)))
+	}
+}
+
+func (s *Subscriptions) Validate(validator structure.Validator) {
+	if length := len(*s); length > SubscriptionArrayLengthMaximum {
+		validator.ReportError(structureValidator.ErrorLengthNotLessThanOrEqualTo(length, SubscriptionArrayLengthMaximum))
+	}
+	for index, datum := range *s {
+		if datumValidator := validator.WithReference(strconv.Itoa(index)); datum != nil {
+			datum.Validate(datumValidator)
+		} else {
+			datumValidator.ReportError(structureValidator.ErrorValueNotExists())
+		}
+	}
+}
+
+func (s *Subscriptions) Get(dataType string, eventType string) *Subscription {
+	for _, subscription := range *s {
+		if subscription != nil &&
+			subscription.DataType != nil && *subscription.DataType == dataType &&
+			subscription.EventType != nil && *subscription.EventType == eventType {
+			return subscription
+		}
+	}
+	return nil
+}
+
 type PersonalInfo struct {
-	ID            *string  `json:"id,omitempty"`
-	Age           *int     `json:"age,omitempty"`
-	Weight        *float64 `json:"weight,omitempty"`
-	Height        *float64 `json:"height,omitempty"`
-	BiologicalSex *string  `json:"biological_sex,omitempty"`
-	Email         *string  `json:"email,omitempty"`
+	ID            *string  `json:"id,omitempty" bson:"id,omitempty"`
+	Age           *int     `json:"age,omitempty" bson:"age,omitempty"`
+	Weight        *float64 `json:"weight,omitempty" bson:"weight,omitempty"`
+	Height        *float64 `json:"height,omitempty" bson:"height,omitempty"`
+	BiologicalSex *string  `json:"biological_sex,omitempty" bson:"biological_sex,omitempty"`
+	Email         *string  `json:"email,omitempty" bson:"email,omitempty"`
 }
 
 func (p *PersonalInfo) Parse(parser structure.ObjectParser) {
@@ -155,8 +232,57 @@ func (p *PersonalInfo) Validate(validator structure.Validator) {
 	validator.String("id", p.ID).Exists().NotEmpty()
 }
 
+type Data []*Datum
+
 type Datum struct {
 	ID string `json:"id,omitempty"`
 }
 
-type Data []*Datum
+func IsValidDataID(value string) bool {
+	return ValidateDataID(value) == nil
+}
+
+func DataIDValidator(value string, errorReporter structure.ErrorReporter) {
+	errorReporter.ReportError(ValidateDataID(value))
+}
+
+func ValidateDataID(value string) error {
+	if value == "" {
+		return structureValidator.ErrorValueEmpty()
+	}
+	return nil
+}
+
+func IsValidDataType(value string) bool {
+	return ValidateDataType(value) == nil
+}
+
+func DataTypeValidator(value string, errorReporter structure.ErrorReporter) {
+	errorReporter.ReportError(ValidateDataType(value))
+}
+
+func ValidateDataType(value string) error {
+	if value == "" {
+		return structureValidator.ErrorValueEmpty()
+	} else if !slices.Contains(DataTypes(), value) {
+		return structureValidator.ErrorValueStringNotOneOf(value, DataTypes())
+	}
+	return nil
+}
+
+func IsValidEventType(value string) bool {
+	return ValidateEventType(value) == nil
+}
+
+func EventTypeValidator(value string, errorReporter structure.ErrorReporter) {
+	errorReporter.ReportError(ValidateEventType(value))
+}
+
+func ValidateEventType(value string) error {
+	if value == "" {
+		return structureValidator.ErrorValueEmpty()
+	} else if !slices.Contains(EventTypes(), value) {
+		return structureValidator.ErrorValueStringNotOneOf(value, EventTypes())
+	}
+	return nil
+}

--- a/oura/oura_test.go
+++ b/oura/oura_test.go
@@ -12,6 +12,7 @@ import (
 	ouraTest "github.com/tidepool-org/platform/oura/test"
 	"github.com/tidepool-org/platform/pointer"
 	structureParser "github.com/tidepool-org/platform/structure/parser"
+	structureTest "github.com/tidepool-org/platform/structure/test"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/test"
 )
@@ -105,6 +106,14 @@ var _ = Describe("oura", func() {
 		Expect(oura.PartnerPathPrefix).To(Equal("/v1/partners/oura"))
 	})
 
+	It("SubscriptionArrayLengthMaximum is expected", func() {
+		Expect(oura.SubscriptionArrayLengthMaximum).To(Equal(100))
+	})
+
+	It("SubscriptionExpirationTimeFormat is expected", func() {
+		Expect(oura.SubscriptionExpirationTimeFormat).To(Equal("2006-01-02T15:04:05.999999999"))
+	})
+
 	It("TimeRangeFormat is expected", func() {
 		Expect(oura.TimeRangeFormat).To(Equal(time.RFC3339))
 	})
@@ -156,6 +165,7 @@ var _ = Describe("oura", func() {
 				datum := ouraTest.RandomCreateSubscription(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraTest.NewObjectFromCreateSubscription(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraTest.NewObjectFromCreateSubscription(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *oura.CreateSubscription) {},
@@ -195,17 +205,17 @@ var _ = Describe("oura", func() {
 					func(object map[string]any, expectedDatum *oura.CreateSubscription) {
 						object["callback_url"] = true
 						object["verification_token"] = true
-						object["event_type"] = true
 						object["data_type"] = true
+						object["event_type"] = true
 						expectedDatum.CallbackURL = nil
 						expectedDatum.VerificationToken = nil
-						expectedDatum.EventType = nil
 						expectedDatum.DataType = nil
+						expectedDatum.EventType = nil
 					},
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/callback_url"),
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/verification_token"),
-					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/event_type"),
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/data_type"),
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/event_type"),
 				),
 			)
 		})
@@ -254,23 +264,6 @@ var _ = Describe("oura", func() {
 						datum.VerificationToken = pointer.FromString(ouraTest.RandomVerificationToken())
 					},
 				),
-				Entry("event_type",
-					func(datum *oura.CreateSubscription) {
-						datum.EventType = nil
-					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
-				),
-				Entry("event_type invalid",
-					func(datum *oura.CreateSubscription) {
-						datum.EventType = pointer.FromString("invalid")
-					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", oura.EventTypes()), "/event_type"),
-				),
-				Entry("event_type valid",
-					func(datum *oura.CreateSubscription) {
-						datum.EventType = pointer.FromString(ouraTest.RandomEventType())
-					},
-				),
 				Entry("data_type",
 					func(datum *oura.CreateSubscription) {
 						datum.DataType = nil
@@ -288,28 +281,218 @@ var _ = Describe("oura", func() {
 						datum.DataType = pointer.FromString(ouraTest.RandomDataType())
 					},
 				),
+				Entry("event_type",
+					func(datum *oura.CreateSubscription) {
+						datum.EventType = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
+				),
+				Entry("event_type invalid",
+					func(datum *oura.CreateSubscription) {
+						datum.EventType = pointer.FromString("invalid")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", oura.EventTypes()), "/event_type"),
+				),
+				Entry("event_type valid",
+					func(datum *oura.CreateSubscription) {
+						datum.EventType = pointer.FromString(ouraTest.RandomEventType())
+					},
+				),
 				Entry("multiple errors",
 					func(datum *oura.CreateSubscription) {
 						datum.CallbackURL = nil
 						datum.VerificationToken = nil
-						datum.EventType = nil
 						datum.DataType = nil
+						datum.EventType = nil
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/callback_url"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/verification_token"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/data_type"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
+				),
+			)
+		})
+	})
+
+	Context("UpdateSubscription", func() {
+		DescribeTable("serializes the datum as expected",
+			func(mutator func(datum *oura.UpdateSubscription)) {
+				datum := ouraTest.RandomUpdateSubscription(test.AllowOptional())
+				mutator(datum)
+				test.ExpectSerializedObjectJSON(datum, ouraTest.NewObjectFromUpdateSubscription(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraTest.NewObjectFromUpdateSubscription(datum, test.ObjectFormatBSON))
+			},
+			Entry("succeeds",
+				func(datum *oura.UpdateSubscription) {},
+			),
+			Entry("empty",
+				func(datum *oura.UpdateSubscription) {
+					*datum = oura.UpdateSubscription{}
+				},
+			),
+			Entry("all",
+				func(datum *oura.UpdateSubscription) {
+					*datum = *ouraTest.RandomUpdateSubscription()
+				},
+			),
+		)
+
+		Context("Parse", func() {
+			DescribeTable("parses the datum",
+				func(mutator func(object map[string]any, expectedDatum *oura.UpdateSubscription), expectedErrors ...error) {
+					expectedDatum := ouraTest.RandomUpdateSubscription(test.AllowOptional())
+					object := ouraTest.NewObjectFromUpdateSubscription(expectedDatum, test.ObjectFormatJSON)
+					mutator(object, expectedDatum)
+					result := &oura.UpdateSubscription{}
+					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(result), expectedErrors...)
+					Expect(result).To(Equal(expectedDatum))
+				},
+				Entry("succeeds",
+					func(object map[string]any, expectedDatum *oura.UpdateSubscription) {},
+				),
+				Entry("empty",
+					func(object map[string]any, expectedDatum *oura.UpdateSubscription) {
+						clear(object)
+						*expectedDatum = oura.UpdateSubscription{}
+					},
+				),
+				Entry("multiple errors",
+					func(object map[string]any, expectedDatum *oura.UpdateSubscription) {
+						object["callback_url"] = true
+						object["verification_token"] = true
+						object["data_type"] = true
+						object["event_type"] = true
+						expectedDatum.CallbackURL = nil
+						expectedDatum.VerificationToken = nil
+						expectedDatum.DataType = nil
+						expectedDatum.EventType = nil
+					},
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/callback_url"),
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/verification_token"),
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/data_type"),
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/event_type"),
+				),
+			)
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *oura.UpdateSubscription), expectedErrors ...error) {
+					datum := ouraTest.RandomUpdateSubscription(test.AllowOptional())
+					mutator(datum)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *oura.UpdateSubscription) {},
+				),
+				Entry("callback_url",
+					func(datum *oura.UpdateSubscription) {
+						datum.CallbackURL = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/callback_url"),
+				),
+				Entry("callback_url empty",
+					func(datum *oura.UpdateSubscription) {
+						datum.CallbackURL = pointer.FromString("")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/callback_url"),
+				),
+				Entry("callback_url valid",
+					func(datum *oura.UpdateSubscription) {
+						datum.CallbackURL = pointer.FromString(ouraTest.RandomCallbackURL())
+					},
+				),
+				Entry("verification_token",
+					func(datum *oura.UpdateSubscription) {
+						datum.VerificationToken = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/verification_token"),
+				),
+				Entry("verification_token empty",
+					func(datum *oura.UpdateSubscription) {
+						datum.VerificationToken = pointer.FromString("")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueEmpty(), "/verification_token"),
+				),
+				Entry("verification_token valid",
+					func(datum *oura.UpdateSubscription) {
+						datum.VerificationToken = pointer.FromString(ouraTest.RandomVerificationToken())
+					},
+				),
+				Entry("data_type",
+					func(datum *oura.UpdateSubscription) {
+						datum.DataType = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/data_type"),
+				),
+				Entry("data_type invalid",
+					func(datum *oura.UpdateSubscription) {
+						datum.DataType = pointer.FromString("invalid")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", oura.DataTypes()), "/data_type"),
+				),
+				Entry("data_type valid",
+					func(datum *oura.UpdateSubscription) {
+						datum.DataType = pointer.FromString(ouraTest.RandomDataType())
+					},
+				),
+				Entry("event_type",
+					func(datum *oura.UpdateSubscription) {
+						datum.EventType = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
+				),
+				Entry("event_type invalid",
+					func(datum *oura.UpdateSubscription) {
+						datum.EventType = pointer.FromString("invalid")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", oura.EventTypes()), "/event_type"),
+				),
+				Entry("event_type valid",
+					func(datum *oura.UpdateSubscription) {
+						datum.EventType = pointer.FromString(ouraTest.RandomEventType())
+					},
+				),
+				Entry("multiple errors",
+					func(datum *oura.UpdateSubscription) {
+						datum.CallbackURL = nil
+						datum.VerificationToken = nil
+						datum.DataType = nil
+						datum.EventType = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/callback_url"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/verification_token"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/data_type"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
 				),
 			)
 		})
 	})
 
 	Context("Subscription", func() {
+		Context("ParseSubscription", func() {
+			It("returns nil if the object does not exist", func() {
+				Expect(oura.ParseSubscription(structureParser.NewObject(logTest.NewLogger(), nil))).To(BeNil())
+			})
+
+			It("parses the datum", func() {
+				datum := ouraTest.RandomSubscription(test.AllowOptional())
+				object := ouraTest.NewObjectFromSubscription(datum, test.ObjectFormatJSON)
+				if datum.ExpirationTime != nil {
+					object["expiration_time"] = datum.ExpirationTime.Format(oura.SubscriptionExpirationTimeFormat)
+				}
+				parser := structureParser.NewObject(logTest.NewLogger(), &object)
+				Expect(oura.ParseSubscription(parser)).To(Equal(datum))
+				Expect(parser.Error()).ToNot(HaveOccurred())
+			})
+		})
+
 		DescribeTable("serializes the datum as expected",
 			func(mutator func(datum *oura.Subscription)) {
 				datum := ouraTest.RandomSubscription(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraTest.NewObjectFromSubscription(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraTest.NewObjectFromSubscription(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *oura.Subscription) {},
@@ -331,6 +514,9 @@ var _ = Describe("oura", func() {
 				func(mutator func(object map[string]any, expectedDatum *oura.Subscription), expectedErrors ...error) {
 					expectedDatum := ouraTest.RandomSubscription(test.AllowOptional())
 					object := ouraTest.NewObjectFromSubscription(expectedDatum, test.ObjectFormatJSON)
+					if expectedDatum.ExpirationTime != nil {
+						object["expiration_time"] = expectedDatum.ExpirationTime.Format(oura.SubscriptionExpirationTimeFormat)
+					}
 					mutator(object, expectedDatum)
 					result := &oura.Subscription{}
 					errorsTest.ExpectEqual(structureParser.NewObject(logTest.NewLogger(), &object).Parse(result), expectedErrors...)
@@ -349,19 +535,19 @@ var _ = Describe("oura", func() {
 					func(object map[string]any, expectedDatum *oura.Subscription) {
 						object["id"] = true
 						object["callback_url"] = true
-						object["event_type"] = true
 						object["data_type"] = true
+						object["event_type"] = true
 						object["expiration_time"] = true
 						expectedDatum.ID = nil
 						expectedDatum.CallbackURL = nil
-						expectedDatum.EventType = nil
 						expectedDatum.DataType = nil
+						expectedDatum.EventType = nil
 						expectedDatum.ExpirationTime = nil
 					},
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/id"),
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/callback_url"),
-					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/event_type"),
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/data_type"),
+					errorsTest.WithPointerSource(structureParser.ErrorTypeNotString(true), "/event_type"),
 					errorsTest.WithPointerSource(structureParser.ErrorTypeNotTime(true), "/expiration_time"),
 				),
 			)
@@ -411,23 +597,6 @@ var _ = Describe("oura", func() {
 						datum.CallbackURL = pointer.FromString(ouraTest.RandomCallbackURL())
 					},
 				),
-				Entry("event_type",
-					func(datum *oura.Subscription) {
-						datum.EventType = nil
-					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
-				),
-				Entry("event_type invalid",
-					func(datum *oura.Subscription) {
-						datum.EventType = pointer.FromString("invalid")
-					},
-					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", oura.EventTypes()), "/event_type"),
-				),
-				Entry("event_type valid",
-					func(datum *oura.Subscription) {
-						datum.EventType = pointer.FromString(ouraTest.RandomEventType())
-					},
-				),
 				Entry("data_type",
 					func(datum *oura.Subscription) {
 						datum.DataType = nil
@@ -443,6 +612,23 @@ var _ = Describe("oura", func() {
 				Entry("data_type valid",
 					func(datum *oura.Subscription) {
 						datum.DataType = pointer.FromString(ouraTest.RandomDataType())
+					},
+				),
+				Entry("event_type",
+					func(datum *oura.Subscription) {
+						datum.EventType = nil
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
+				),
+				Entry("event_type invalid",
+					func(datum *oura.Subscription) {
+						datum.EventType = pointer.FromString("invalid")
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueStringNotOneOf("invalid", oura.EventTypes()), "/event_type"),
+				),
+				Entry("event_type valid",
+					func(datum *oura.Subscription) {
+						datum.EventType = pointer.FromString(ouraTest.RandomEventType())
 					},
 				),
 				Entry("expiration_time",
@@ -466,14 +652,14 @@ var _ = Describe("oura", func() {
 					func(datum *oura.Subscription) {
 						datum.ID = nil
 						datum.CallbackURL = nil
-						datum.EventType = nil
 						datum.DataType = nil
+						datum.EventType = nil
 						datum.ExpirationTime = nil
 					},
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/id"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/callback_url"),
-					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/data_type"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/event_type"),
 					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/expiration_time"),
 				),
 			)
@@ -481,6 +667,153 @@ var _ = Describe("oura", func() {
 	})
 
 	Context("Subscriptions", func() {
+		DescribeTable("serializes the datum as expected",
+			func(mutator func(datum *oura.Subscriptions)) {
+				datum := pointer.From(ouraTest.RandomSubscriptions(test.AllowOptional()))
+				mutator(datum)
+				array := test.AsAnyArray(*datum)
+				test.ExpectSerializedArrayJSON(array, ouraTest.NewArrayFromSubscriptions(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedArrayBSON(array, ouraTest.NewArrayFromSubscriptions(datum, test.ObjectFormatBSON))
+			},
+			Entry("succeeds",
+				func(datum *oura.Subscriptions) {},
+			),
+			Entry("empty",
+				func(datum *oura.Subscriptions) {
+					*datum = oura.Subscriptions{}
+				},
+			),
+			Entry("all",
+				func(datum *oura.Subscriptions) {
+					*datum = ouraTest.RandomSubscriptions()
+				},
+			),
+		)
+
+		Context("Parse", func() {
+			It("successfully parses a nil array", func() {
+				parser := structureParser.NewArray(logTest.NewLogger(), nil)
+				datum := oura.Subscriptions{}
+				datum.Parse(parser)
+				Expect(datum).To(Equal(oura.Subscriptions{}))
+				Expect(parser.Error()).ToNot(HaveOccurred())
+			})
+
+			It("successfully parses an empty array", func() {
+				parser := structureParser.NewArray(logTest.NewLogger(), &[]any{})
+				datum := oura.Subscriptions{}
+				datum.Parse(parser)
+				Expect(datum).To(Equal(oura.Subscriptions{}))
+				Expect(parser.Error()).ToNot(HaveOccurred())
+			})
+
+			It("successfully parses a non-empty array", func() {
+				expectedDatum := ouraTest.RandomSubscriptions()
+				array := ouraTest.NewArrayFromSubscriptions(&expectedDatum, test.ObjectFormatJSON)
+				for index, datum := range expectedDatum {
+					if datum.ExpirationTime != nil {
+						array[index].(map[string]any)["expiration_time"] = datum.ExpirationTime.Format(oura.SubscriptionExpirationTimeFormat)
+					}
+				}
+				parser := structureParser.NewArray(logTest.NewLogger(), &array)
+				datum := oura.Subscriptions{}
+				datum.Parse(parser)
+				Expect(datum).To(Equal(expectedDatum))
+				Expect(parser.Error()).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("Validate", func() {
+			DescribeTable("validates the datum",
+				func(mutator func(datum *oura.Subscriptions), expectedErrors ...error) {
+					datum := pointer.From(ouraTest.RandomSubscriptions())
+					mutator(datum)
+					errorsTest.ExpectEqual(structureValidator.New(logTest.NewLogger()).Validate(datum), expectedErrors...)
+				},
+				Entry("succeeds",
+					func(datum *oura.Subscriptions) {},
+				),
+				Entry("empty",
+					func(datum *oura.Subscriptions) { *datum = oura.Subscriptions{} },
+				),
+				Entry("nil",
+					func(datum *oura.Subscriptions) {
+						*datum = oura.Subscriptions{nil}
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/0"),
+				),
+				Entry("single invalid",
+					func(datum *oura.Subscriptions) {
+						invalid := ouraTest.RandomSubscription()
+						invalid.ID = nil
+						*datum = oura.Subscriptions{invalid}
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/0/id"),
+				),
+				Entry("single valid",
+					func(datum *oura.Subscriptions) {
+						*datum = oura.Subscriptions{ouraTest.RandomSubscription()}
+					},
+				),
+				Entry("multiple invalid",
+					func(datum *oura.Subscriptions) {
+						invalid := ouraTest.RandomSubscription()
+						invalid.ID = nil
+						*datum = oura.Subscriptions{ouraTest.RandomSubscription(), invalid, ouraTest.RandomSubscription()}
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/1/id"),
+				),
+				Entry("multiple valid",
+					func(datum *oura.Subscriptions) {
+						*datum = ouraTest.RandomSubscriptions()
+					},
+				),
+				Entry("multiple in range (upper)",
+					func(datum *oura.Subscriptions) {
+						*datum = oura.Subscriptions{}
+						for count := oura.SubscriptionArrayLengthMaximum; count > 0; count-- {
+							*datum = append(*datum, ouraTest.RandomSubscription())
+						}
+					},
+				),
+				Entry("multiple out of range range (upper)",
+					func(datum *oura.Subscriptions) {
+						*datum = oura.Subscriptions{}
+						for count := oura.SubscriptionArrayLengthMaximum + 1; count > 0; count-- {
+							*datum = append(*datum, ouraTest.RandomSubscription())
+						}
+					},
+					structureValidator.ErrorLengthNotLessThanOrEqualTo(oura.SubscriptionArrayLengthMaximum+1, oura.SubscriptionArrayLengthMaximum),
+				),
+				Entry("multiple errors",
+					func(datum *oura.Subscriptions) {
+						invalid := ouraTest.RandomSubscription()
+						invalid.ID = nil
+						*datum = oura.Subscriptions{nil, invalid, ouraTest.RandomSubscription()}
+					},
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/0"),
+					errorsTest.WithPointerSource(structureValidator.ErrorValueNotExists(), "/1/id"),
+				),
+			)
+		})
+
+		Context("with subscriptions", func() {
+			var subscriptions oura.Subscriptions
+
+			BeforeEach(func() {
+				subscriptions = ouraTest.RandomSubscriptions()
+			})
+
+			It("returns nil if there is no subscription for the event type and data type", func() {
+				Expect(subscriptions.Get("invalid", "invalid")).To(BeNil())
+			})
+
+			It("returns a subscription for the event type and data type", func() {
+				for _, subscription := range subscriptions {
+					Expect(subscriptions.Get(*subscription.DataType, *subscription.EventType)).To(Equal(subscription))
+				}
+			})
+		})
 	})
 
 	Context("PersonalInfo", func() {
@@ -489,6 +822,7 @@ var _ = Describe("oura", func() {
 				datum := ouraTest.RandomPersonalInfo(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraTest.NewObjectFromPersonalInfo(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraTest.NewObjectFromPersonalInfo(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *oura.PersonalInfo) {},
@@ -578,5 +912,66 @@ var _ = Describe("oura", func() {
 				),
 			)
 		})
+	})
+
+	Context("IsValidDataID, DataIDValidator, and ValidateDataID", func() {
+		DescribeTable("return the expected results when the input",
+			func(value string, expectedErrors ...error) {
+				Expect(oura.IsValidDataID(value)).To(Equal(len(expectedErrors) == 0))
+				errorReporter := structureTest.NewErrorReporter()
+				oura.DataIDValidator(value, errorReporter)
+				errorsTest.ExpectEqual(errorReporter.Error(), expectedErrors...)
+				errorsTest.ExpectEqual(oura.ValidateDataID(value), expectedErrors...)
+			},
+			Entry("is empty", "", structureValidator.ErrorValueEmpty()),
+			Entry("is valid", ouraTest.RandomID()),
+		)
+	})
+
+	Context("IsValidDataType, DataTypeValidator, and ValidateDataType", func() {
+		DescribeTable("return the expected results when the input",
+			func(value string, expectedErrors ...error) {
+				Expect(oura.IsValidDataType(value)).To(Equal(len(expectedErrors) == 0))
+				errorReporter := structureTest.NewErrorReporter()
+				oura.DataTypeValidator(value, errorReporter)
+				errorsTest.ExpectEqual(errorReporter.Error(), expectedErrors...)
+				errorsTest.ExpectEqual(oura.ValidateDataType(value), expectedErrors...)
+			},
+			Entry("is empty", "", structureValidator.ErrorValueEmpty()),
+			Entry("is invalid", "invalid", structureValidator.ErrorValueStringNotOneOf("invalid", oura.DataTypes())),
+			Entry("is DataTypeDailyActivity", oura.DataTypeDailyActivity),
+			Entry("is DataTypeDailyCardiovascularAge", oura.DataTypeDailyCardiovascularAge),
+			Entry("is DataTypeDailyReadiness", oura.DataTypeDailyReadiness),
+			Entry("is DataTypeDailyResilience", oura.DataTypeDailyResilience),
+			Entry("is DataTypeDailySleep", oura.DataTypeDailySleep),
+			Entry("is DataTypeDailySpO2", oura.DataTypeDailySpO2),
+			Entry("is DataTypeDailyStress", oura.DataTypeDailyStress),
+			Entry("is DataTypeEnhancedTag", oura.DataTypeEnhancedTag),
+			Entry("is DataTypeHeartRate", oura.DataTypeHeartRate),
+			Entry("is DataTypeRestModePeriod", oura.DataTypeRestModePeriod),
+			Entry("is DataTypeRingConfiguration", oura.DataTypeRingConfiguration),
+			Entry("is DataTypeSession", oura.DataTypeSession),
+			Entry("is DataTypeSleep", oura.DataTypeSleep),
+			Entry("is DataTypeSleepTime", oura.DataTypeSleepTime),
+			Entry("is DataTypeVO2Max", oura.DataTypeVO2Max),
+			Entry("is DataTypeWorkout", oura.DataTypeWorkout),
+		)
+	})
+
+	Context("IsValidEventType, EventTypeValidator, and ValidateEventType", func() {
+		DescribeTable("return the expected results when the input",
+			func(value string, expectedErrors ...error) {
+				Expect(oura.IsValidEventType(value)).To(Equal(len(expectedErrors) == 0))
+				errorReporter := structureTest.NewErrorReporter()
+				oura.EventTypeValidator(value, errorReporter)
+				errorsTest.ExpectEqual(errorReporter.Error(), expectedErrors...)
+				errorsTest.ExpectEqual(oura.ValidateEventType(value), expectedErrors...)
+			},
+			Entry("is empty", "", structureValidator.ErrorValueEmpty()),
+			Entry("is invalid", "invalid", structureValidator.ErrorValueStringNotOneOf("invalid", oura.EventTypes())),
+			Entry("is EventTypeCreate", oura.EventTypeCreate),
+			Entry("is EventTypeUpdate", oura.EventTypeUpdate),
+			Entry("is EventTypeDelete", oura.EventTypeDelete),
+		)
 	})
 })

--- a/oura/provider/config.go
+++ b/oura/provider/config.go
@@ -10,8 +10,8 @@ import (
 
 type Config struct {
 	*oauthProviderClient.Config
-	PartnerURL    string `json:"partner_url,omitempty"`
-	PartnerSecret string `json:"partner_secret,omitempty"`
+	PartnerURL    string `json:"partner_url,omitempty" bson:"partner_url,omitempty"`
+	PartnerSecret string `json:"partner_secret,omitempty" bson:"partner_secret,omitempty"`
 }
 
 func NewConfigWithConfigReporter(configReporter config.Reporter) (*Config, error) {

--- a/oura/provider/provider.go
+++ b/oura/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"net/url"
 	"slices"
 
 	"github.com/tidepool-org/platform/auth"
@@ -52,7 +51,7 @@ type Provider struct {
 	dataSourceClient      dataSource.Client
 	workClient            work.Client
 	acceptURL             *string
-	partnerURL            *url.URL
+	partnerURL            string
 	partnerSecret         string
 	client                *ouraClient.Client
 }
@@ -65,14 +64,9 @@ func New(dependencies Dependencies) (*Provider, error) {
 		return nil, errors.Wrap(err, "dependencies is invalid")
 	}
 
-	oauthProviderClient, err := oauthProviderClient.New(oura.ProviderName, dependencies.Config.Config, nil)
+	oauthProviderClient, err := oauthProviderClient.NewWithErrorParser(oura.ProviderName, dependencies.Config.Config, nil, ouraClient.NewErrorResponseParser())
 	if err != nil {
 		return nil, err
-	}
-
-	partnerURL, err := url.Parse(dependencies.Config.PartnerURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "partner url is invalid")
 	}
 
 	provider := &Provider{
@@ -81,7 +75,7 @@ func New(dependencies Dependencies) (*Provider, error) {
 		dataSourceClient:      dependencies.DataSourceClient,
 		workClient:            dependencies.WorkClient,
 		acceptURL:             dependencies.Config.Provider.AcceptURL,
-		partnerURL:            partnerURL,
+		partnerURL:            dependencies.Config.PartnerURL,
 		partnerSecret:         dependencies.Config.PartnerSecret,
 	}
 
@@ -150,7 +144,7 @@ func (p *Provider) UserActionAcceptURL(ctx context.Context, userID string, actio
 	}
 }
 
-func (p *Provider) PartnerURL() *url.URL {
+func (p *Provider) PartnerURL() string {
 	return p.partnerURL
 }
 

--- a/oura/service/api/v1/subscription.go
+++ b/oura/service/api/v1/subscription.go
@@ -4,13 +4,46 @@ import (
 	"net/http"
 
 	dataService "github.com/tidepool-org/platform/data/service"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/request"
+)
+
+const (
+	RequestQueryParameterVerificationToken = "verification_token"
+	RequestQueryParameterChallenge         = "challenge"
 )
 
 func Subscription(dataServiceContext dataService.Context) {
 	res := dataServiceContext.Response()
 	req := dataServiceContext.Request()
+	ctx := req.Context()
+	lgr := log.LoggerFromContext(ctx)
 	responder := request.MustNewResponder(res, req)
 
-	responder.String(http.StatusOK, "OK")
+	// Get required query parameters
+	query := req.URL.Query()
+	verificationToken := query.Get(RequestQueryParameterVerificationToken)
+	lgr = lgr.WithField("verificationToken", verificationToken)
+	if verificationToken == "" {
+		lgr.Error("verification token is missing")
+		responder.String(http.StatusForbidden, "verification token is missing")
+		return
+	}
+	challenge := query.Get(RequestQueryParameterChallenge)
+	lgr = lgr.WithField("challenge", challenge)
+	if challenge == "" {
+		lgr.Error("challenge is missing")
+		responder.String(http.StatusForbidden, "challenge is missing")
+		return
+	}
+
+	// Ensure verification token matches partner secret
+	if verificationToken != dataServiceContext.OuraClient().PartnerSecret() {
+		lgr.Error("verification token is invalid")
+		responder.String(http.StatusForbidden, "verification token is invalid")
+		return
+	}
+
+	// Return challenge
+	responder.Data(http.StatusOK, map[string]string{"challenge": challenge})
 }

--- a/oura/service/api/v1/v1.go
+++ b/oura/service/api/v1/v1.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Routes() []dataService.Route {
-	webhookPath := oura.PartnerPathPrefix + ouraWebhook.WebhookPathEvent
+	webhookPath := oura.PartnerPathPrefix + ouraWebhook.EventPath
 	return []dataService.Route{
 		dataService.Get(webhookPath, Subscription),
 		dataService.Post(webhookPath, Event),

--- a/oura/test/oura.go
+++ b/oura/test/oura.go
@@ -15,12 +15,12 @@ func RandomVerificationToken() string {
 	return test.RandomString()
 }
 
-func RandomEventType() string {
-	return test.RandomStringFromArray(oura.EventTypes())
-}
-
 func RandomDataType() string {
 	return test.RandomStringFromArray(oura.DataTypes())
+}
+
+func RandomEventType() string {
+	return test.RandomStringFromArray(oura.EventTypes())
 }
 
 func RandomID() string {
@@ -35,8 +35,8 @@ func RandomCreateSubscription(options ...test.Option) *oura.CreateSubscription {
 	return &oura.CreateSubscription{
 		CallbackURL:       pointer.FromString(RandomCallbackURL()),
 		VerificationToken: pointer.FromString(RandomVerificationToken()),
-		EventType:         pointer.FromString(RandomEventType()),
 		DataType:          pointer.FromString(RandomDataType()),
+		EventType:         pointer.FromString(RandomEventType()),
 	}
 }
 
@@ -47,8 +47,8 @@ func CloneCreateSubscription(datum *oura.CreateSubscription) *oura.CreateSubscri
 	return &oura.CreateSubscription{
 		CallbackURL:       pointer.CloneString(datum.CallbackURL),
 		VerificationToken: pointer.CloneString(datum.VerificationToken),
-		EventType:         pointer.CloneString(datum.EventType),
 		DataType:          pointer.CloneString(datum.DataType),
+		EventType:         pointer.CloneString(datum.EventType),
 	}
 }
 
@@ -63,11 +63,52 @@ func NewObjectFromCreateSubscription(datum *oura.CreateSubscription, format test
 	if datum.VerificationToken != nil {
 		object["verification_token"] = test.NewObjectFromString(*datum.VerificationToken, format)
 	}
+	if datum.DataType != nil {
+		object["data_type"] = test.NewObjectFromString(*datum.DataType, format)
+	}
 	if datum.EventType != nil {
 		object["event_type"] = test.NewObjectFromString(*datum.EventType, format)
 	}
+	return object
+}
+
+func RandomUpdateSubscription(options ...test.Option) *oura.UpdateSubscription {
+	return &oura.UpdateSubscription{
+		CallbackURL:       pointer.FromString(RandomCallbackURL()),
+		VerificationToken: pointer.FromString(RandomVerificationToken()),
+		DataType:          pointer.FromString(RandomDataType()),
+		EventType:         pointer.FromString(RandomEventType()),
+	}
+}
+
+func CloneUpdateSubscription(datum *oura.UpdateSubscription) *oura.UpdateSubscription {
+	if datum == nil {
+		return nil
+	}
+	return &oura.UpdateSubscription{
+		CallbackURL:       pointer.CloneString(datum.CallbackURL),
+		VerificationToken: pointer.CloneString(datum.VerificationToken),
+		DataType:          pointer.CloneString(datum.DataType),
+		EventType:         pointer.CloneString(datum.EventType),
+	}
+}
+
+func NewObjectFromUpdateSubscription(datum *oura.UpdateSubscription, format test.ObjectFormat) map[string]any {
+	if datum == nil {
+		return nil
+	}
+	object := map[string]any{}
+	if datum.CallbackURL != nil {
+		object["callback_url"] = test.NewObjectFromString(*datum.CallbackURL, format)
+	}
+	if datum.VerificationToken != nil {
+		object["verification_token"] = test.NewObjectFromString(*datum.VerificationToken, format)
+	}
 	if datum.DataType != nil {
 		object["data_type"] = test.NewObjectFromString(*datum.DataType, format)
+	}
+	if datum.EventType != nil {
+		object["event_type"] = test.NewObjectFromString(*datum.EventType, format)
 	}
 	return object
 }
@@ -76,9 +117,9 @@ func RandomSubscription(options ...test.Option) *oura.Subscription {
 	return &oura.Subscription{
 		ID:             pointer.FromString(RandomID()),
 		CallbackURL:    pointer.FromString(RandomCallbackURL()),
-		EventType:      pointer.FromString(RandomEventType()),
 		DataType:       pointer.FromString(RandomDataType()),
-		ExpirationTime: pointer.FromTime(test.RandomTimeAfterNow()),
+		EventType:      pointer.FromString(RandomEventType()),
+		ExpirationTime: pointer.FromTime(test.RandomTimeAfterNow().UTC()),
 	}
 }
 
@@ -89,8 +130,8 @@ func CloneSubscription(datum *oura.Subscription) *oura.Subscription {
 	return &oura.Subscription{
 		ID:             pointer.CloneString(datum.ID),
 		CallbackURL:    pointer.CloneString(datum.CallbackURL),
-		EventType:      pointer.CloneString(datum.EventType),
 		DataType:       pointer.CloneString(datum.DataType),
+		EventType:      pointer.CloneString(datum.EventType),
 		ExpirationTime: pointer.CloneTime(datum.ExpirationTime),
 	}
 }
@@ -106,11 +147,11 @@ func NewObjectFromSubscription(datum *oura.Subscription, format test.ObjectForma
 	if datum.CallbackURL != nil {
 		object["callback_url"] = test.NewObjectFromString(*datum.CallbackURL, format)
 	}
-	if datum.EventType != nil {
-		object["event_type"] = test.NewObjectFromString(*datum.EventType, format)
-	}
 	if datum.DataType != nil {
 		object["data_type"] = test.NewObjectFromString(*datum.DataType, format)
+	}
+	if datum.EventType != nil {
+		object["event_type"] = test.NewObjectFromString(*datum.EventType, format)
 	}
 	if datum.ExpirationTime != nil {
 		object["expiration_time"] = test.NewObjectFromTime(*datum.ExpirationTime, format)

--- a/oura/test/oura_mocks.go
+++ b/oura/test/oura_mocks.go
@@ -21,6 +21,86 @@ import (
 	times "github.com/tidepool-org/platform/times"
 )
 
+// MockBaseClient is a mock of BaseClient interface.
+type MockBaseClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockBaseClientMockRecorder
+	isgomock struct{}
+}
+
+// MockBaseClientMockRecorder is the mock recorder for MockBaseClient.
+type MockBaseClientMockRecorder struct {
+	mock *MockBaseClient
+}
+
+// NewMockBaseClient creates a new mock instance.
+func NewMockBaseClient(ctrl *gomock.Controller) *MockBaseClient {
+	mock := &MockBaseClient{ctrl: ctrl}
+	mock.recorder = &MockBaseClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBaseClient) EXPECT() *MockBaseClientMockRecorder {
+	return m.recorder
+}
+
+// ClientID mocks base method.
+func (m *MockBaseClient) ClientID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClientID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClientID indicates an expected call of ClientID.
+func (mr *MockBaseClientMockRecorder) ClientID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientID", reflect.TypeOf((*MockBaseClient)(nil).ClientID))
+}
+
+// ClientSecret mocks base method.
+func (m *MockBaseClient) ClientSecret() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClientSecret")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClientSecret indicates an expected call of ClientSecret.
+func (mr *MockBaseClientMockRecorder) ClientSecret() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientSecret", reflect.TypeOf((*MockBaseClient)(nil).ClientSecret))
+}
+
+// PartnerSecret mocks base method.
+func (m *MockBaseClient) PartnerSecret() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PartnerSecret")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PartnerSecret indicates an expected call of PartnerSecret.
+func (mr *MockBaseClientMockRecorder) PartnerSecret() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PartnerSecret", reflect.TypeOf((*MockBaseClient)(nil).PartnerSecret))
+}
+
+// PartnerURL mocks base method.
+func (m *MockBaseClient) PartnerURL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PartnerURL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PartnerURL indicates an expected call of PartnerURL.
+func (mr *MockBaseClientMockRecorder) PartnerURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PartnerURL", reflect.TypeOf((*MockBaseClient)(nil).PartnerURL))
+}
+
 // MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
@@ -43,6 +123,34 @@ func NewMockClient(ctrl *gomock.Controller) *MockClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
+}
+
+// ClientID mocks base method.
+func (m *MockClient) ClientID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClientID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClientID indicates an expected call of ClientID.
+func (mr *MockClientMockRecorder) ClientID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientID", reflect.TypeOf((*MockClient)(nil).ClientID))
+}
+
+// ClientSecret mocks base method.
+func (m *MockClient) ClientSecret() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClientSecret")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClientSecret indicates an expected call of ClientSecret.
+func (mr *MockClientMockRecorder) ClientSecret() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientSecret", reflect.TypeOf((*MockClient)(nil).ClientSecret))
 }
 
 // CreateSubscription mocks base method.
@@ -75,10 +183,10 @@ func (mr *MockClientMockRecorder) DeleteSubscription(ctx, id any) *gomock.Call {
 }
 
 // GetData mocks base method.
-func (m *MockClient) GetData(ctx context.Context, dataType string, timeRange times.TimeRange, tokenSource oauth.TokenSource) (oura.Data, error) {
+func (m *MockClient) GetData(ctx context.Context, dataType string, timeRange times.TimeRange, tokenSource oauth.TokenSource) (*oura.Data, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetData", ctx, dataType, timeRange, tokenSource)
-	ret0, _ := ret[0].(oura.Data)
+	ret0, _ := ret[0].(*oura.Data)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -134,6 +242,34 @@ func (mr *MockClientMockRecorder) ListSubscriptions(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockClient)(nil).ListSubscriptions), ctx)
 }
 
+// PartnerSecret mocks base method.
+func (m *MockClient) PartnerSecret() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PartnerSecret")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PartnerSecret indicates an expected call of PartnerSecret.
+func (mr *MockClientMockRecorder) PartnerSecret() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PartnerSecret", reflect.TypeOf((*MockClient)(nil).PartnerSecret))
+}
+
+// PartnerURL mocks base method.
+func (m *MockClient) PartnerURL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PartnerURL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// PartnerURL indicates an expected call of PartnerURL.
+func (mr *MockClientMockRecorder) PartnerURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PartnerURL", reflect.TypeOf((*MockClient)(nil).PartnerURL))
+}
+
 // RenewSubscription mocks base method.
 func (m *MockClient) RenewSubscription(ctx context.Context, id string) (*oura.Subscription, error) {
 	m.ctrl.T.Helper()
@@ -161,4 +297,19 @@ func (m *MockClient) RevokeOAuthToken(ctx context.Context, oauthToken *auth.OAut
 func (mr *MockClientMockRecorder) RevokeOAuthToken(ctx, oauthToken any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeOAuthToken", reflect.TypeOf((*MockClient)(nil).RevokeOAuthToken), ctx, oauthToken)
+}
+
+// UpdateSubscription mocks base method.
+func (m *MockClient) UpdateSubscription(ctx context.Context, id string, update *oura.UpdateSubscription) (*oura.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubscription", ctx, id, update)
+	ret0, _ := ret[0].(*oura.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSubscription indicates an expected call of UpdateSubscription.
+func (mr *MockClientMockRecorder) UpdateSubscription(ctx, id, update any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscription", reflect.TypeOf((*MockClient)(nil).UpdateSubscription), ctx, id, update)
 }

--- a/oura/webhook/webhook.go
+++ b/oura/webhook/webhook.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tidepool-org/platform/structure"
 )
 
-const WebhookPathEvent = "/event"
+const EventPath = "/event"
 
 // All, but heartrate
 func DataTypes() []string {
@@ -33,11 +33,11 @@ func DataTypes() []string {
 }
 
 type Event struct {
-	EventTime *time.Time `json:"event_time,omitempty"`
-	EventType *string    `json:"event_type,omitempty"`
-	UserID    *string    `json:"user_id,omitempty"`
-	ObjectID  *string    `json:"object_id,omitempty"`
-	DataType  *string    `json:"data_type,omitempty"`
+	EventTime *time.Time `json:"event_time,omitempty" bson:"event_time,omitempty"`
+	EventType *string    `json:"event_type,omitempty" bson:"event_type,omitempty"`
+	UserID    *string    `json:"user_id,omitempty" bson:"user_id,omitempty"`
+	ObjectID  *string    `json:"object_id,omitempty" bson:"object_id,omitempty"`
+	DataType  *string    `json:"data_type,omitempty" bson:"data_type,omitempty"`
 }
 
 func ParseEvent(parser structure.ObjectParser) *Event {
@@ -85,7 +85,7 @@ func (e *Event) String() string {
 const MetadataKeyEvent = "event"
 
 type EventMetadata struct {
-	Event *Event `json:"event,omitempty"`
+	Event *Event `json:"event,omitempty" bson:"event,omitempty"`
 }
 
 func (e *EventMetadata) Parse(parser structure.ObjectParser) {

--- a/oura/webhook/webhook_test.go
+++ b/oura/webhook/webhook_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 var _ = Describe("Webhook", func() {
-	It("WebhookPathEvent is expected", func() {
-		Expect(ouraWebhook.WebhookPathEvent).To(Equal("/event"))
+	It("EventPath is expected", func() {
+		Expect(ouraWebhook.EventPath).To(Equal("/event"))
 	})
 
 	Context("DataTypes", func() {
@@ -64,6 +64,7 @@ var _ = Describe("Webhook", func() {
 				datum := ouraWebhookTest.RandomEvent(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraWebhookTest.NewObjectFromEvent(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraWebhookTest.NewObjectFromEvent(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *ouraWebhook.Event) {},
@@ -234,7 +235,7 @@ var _ = Describe("Webhook", func() {
 		})
 
 		Context("with event", func() {
-			var eventTime, _ = time.Parse(time.RFC3339Nano, "2026-01-15T20:15:42.123Z")
+			var eventTime, _ = time.ParseInLocation(time.RFC3339Nano, "2026-01-15T20:15:42.123Z", time.UTC)
 
 			DescribeTable("String returns expected string",
 				func(eventTime *time.Time, eventType *string, userID *string, objectID *string, dataType *string, expectedString string) {
@@ -268,6 +269,7 @@ var _ = Describe("Webhook", func() {
 				datum := ouraWebhookTest.RandomEventMetadata(test.AllowOptional())
 				mutator(datum)
 				test.ExpectSerializedObjectJSON(datum, ouraWebhookTest.NewObjectFromEventMetadata(datum, test.ObjectFormatJSON))
+				test.ExpectSerializedObjectBSON(datum, ouraWebhookTest.NewObjectFromEventMetadata(datum, test.ObjectFormatBSON))
 			},
 			Entry("succeeds",
 				func(datum *ouraWebhook.EventMetadata) {},

--- a/oura/webhook/work/subscribe/processor.go
+++ b/oura/webhook/work/subscribe/processor.go
@@ -5,14 +5,18 @@ import (
 	"time"
 
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/oura"
+	ouraWebhook "github.com/tidepool-org/platform/oura/webhook"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/work"
 	workBase "github.com/tidepool-org/platform/work/base"
 )
 
 const (
-	PendingAvailableDuration   = 24 * time.Hour
-	FailingRetryDuration       = 10 * time.Minute
-	FailingRetryDurationJitter = time.Minute
+	PendingAvailableDuration      = 24 * time.Hour
+	FailingRetryDuration          = 10 * time.Minute
+	FailingRetryDurationJitter    = time.Minute
+	ExpirationTimeDurationMinimum = 7 * 24 * time.Hour // Normal expiration seems like 90 days, but this will refresh every 7
 )
 
 type Processor struct {
@@ -53,6 +57,47 @@ func (p *Processor) Process(ctx context.Context, wrk *work.Work, processingUpdat
 }
 
 func (p *Processor) synchronizeSubscriptions() *work.ProcessResult {
-	// TODO: Implement
+	existingSubscriptions, err := p.ListSubscriptions(p.Context())
+	if err != nil {
+		return p.Failing(errors.Wrap(err, "unable to list existing subscriptions"))
+	}
+
+	callbackURL := p.PartnerURL() + ouraWebhook.EventPath
+	verificationToken := p.PartnerSecret()
+
+	for _, dataType := range ouraWebhook.DataTypes() {
+		for _, eventType := range oura.EventTypes() {
+
+			// If an existing subscription exists for this event type and data type, either update it or renew it
+			if existingSubscription := existingSubscriptions.Get(dataType, eventType); existingSubscription != nil && existingSubscription.ID != nil {
+				if existingSubscription.CallbackURL == nil || *existingSubscription.CallbackURL != callbackURL {
+					updateSubscription := &oura.UpdateSubscription{
+						CallbackURL:       pointer.FromString(callbackURL),
+						VerificationToken: pointer.FromString(verificationToken),
+						DataType:          existingSubscription.DataType,
+						EventType:         existingSubscription.EventType,
+					}
+					if _, err := p.UpdateSubscription(p.Context(), *existingSubscription.ID, updateSubscription); err != nil {
+						return p.Failing(errors.WithMeta(errors.Wrapf(err, "unable to update existing subscription"), existingSubscription))
+					}
+				} else if existingSubscription.ExpirationTime != nil && time.Until(*existingSubscription.ExpirationTime) < ExpirationTimeDurationMinimum {
+					if _, err := p.RenewSubscription(p.Context(), *existingSubscription.ID); err != nil {
+						return p.Failing(errors.WithMeta(errors.Wrapf(err, "unable to renew existing subscription"), existingSubscription))
+					}
+				}
+			} else {
+				createSubscription := &oura.CreateSubscription{
+					CallbackURL:       pointer.FromString(callbackURL),
+					VerificationToken: pointer.FromString(verificationToken),
+					DataType:          pointer.FromString(dataType),
+					EventType:         pointer.FromString(eventType),
+				}
+				if _, err := p.CreateSubscription(p.Context(), createSubscription); err != nil {
+					return p.Failing(errors.WithMeta(errors.Wrapf(err, "unable to create new subscription"), createSubscription))
+				}
+			}
+		}
+	}
+
 	return nil
 }

--- a/oura/webhook/work/subscribe/processor_test.go
+++ b/oura/webhook/work/subscribe/processor_test.go
@@ -2,6 +2,8 @@ package subscribe_test
 
 import (
 	"context"
+	"math/rand/v2"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -10,10 +12,15 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	errorsTest "github.com/tidepool-org/platform/errors/test"
 	"github.com/tidepool-org/platform/log"
 	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/oura"
 	ouraTest "github.com/tidepool-org/platform/oura/test"
+	ouraWebhook "github.com/tidepool-org/platform/oura/webhook"
 	ouraWebhookWorkSubscribe "github.com/tidepool-org/platform/oura/webhook/work/subscribe"
+	"github.com/tidepool-org/platform/pointer"
+	"github.com/tidepool-org/platform/test"
 	"github.com/tidepool-org/platform/work"
 	workBase "github.com/tidepool-org/platform/work/base"
 	workTest "github.com/tidepool-org/platform/work/test"
@@ -83,15 +90,175 @@ var _ = Describe("processor", func() {
 				})
 
 				Context("Process", func() {
-					It("returns successful process result if able to revoke oauth token", func() {
-						Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchPendingProcessResult(
-							MatchAllFields(Fields{
-								"ProcessingAvailableTime": BeTemporally("~", time.Now().Add(ouraWebhookWorkSubscribe.PendingAvailableDuration), time.Second),
-								"ProcessingPriority":      Equal(0),
-								"ProcessingTimeout":       Equal(int(ouraWebhookWorkSubscribe.ProcessingTimeout.Seconds())),
-								"Metadata":                BeNil(),
-							}),
-						))
+					It("returns an error if unable to list existing subscriptions", func() {
+						testErr := errorsTest.RandomError()
+						mockOuraClient.EXPECT().ListSubscriptions(gomock.Any()).Return(nil, testErr)
+						Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchFailingProcessResultError(MatchError(testErr)))
+					})
+
+					Context("with list subscriptions successful", func() {
+						var now time.Time
+						var expirationTime time.Time
+						var partnerURL string
+						var partnerSecret string
+
+						BeforeEach(func() {
+							now = time.Now()
+							expirationTime = now.Add(ouraWebhookWorkSubscribe.ExpirationTimeDurationMinimum)
+							partnerURL = test.RandomString()
+							partnerSecret = test.RandomString()
+							mockOuraClient.EXPECT().PartnerURL().Return(partnerURL)
+							mockOuraClient.EXPECT().PartnerSecret().Return(partnerSecret)
+						})
+
+						_subscription := func(dataType string, eventType string) *oura.Subscription {
+							return &oura.Subscription{
+								ID:             pointer.FromString(test.RandomString()),
+								CallbackURL:    pointer.FromString(partnerURL + ouraWebhook.EventPath),
+								DataType:       pointer.FromString(dataType),
+								EventType:      pointer.FromString(eventType),
+								ExpirationTime: pointer.FromTime(test.RandomTimeAfter(expirationTime.Add(time.Minute))),
+							}
+						}
+
+						_createSubscription := func(dataType string, eventType string) *oura.CreateSubscription {
+							return &oura.CreateSubscription{
+								CallbackURL:       pointer.FromString(partnerURL + ouraWebhook.EventPath),
+								VerificationToken: pointer.FromString(partnerSecret),
+								DataType:          pointer.FromString(dataType),
+								EventType:         pointer.FromString(eventType),
+							}
+						}
+
+						_updateSubscription := func(dataType string, eventType string) *oura.UpdateSubscription {
+							return &oura.UpdateSubscription{
+								CallbackURL:       pointer.FromString(partnerURL + ouraWebhook.EventPath),
+								VerificationToken: pointer.FromString(partnerSecret),
+								DataType:          pointer.FromString(dataType),
+								EventType:         pointer.FromString(eventType),
+							}
+						}
+						Context("without existing subscriptions", func() {
+							BeforeEach(func() {
+								mockOuraClient.EXPECT().ListSubscriptions(gomock.Any()).Return(oura.Subscriptions{}, nil)
+							})
+
+							It("fails if unable to create subscription", func() {
+								testErr := errorsTest.RandomError()
+								mockOuraClient.EXPECT().CreateSubscription(gomock.Any(), _createSubscription(oura.DataTypeDailyActivity, oura.EventTypeCreate)).Return(nil, testErr)
+								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchFailingProcessResultError(MatchError(testErr)))
+							})
+
+							It("returns successful after creating subscriptions for all event types and data types", func() {
+								for _, dataType := range ouraWebhook.DataTypes() {
+									for _, eventType := range oura.EventTypes() {
+										mockOuraClient.EXPECT().CreateSubscription(gomock.Any(), _createSubscription(dataType, eventType)).Return(_subscription(dataType, eventType), nil)
+									}
+								}
+								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchPendingProcessResult(
+									MatchAllFields(Fields{
+										"ProcessingAvailableTime": BeTemporally("~", time.Now().Add(ouraWebhookWorkSubscribe.PendingAvailableDuration), time.Second),
+										"ProcessingPriority":      Equal(0),
+										"ProcessingTimeout":       Equal(int(ouraWebhookWorkSubscribe.ProcessingTimeout.Seconds())),
+										"Metadata":                BeNil(),
+									}),
+								))
+							})
+						})
+
+						Context("with existing subscriptions", func() {
+							It("fails if unable to update subscription", func() {
+								subscription := _subscription(oura.DataTypeDailyActivity, oura.EventTypeCreate)
+								subscription.CallbackURL = pointer.FromString(test.RandomString())
+								mockOuraClient.EXPECT().ListSubscriptions(gomock.Any()).Return(oura.Subscriptions{subscription}, nil)
+								testErr := errorsTest.RandomError()
+								mockOuraClient.EXPECT().UpdateSubscription(gomock.Any(), *subscription.ID, _updateSubscription(oura.DataTypeDailyActivity, oura.EventTypeCreate)).Return(nil, testErr)
+								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchFailingProcessResultError(MatchError(testErr)))
+							})
+
+							It("fails if unable to renew subscription", func() {
+								subscription := _subscription(oura.DataTypeDailyActivity, oura.EventTypeCreate)
+								subscription.ExpirationTime = pointer.FromTime(test.RandomTimeFromRange(now, expirationTime))
+								mockOuraClient.EXPECT().ListSubscriptions(gomock.Any()).Return(oura.Subscriptions{subscription}, nil)
+								testErr := errorsTest.RandomError()
+								mockOuraClient.EXPECT().RenewSubscription(gomock.Any(), *subscription.ID).Return(nil, testErr)
+								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchFailingProcessResultError(MatchError(testErr)))
+							})
+
+							Context("with successful create, update, and renew", func() {
+								var createSubscriptions oura.Subscriptions
+								var updateSubscriptions oura.Subscriptions
+								var renewSubscriptions oura.Subscriptions
+
+								BeforeEach(func() {
+									// All possible subscriptions, randomized
+									subscriptions := oura.Subscriptions{}
+									for _, dataType := range ouraWebhook.DataTypes() {
+										for _, eventType := range oura.EventTypes() {
+											subscriptions = append(subscriptions, _subscription(dataType, eventType))
+										}
+									}
+									rand.Shuffle(len(subscriptions), func(i, j int) {
+										subscriptions[i], subscriptions[j] = subscriptions[j], subscriptions[i]
+									})
+
+									// Remove zero to all as not existing
+									for range test.RandomIntFromRange(0, len(subscriptions)) {
+										index := test.RandomIntFromRange(0, len(subscriptions)-1)
+										createSubscriptions = append(createSubscriptions, subscriptions[index])
+										subscriptions = slices.Delete(subscriptions, index, index+1)
+									}
+
+									// Break into different existing subscription use cases
+									for _, subscription := range subscriptions {
+										switch test.RandomIntFromRange(0, 6) {
+										case 0:
+											subscription.CallbackURL = nil
+											updateSubscriptions = append(updateSubscriptions, subscription)
+										case 1:
+											subscription.CallbackURL = pointer.FromString(test.RandomString())
+											updateSubscriptions = append(updateSubscriptions, subscription)
+										case 2:
+											subscription.ExpirationTime = pointer.FromTime(test.RandomTimeBefore(now))
+											renewSubscriptions = append(renewSubscriptions, subscription)
+										case 3:
+											subscription.ExpirationTime = pointer.FromTime(test.RandomTimeFromRange(now, expirationTime))
+											renewSubscriptions = append(renewSubscriptions, subscription)
+										default:
+											// Existing, but valid (does not require update or renew)
+										}
+									}
+
+									// All expectations
+									for _, subscription := range createSubscriptions {
+										mockOuraClient.EXPECT().CreateSubscription(gomock.Any(), _createSubscription(*subscription.DataType, *subscription.EventType)).Return(subscription, nil)
+									}
+									for _, subscription := range updateSubscriptions {
+										mockOuraClient.EXPECT().UpdateSubscription(gomock.Any(), *subscription.ID, _updateSubscription(*subscription.DataType, *subscription.EventType)).Return(subscription, nil)
+									}
+									for _, subscription := range renewSubscriptions {
+										mockOuraClient.EXPECT().RenewSubscription(gomock.Any(), *subscription.ID).Return(subscription, nil)
+									}
+
+									// Shuffle again
+									rand.Shuffle(len(subscriptions), func(i, j int) {
+										subscriptions[i], subscriptions[j] = subscriptions[j], subscriptions[i]
+									})
+									mockOuraClient.EXPECT().ListSubscriptions(gomock.Any()).Return(subscriptions, nil)
+								})
+
+								It("returns successful after creating subscriptions for all event types and data types", func() {
+									Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchPendingProcessResult(
+										MatchAllFields(Fields{
+											"ProcessingAvailableTime": BeTemporally("~", time.Now().Add(ouraWebhookWorkSubscribe.PendingAvailableDuration), time.Second),
+											"ProcessingPriority":      Equal(0),
+											"ProcessingTimeout":       Equal(int(ouraWebhookWorkSubscribe.ProcessingTimeout.Seconds())),
+											"Metadata":                BeNil(),
+										}),
+									))
+								})
+							})
+						})
 					})
 				})
 			})

--- a/oura/work/processors/processors.go
+++ b/oura/work/processors/processors.go
@@ -1,11 +1,14 @@
 package processors
 
 import (
+	"context"
+
 	providerSession "github.com/tidepool-org/platform/auth/providersession"
 	dataRaw "github.com/tidepool-org/platform/data/raw"
 	dataSet "github.com/tidepool-org/platform/data/set"
 	dataSource "github.com/tidepool-org/platform/data/source"
 	"github.com/tidepool-org/platform/errors"
+	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/oura"
 	ouraDataWorkEvent "github.com/tidepool-org/platform/oura/data/work/event"
 	ouraDataWorkHistoric "github.com/tidepool-org/platform/oura/data/work/historic"
@@ -116,10 +119,20 @@ func NewProcessorFactories(dependencies Dependencies) ([]work.ProcessorFactory, 
 	return processorFactories, nil
 }
 
-func EnsureWork(dependencies Dependencies) error {
-	if err := dependencies.Validate(); err != nil {
-		return errors.Wrap(err, "dependencies is invalid")
+func EnsureWork(ctx context.Context, workClient work.Client) error {
+	if ctx == nil {
+		return errors.New("context is missing")
+	}
+	if workClient == nil {
+		return errors.New("work client is missing")
 	}
 
+	if workCreate, err := ouraWebhookWorkSubscribe.NewWorkCreate(); err != nil {
+		return errors.Wrap(err, "unable to create webhook subscribe work create")
+	} else if _, err = workClient.Create(ctx, workCreate); err != nil {
+		return errors.Wrap(err, "unable to create webhook subscribe work")
+	}
+
+	log.LoggerFromContext(ctx).Debug("created webhook subscribe work")
 	return nil
 }

--- a/oura/work/processors/processors_test.go
+++ b/oura/work/processors/processors_test.go
@@ -1,6 +1,8 @@
 package processors_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -10,8 +12,13 @@ import (
 	dataRawTest "github.com/tidepool-org/platform/data/raw/test"
 	dataSetTest "github.com/tidepool-org/platform/data/set/test"
 	dataSourceTest "github.com/tidepool-org/platform/data/source/test"
+	errorsTest "github.com/tidepool-org/platform/errors/test"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
 	ouraTest "github.com/tidepool-org/platform/oura/test"
+	ouraWebhookWorkSubscribe "github.com/tidepool-org/platform/oura/webhook/work/subscribe"
 	ouraWorkProcessors "github.com/tidepool-org/platform/oura/work/processors"
+	"github.com/tidepool-org/platform/work"
 	workBase "github.com/tidepool-org/platform/work/base"
 	workTest "github.com/tidepool-org/platform/work/test"
 )
@@ -99,15 +106,58 @@ var _ = Describe("processors", func() {
 				Expect(processorFactories).To(HaveLen(5))
 			})
 		})
+	})
 
-		Context("EnsureWork", func() {
-			It("returns an error if dependencies is invalid", func() {
-				dependencies.WorkClient = nil
-				Expect(ouraWorkProcessors.EnsureWork(dependencies)).To(MatchError("dependencies is invalid; work client is missing"))
+	Context("EnsureWork", func() {
+		var ctx context.Context
+		var mockController *gomock.Controller
+		var mockWorkClient *workTest.MockClient
+
+		BeforeEach(func() {
+			ctx = log.NewContextWithLogger(context.Background(), logTest.NewLogger())
+			mockController, ctx = gomock.WithContext(ctx, GinkgoT())
+			mockWorkClient = workTest.NewMockClient(mockController)
+		})
+
+		It("returns an error if context is missing", func() {
+			Expect(ouraWorkProcessors.EnsureWork(context.Context(nil), mockWorkClient)).To(MatchError("context is missing"))
+		})
+
+		It("returns an error if context is missing", func() {
+			Expect(ouraWorkProcessors.EnsureWork(ctx, nil)).To(MatchError("work client is missing"))
+		})
+
+		Context("with webhook subscribe work create", func() {
+			var webhookSubscribeWorkCreate *work.Create
+			var webhookSubscribeWork *work.Work
+
+			BeforeEach(func() {
+				var err error
+				webhookSubscribeWorkCreate, err = ouraWebhookWorkSubscribe.NewWorkCreate()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(webhookSubscribeWorkCreate).ToNot(BeNil())
+				webhookSubscribeWork = workTest.NewWorkFromCreateWithState(webhookSubscribeWorkCreate, work.StatePending)
+			})
+
+			It("returns error if the work client returns an error", func() {
+				testErr := errorsTest.RandomError()
+				mockWorkClient.EXPECT().
+					Create(gomock.Any(), gomock.Any()).
+					Do(func(ctx context.Context, create *work.Create) {
+						Expect(create).To(Equal(webhookSubscribeWorkCreate))
+					}).
+					Return(nil, testErr)
+				Expect(ouraWorkProcessors.EnsureWork(ctx, mockWorkClient)).To(MatchError("unable to create webhook subscribe work; " + testErr.Error()))
 			})
 
 			It("returns successfully", func() {
-				Expect(ouraWorkProcessors.EnsureWork(dependencies)).To(Succeed())
+				mockWorkClient.EXPECT().
+					Create(gomock.Any(), gomock.Any()).
+					Do(func(ctx context.Context, create *work.Create) {
+						Expect(create).To(Equal(webhookSubscribeWorkCreate))
+					}).
+					Return(webhookSubscribeWork, nil)
+				Expect(ouraWorkProcessors.EnsureWork(ctx, mockWorkClient)).To(Succeed())
 			})
 		})
 	})

--- a/request/parser.go
+++ b/request/parser.go
@@ -320,7 +320,7 @@ func ParseMediaTypeHeader(header http.Header, key string) (*string, error) {
 func ParseTimeHeader(header http.Header, key string, layout string) (*time.Time, error) {
 	if stringValue, err := ParseSingletonHeader(header, key); err != nil || stringValue == nil {
 		return nil, err
-	} else if value, valueErr := time.Parse(layout, *stringValue); valueErr == nil {
+	} else if value, valueErr := time.ParseInLocation(layout, *stringValue, time.UTC); valueErr == nil {
 		return &value, nil
 	}
 	return nil, ErrorHeaderInvalid(key)

--- a/request/values_parser.go
+++ b/request/values_parser.go
@@ -189,7 +189,7 @@ func (v *Values) Time(reference string, layout string) *time.Time {
 		return nil
 	}
 
-	timeValue, err := time.Parse(layout, rawValue)
+	timeValue, err := time.ParseInLocation(layout, rawValue, time.UTC)
 	if err != nil {
 		v.base.WithReference(reference).ReportError(structureParser.ErrorValueTimeNotParsable(rawValue, layout))
 		return nil

--- a/structure/parser/array_parser.go
+++ b/structure/parser/array_parser.go
@@ -219,7 +219,7 @@ func (a *Array) Time(reference int, layout string) *time.Time {
 			}
 
 			var err error
-			timeValue, err = time.Parse(layout, stringValue)
+			timeValue, err = time.ParseInLocation(layout, stringValue, time.UTC)
 			if err != nil {
 				a.base.WithReference(strconv.Itoa(reference)).ReportError(ErrorValueTimeNotParsable(stringValue, layout))
 				return nil

--- a/structure/parser/object_parser.go
+++ b/structure/parser/object_parser.go
@@ -221,7 +221,7 @@ func (o *Object) Time(reference string, layout string) *time.Time {
 			}
 
 			var err error
-			timeValue, err = time.Parse(layout, stringValue)
+			timeValue, err = time.ParseInLocation(layout, stringValue, time.UTC)
 			if err != nil {
 				o.base.WithReference(reference).ReportError(ErrorValueTimeNotParsable(stringValue, layout))
 				return nil

--- a/structure/validator/string.go
+++ b/structure/validator/string.go
@@ -203,7 +203,7 @@ func (s *String) AsTime(layout string) structure.Time {
 	var valueAsTime *time.Time
 
 	if s.value != nil {
-		if parsed, err := time.Parse(layout, *s.value); err != nil {
+		if parsed, err := time.ParseInLocation(layout, *s.value, time.UTC); err != nil {
 			s.base.ReportError(ErrorValueStringAsTimeNotValid(*s.value, layout))
 		} else {
 			valueAsTime = &parsed

--- a/test/array.go
+++ b/test/array.go
@@ -9,6 +9,14 @@ import (
 	gomegaTypes "github.com/onsi/gomega/types"
 )
 
+func AsAnyArray[T any, U ~[]T](array U) []any {
+	anyArray := make([]any, len(array))
+	for index, element := range array {
+		anyArray[index] = element
+	}
+	return anyArray
+}
+
 func MatchArray(elements ...interface{}) gomegaTypes.GomegaMatcher {
 	return &MatchArrayMatcher{
 		Elements: elements,

--- a/work/store/structured/mongo/mongo.go
+++ b/work/store/structured/mongo/mongo.go
@@ -319,15 +319,15 @@ func (s *Store) Create(ctx context.Context, create *work.Create) (*work.Work, er
 	ctx = context.WithoutCancel(ctx)
 
 	result, err := s.InsertOne(ctx, document)
-	lgr = lgr.WithError(err)
 	if err != nil {
 
 		// Return nil without error to indicate duplicate based upon type and deduplication id (see unique index above), but ok
 		if mongo.IsDuplicateKeyError(err) {
+			lgr.Debug("work with same type and deduplication id already exists")
 			return nil, nil
 		}
 
-		lgr.Error("unable to create work")
+		lgr.WithError(err).Error("unable to create work")
 		return nil, errors.Wrap(err, "unable to create work")
 	}
 


### PR DESCRIPTION
- Add Oura webhook subscriptions
- Add Oura partner endpoints
- Add webhook work to periodically check and renew subscriptions
- Add custom error parser for Oura response with status 422
- Add UpdateSubscription struct and function
- Add OuraClient to data service context
- Add bson tags throughout in case struct is captured in persisted error
- Use time.ParseInLocation with default location time.UTC
- Add various Oura data validations
- Fix bugs
- Add and update tests
- https://tidepool.atlassian.net/browse/BACK-4027
- https://tidepool.atlassian.net/browse/BACK-4028
- https://tidepool.atlassian.net/browse/BACK-4029