### PR TITLE
[BACK-4279] Fix for incorrectly computed summaries due to a truncation issue

### DIFF
--- a/summary/store/buckets.go
+++ b/summary/store/buckets.go
@@ -241,32 +241,6 @@ func (r *Buckets[PB, B]) GetOldestRecordTime(ctx context.Context, userId string)
 	return bucket.FirstData, nil
 }
 
-func (r *Buckets[PB, B]) GetTotalHours(ctx context.Context, userId string) (int, error) {
-	if ctx == nil {
-		return 0, errors.New("context is missing")
-	}
-	if userId == "" {
-		return 0, errors.New("userId is missing")
-	}
-
-	firstBucket, err := r.GetOldest(ctx, userId)
-	if err != nil {
-		return 0, err
-	}
-
-	// we have no buckets, no point in continuing
-	if firstBucket == nil {
-		return 0, nil
-	}
-
-	lastBucket, err := r.GetNewest(ctx, userId)
-	if err != nil {
-		return 0, err
-	}
-
-	return int(lastBucket.LastData.Sub(firstBucket.FirstData).Hours()), nil
-}
-
 func (r *Buckets[PB, B]) WriteModifiedBuckets(ctx context.Context, buckets types.BucketsByTime[PB, B]) error {
 	if ctx == nil {
 		return errors.New("context is missing")

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -229,23 +229,17 @@ func (gs *GlucoseSummarizer[PP, PB, P, B]) UpdateSummary(ctx context.Context, us
 		}
 
 		// this filters out users which may have appeared to have relevant data, but was filtered during calculation
-		totalHours, err := gs.buckets.GetTotalHours(sessionCtx, userId)
+		oldest, err := gs.buckets.GetOldestRecordTime(sessionCtx, userId)
 		if err != nil {
 			return nil, err
 		}
 
-		if totalHours == 0 {
-			logger.Warnf("User %s has a summary, but no valid data within range, creating placeholder summary", userId)
-			userSummary.Dates.Reset()
-			userSummary.Periods = nil
-		} else {
-			oldest, err := gs.buckets.GetOldestRecordTime(sessionCtx, userId)
-			if err != nil {
-				return nil, err
-			}
-			userSummary.Dates.Update(status, oldest)
+		if oldest.IsZero() {
+			logger.Warnf("User %s has a summary, but no valid data within range, deleting summary", userId)
+			return nil, gs.summaries.DeleteSummary(sessionCtx, userId)
 		}
 
+		userSummary.Dates.Update(status, oldest)
 		return userSummary, gs.summaries.ReplaceSummary(sessionCtx, userSummary)
 	})
 	if err != nil {

--- a/summary/summary_test.go
+++ b/summary/summary_test.go
@@ -318,11 +318,6 @@ var _ = Describe("End to end summary calculations", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cgmSummary).ToNot(BeNil())
 
-		totalHours, err := cgmBucketsStore.GetTotalHours(ctx, userId)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(totalHours).To(Equal(4))
-
 		// get the real summary stored to the db
 		cgmSummary, err = cgmSummarizer.GetSummary(ctx, userId)
 		Expect(err).ToNot(HaveOccurred())
@@ -409,11 +404,11 @@ var _ = Describe("End to end summary calculations", func() {
 
 		conSummary, err = continuousSummarizer.UpdateSummary(ctx, userId)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(conSummary).ToNot(BeNil())
-		Expect(conSummary.Dates.LastUpdatedDate.IsZero()).To(BeTrue())
-		Expect(conSummary.Dates.OutdatedSince).To(BeNil())
-		Expect(conSummary.Dates.LastData).To(BeZero())
-		Expect(conSummary.Periods).To(BeNil())
+		Expect(conSummary).To(BeNil())
+
+		conSummary, err = continuousSummarizer.GetSummary(ctx, userId)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(conSummary).To(BeNil())
 	})
 
 	It("summary calc with non-continuous data multiple times", func() {
@@ -430,19 +425,11 @@ var _ = Describe("End to end summary calculations", func() {
 
 		conSummary, err = continuousSummarizer.UpdateSummary(ctx, userId)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(conSummary).ToNot(BeNil())
-		Expect(conSummary.Dates.LastUpdatedDate.IsZero()).To(BeTrue())
-		Expect(conSummary.Dates.OutdatedSince).To(BeNil())
-		Expect(conSummary.Dates.LastData).To(BeZero())
-		Expect(conSummary.Periods).To(BeNil())
+		Expect(conSummary).To(BeNil())
 
 		conSummary, err = continuousSummarizer.UpdateSummary(ctx, userId)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(conSummary).ToNot(BeNil())
-		Expect(conSummary.Dates.LastUpdatedDate.IsZero()).To(BeTrue())
-		Expect(conSummary.Dates.OutdatedSince).To(BeNil())
-		Expect(conSummary.Dates.LastData).To(BeZero())
-		Expect(conSummary.Periods).To(BeNil())
+		Expect(conSummary).To(BeNil())
 	})
 
 	It("continuous summary calc with >batch of realtime data", func() {

--- a/summary/summary_test.go
+++ b/summary/summary_test.go
@@ -498,6 +498,38 @@ var _ = Describe("End to end summary calculations", func() {
 		Expect(len(buckets)).To(Equal(350))
 	})
 
+	It("bgm summary calc with data within a single hour produces valid summary", func() {
+		opts := options.BulkWrite().SetOrdered(false)
+
+		// Create 3 BGM records all within the same hour, minutes apart
+		glucoseValue := InTargetBloodGlucose
+		writeModels := make([]mongo.WriteModel, 3)
+		for i := 0; i < 3; i++ {
+			recordTime := datumTime.Add(-time.Duration(i+1) * 10 * time.Minute)
+			datum := NewGlucoseWithValue("smbg", recordTime, glucoseValue)
+			datum.UserID = &userId
+			writeModels[i] = mongo.NewInsertOneModel().SetDocument(datum)
+		}
+		_, err := dataCollection.BulkWrite(ctx, writeModels, opts)
+		Expect(err).ToNot(HaveOccurred())
+
+		bgmSummary, err = bgmSummarizer.UpdateSummary(ctx, userId)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(bgmSummary).ToNot(BeNil())
+
+		buckets := GetBuckets(ctx, userId, bgmBucketsStore)
+		Expect(len(buckets)).To(Equal(1))
+
+		Expect(bgmSummary.Periods).ToNot(BeNil())
+		Expect(bgmSummary.Periods.GlucosePeriods).ToNot(BeEmpty())
+		Expect(bgmSummary.Periods.GlucosePeriods["1d"]).ToNot(BeNil())
+		Expect(bgmSummary.Periods.GlucosePeriods["1d"].Total.Records).To(Equal(3))
+		Expect(bgmSummary.Dates.LastUpdatedDate.IsZero()).To(BeFalse())
+		Expect(bgmSummary.Dates.FirstData.IsZero()).To(BeFalse())
+		Expect(bgmSummary.Dates.LastData.IsZero()).To(BeFalse())
+		Expect(bgmSummary.Dates.OutdatedSince).To(BeNil())
+	})
+
 	It("cgm summary calc with the same data range twice, with new modifiedTime", func() {
 		opts := options.BulkWrite().SetOrdered(false)
 		hourAgo := time.Now().UTC().Truncate(time.Millisecond).Add(-time.Hour)

--- a/summary/types/continuous.go
+++ b/summary/types/continuous.go
@@ -88,7 +88,7 @@ func (p *ContinuousPeriod) Update(bucket *Bucket[*ContinuousBucket, ContinuousBu
 		return nil
 	}
 
-	if p.state.FirstCountedHour.IsZero() && p.state.FirstCountedHour.IsZero() {
+	if p.state.FirstCountedHour.IsZero() && p.state.LastCountedHour.IsZero() {
 		p.state.FirstCountedHour = bucket.Time
 		p.state.LastCountedHour = bucket.Time
 	} else {

--- a/summary/types/continuous_test.go
+++ b/summary/types/continuous_test.go
@@ -155,6 +155,29 @@ var _ = Describe("Continuous", func() {
 			Expect(period.Total.Records).To(Equal(1))
 		})
 
+		It("Add two buckets to an empty period in reverse order", func() {
+			datumTime := bucketTime.Add(5 * time.Minute)
+			period = ContinuousPeriod{}
+
+			// Add the newer bucket first (reverse chronological, matching real usage)
+			bucketTwo := NewBucket[*ContinuousBucket](userId, bucketTime.Add(time.Hour), SummaryTypeCGM)
+			err = bucketTwo.Update(NewRealtimeGlucose(datumTime.Add(time.Hour), InTargetBloodGlucose))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = period.Update(bucketTwo)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(period.Total.Records).To(Equal(1))
+
+			// Then add the older bucket
+			bucketOne := NewBucket[*ContinuousBucket](userId, bucketTime, SummaryTypeCGM)
+			err = bucketOne.Update(NewRealtimeGlucose(datumTime, InTargetBloodGlucose))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = period.Update(bucketOne)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(period.Total.Records).To(Equal(2))
+		})
+
 		It("Add duplicate buckets to a period", func() {
 			datumTime := bucketTime.Add(5 * time.Minute)
 			period = ContinuousPeriod{}


### PR DESCRIPTION
We need to clean up the database with the following mongo update:
```
db.summary.updateMany(
    {
      "type": "bgm",
      "dates.lastUpdatedDate": { "$eq": ISODate("0001-01-01T00:00:00Z") },
      "periods": {}
    },
    {
      "$set": { "dates.outdatedSince": new Date() },
      "$addToSet": { "dates.outdatedReason": "DATA_ADDED" }
    }
  )
  ```