### PR TITLE
[BACK-4324] Add ripple sub-consent

### DIFF
--- a/consent/consent.go
+++ b/consent/consent.go
@@ -19,6 +19,9 @@ const (
 	TypeMaxLength = 64
 
 	TypeBigDataDonationProject = "big_data_donation_project"
+	TypeRipple                 = "ripple"
+
+	MinimumBDDPVersionForRipple = 2
 
 	ContentTypeMarkdown ContentType = "markdown"
 )
@@ -86,6 +89,20 @@ func (p *Filter) Validate(validator structure.Validator) {
 	if p.Latest != nil {
 		typeValidator.Exists()
 		versionValidator.NotExists()
+	}
+}
+
+// DependentConsentTypes returns the consent types that must be revoked
+// when the given parent type and version is revoked.
+func DependentConsentTypes(parentType string, version int) []string {
+	switch parentType {
+	case TypeBigDataDonationProject:
+		if version >= MinimumBDDPVersionForRipple {
+			return []string{TypeRipple}
+		}
+		return nil
+	default:
+		return nil
 	}
 }
 

--- a/consent/consent.go
+++ b/consent/consent.go
@@ -22,6 +22,7 @@ const (
 	TypeRipple                 = "ripple"
 
 	MinimumBDDPVersionForRipple = 2
+	RippleVersionForJotform     = 1
 
 	ContentTypeMarkdown ContentType = "markdown"
 )

--- a/consent/consent_record.go
+++ b/consent/consent_record.go
@@ -42,6 +42,7 @@ const (
 type RecordAccessor interface {
 	GetConsentRecord(context.Context, string, string) (*Record, error)
 	CreateConsentRecord(context.Context, string, *RecordCreate) (*Record, error)
+	CreateConsentRecords(context.Context, string, []*RecordCreate) ([]*Record, error)
 	ListConsentRecords(context.Context, string, *RecordFilter, *page.Pagination) (*storeStructuredMongo.ListResult[Record], error)
 	RevokeConsentRecord(context.Context, string, *RecordRevoke) error
 	UpdateConsentRecord(context.Context, *Record) (*Record, error)

--- a/consent/consent_record.go
+++ b/consent/consent_record.go
@@ -41,6 +41,7 @@ const (
 
 type RecordAccessor interface {
 	GetConsentRecord(context.Context, string, string) (*Record, error)
+	GetActiveConsentRecord(context.Context, string, string) (*Record, error)
 	CreateConsentRecord(context.Context, string, *RecordCreate) (*Record, error)
 	CreateConsentRecords(context.Context, string, []*RecordCreate) ([]*Record, error)
 	ListConsentRecords(context.Context, string, *RecordFilter, *page.Pagination) (*storeStructuredMongo.ListResult[Record], error)

--- a/consent/loader/content/big_data_donation_project.v2.md
+++ b/consent/loader/content/big_data_donation_project.v2.md
@@ -1,0 +1,14 @@
+### Tidepool Big Data Donation Project
+
+# Informed Consent Form - Version 2
+
+**TITLE:**    Tidepool Big Data Donation Project Study Protocol
+
+**PROTOCOL NO.:**    None
+
+**SPONSOR:**    Tidepool Project
+
+**STUDY-RELATED**
+**EMAIL ADDRESS:**    bigdataofficer@tidepool.org
+
+Your participation in this study is voluntary. You may decide not to participate or you may leave the study at any time.

--- a/consent/loader/content/ripple.v1.md
+++ b/consent/loader/content/ripple.v1.md
@@ -1,0 +1,12 @@
+### RIPPLE Study
+
+# Informed Consent Form
+
+**TITLE:**    RIPPLE Study Consent
+
+**SPONSOR:**    Tidepool Project
+
+**STUDY-RELATED**
+**EMAIL ADDRESS:**    bigdataofficer@tidepool.org
+
+Your participation in this study is voluntary. You may decide not to participate or you may leave the study at any time.

--- a/consent/loader/loader_test.go
+++ b/consent/loader/loader_test.go
@@ -46,10 +46,10 @@ var _ = Describe("SeedConsents", func() {
 				// Verify the consent object is properly constructed
 				Expect(cons.ContentType).To(Equal(consent.ContentTypeMarkdown))
 				Expect(len(cons.Type)).To(BeNumerically(">", 0))
-				Expect(cons.Version).To(BeNumerically("==", 1))
+				Expect(cons.Version).To(BeNumerically(">", 0))
 				Expect(cons.Content).ToNot(BeEmpty())
 				return nil
-			}).Times(1)
+			}).Times(3)
 
 			err := loader.SeedConsents(ctx, logger, mockService)
 			Expect(err).ToNot(HaveOccurred())
@@ -62,21 +62,31 @@ var _ = Describe("SeedConsents", func() {
 				// Capture the consent for detailed verification
 				capturedConsents = append(capturedConsents, consent)
 				return nil
-			}).Times(1)
+			}).Times(3)
 
 			err := loader.SeedConsents(ctx, logger, mockService)
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify we captured
-			Expect(capturedConsents).To(HaveLen(1))
+			// Verify we captured all 3 consents
+			Expect(capturedConsents).To(HaveLen(3))
 
-			// Verify big_data_donation_project consent
-			tbddp := findConsentByType(capturedConsents, "big_data_donation_project")
-			Expect(tbddp).ToNot(BeNil())
-			Expect(string(tbddp.Type)).To(Equal("big_data_donation_project"))
-			Expect(tbddp.Version).To(Equal(1))
-			Expect(tbddp.ContentType).To(Equal(consent.ContentTypeMarkdown))
-			Expect(tbddp.Content).To(ContainSubstring("Tidepool Big Data Donation Project"))
+			// Verify big_data_donation_project v1 consent
+			tbddpV1 := findConsentByTypeAndVersion(capturedConsents, "big_data_donation_project", 1)
+			Expect(tbddpV1).ToNot(BeNil())
+			Expect(tbddpV1.ContentType).To(Equal(consent.ContentTypeMarkdown))
+			Expect(tbddpV1.Content).To(ContainSubstring("Tidepool Big Data Donation Project"))
+
+			// Verify big_data_donation_project v2 consent
+			tbddpV2 := findConsentByTypeAndVersion(capturedConsents, "big_data_donation_project", 2)
+			Expect(tbddpV2).ToNot(BeNil())
+			Expect(tbddpV2.ContentType).To(Equal(consent.ContentTypeMarkdown))
+			Expect(tbddpV2.Content).To(ContainSubstring("Tidepool Big Data Donation Project"))
+
+			// Verify ripple v1 consent
+			ripple := findConsentByTypeAndVersion(capturedConsents, "ripple", 1)
+			Expect(ripple).ToNot(BeNil())
+			Expect(ripple.ContentType).To(Equal(consent.ContentTypeMarkdown))
+			Expect(ripple.Content).To(ContainSubstring("RIPPLE"))
 		})
 	})
 
@@ -238,7 +248,16 @@ var _ = Describe("SeedConsents", func() {
 // Helper function to find consent by type
 func findConsentByType(consents []*consent.Consent, typeName string) *consent.Consent {
 	for _, c := range consents {
-		if string(c.Type) == typeName {
+		if c.Type == typeName {
+			return c
+		}
+	}
+	return nil
+}
+
+func findConsentByTypeAndVersion(consents []*consent.Consent, typeName string, version int) *consent.Consent {
+	for _, c := range consents {
+		if c.Type == typeName && c.Version == version {
 			return c
 		}
 	}

--- a/consent/service/consent.go
+++ b/consent/service/consent.go
@@ -112,7 +112,7 @@ func (c *ConsentService) CreateConsentRecords(ctx context.Context, userID string
 
 				if existing.Version == createWithConsent.create.Version {
 					return nil, errors.Newf("consent record for the same type and version already exists: %s v%d", create.Type, create.Version)
-				} else if existing.Version > create.Version {
+				} else if existing.Version > createWithConsent.create.Version {
 					return nil, errors.Newf("consent record for a greater version already exists: %s", create.Type)
 				}
 

--- a/consent/service/consent.go
+++ b/consent/service/consent.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"slices"
 
 	"github.com/tidepool-org/platform/log"
 
@@ -48,77 +49,119 @@ func (c *ConsentService) GetConsentRecord(ctx context.Context, userID string, id
 }
 
 func (c *ConsentService) CreateConsentRecord(ctx context.Context, userID string, create *consent.RecordCreate) (*consent.Record, error) {
-	pagination := page.NewPagination()
-	pagination.Size = 1
-
-	consents, err := c.ListConsents(ctx, &consent.Filter{
-		Type:    pointer.FromAny(create.Type),
-		Version: pointer.FromAny(create.Version),
-	}, pagination)
+	records, err := c.CreateConsentRecords(ctx, userID, []*consent.RecordCreate{create})
 	if err != nil {
 		return nil, err
 	}
-	if len(consents.Data) == 0 {
-		return nil, errors.New("invalid consent type and version combination")
-	}
-	cons := consents.Data[0]
+	return records[0], nil
+}
 
-	records, err := c.consentRecordRepository.ListConsentRecords(ctx, userID, &consent.RecordFilter{
-		Latest: pointer.FromAny(true),
-		Status: pointer.FromAny(consent.RecordStatusActive),
-		Type:   pointer.FromAny(create.Type),
-	}, pagination)
-	if err != nil {
-		return nil, err
+func (c *ConsentService) CreateConsentRecords(ctx context.Context, userID string, creates []*consent.RecordCreate) ([]*consent.Record, error) {
+	if len(creates) == 0 {
+		return nil, errors.New("creates is empty")
+	}
+
+	pagination := page.NewPaginationMinimum()
+
+	type createConsentRecord struct {
+		create  consent.RecordCreate
+		consent consent.Consent
+		record  *consent.Record
+	}
+
+	toCreate := make([]createConsentRecord, 0, len(creates))
+	for _, create := range creates {
+		consents, err := c.ListConsents(ctx, &consent.Filter{
+			Type:    pointer.FromAny(create.Type),
+			Version: pointer.FromAny(create.Version),
+		}, pagination)
+		if err != nil {
+			return nil, err
+		}
+		if len(consents.Data) == 0 {
+			return nil, errors.Newf("invalid consent type and version combination: %s v%d", create.Type, create.Version)
+		}
+		createWithConsent := createConsentRecord{
+			create:  *create,
+			consent: consents.Data[0],
+		}
+
+		records, err := c.consentRecordRepository.ListConsentRecords(ctx, userID, &consent.RecordFilter{
+			Latest: pointer.FromAny(true),
+			Status: pointer.FromAny(consent.RecordStatusActive),
+			Type:   pointer.FromAny(create.Type),
+		}, pagination)
+		if err != nil {
+			return nil, err
+		}
+		if len(records.Data) > 0 {
+			createWithConsent.record = pointer.FromAny(records.Data[0])
+		}
+		toCreate = append(toCreate, createWithConsent)
 	}
 
 	res, err := structuredMongo.WithTransaction(ctx, c.dbClient, func(sessCtx mongoDriver.SessionContext) (any, error) {
-		if len(records.Data) > 0 {
-			existing := &records.Data[0]
-			if existing.Version == create.Version {
-				return nil, errors.New("consent record for the same type and version already exists")
-			} else if existing.Version > create.Version {
-				return nil, errors.New("consent record for a greater version already exists")
+		records := make([]*consent.Record, 0, len(toCreate))
+		shareBDDP := false
+
+		for i, createWithConsent := range toCreate {
+			create := createWithConsent.create
+
+			if createWithConsent.record != nil {
+				existing := createWithConsent.record
+
+				if existing.Version == createWithConsent.create.Version {
+					return nil, errors.Newf("consent record for the same type and version already exists: %s v%d", create.Type, create.Version)
+				} else if existing.Version > create.Version {
+					return nil, errors.Newf("consent record for a greater version already exists: %s", create.Type)
+				}
+
+				revoke := consent.NewRecordRevoke()
+				revoke.ID = existing.ID
+				revoke.RevocationTime = existing.CreatedTime
+
+				err := c.consentRecordRepository.RevokeConsentRecord(sessCtx, userID, revoke)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to revoke existing consent record for type %s", create.Type)
+				}
 			}
 
-			revoke := consent.NewRecordRevoke()
-			revoke.ID = existing.ID
-			revoke.RevocationTime = existing.CreatedTime // Ensure non-interrupted stream of data on re-consent
-
-			err = c.consentRecordRepository.RevokeConsentRecord(sessCtx, userID, revoke)
+			record, err := c.consentRecordRepository.CreateConsentRecord(sessCtx, userID, &create)
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to revoke existing consent record for type %s", create.Type)
+				return nil, errors.Wrapf(err, "unable to create consent record for type %s", create.Type)
+			}
+
+			records = append(records, record)
+			toCreate[i].record = record
+
+			if create.Type == consent.TypeBigDataDonationProject {
+				shareBDDP = true
 			}
 		}
 
-		record, err := c.consentRecordRepository.CreateConsentRecord(sessCtx, userID, create)
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to create consent record for type %s", create.Type)
-		}
-
-		if create.Type == consent.TypeBigDataDonationProject {
-			err = c.bddpSharer.Share(sessCtx, userID)
-			if err != nil {
+		if shareBDDP {
+			if err := c.bddpSharer.Share(sessCtx, userID); err != nil {
 				return nil, errors.New("could not share data with bddp account after granting consent")
 			}
 		}
 
-		return record, err
+		return records, nil
 	})
-	if err != nil || res == nil {
+	if err != nil {
 		return nil, err
 	}
 
-	record := res.(*consent.Record)
-
-	// Sending an email is executed outside the transaction to prevent a failure from reverting the consent record
+	// Sending emails is executed outside the transaction to prevent a failure from reverting the consent record
 	// with an active sharing relationship
-	if err := c.consentMailer.SendConsentGrantedEmailNotification(ctx, cons, *record); err != nil {
+	for _, createWithConsent := range toCreate {
 		// Just log the error, there's no need to fail the request
-		c.logger.WithError(err).WithField("user", userID).Warn("unable to send email notification")
+		if err := c.consentMailer.SendConsentGrantedEmailNotification(ctx, createWithConsent.consent, *createWithConsent.record); err != nil {
+			c.logger.WithError(err).WithField("user", userID).Warn("unable to send email notification")
+		}
 	}
 
-	return record, nil
+	records := res.([]*consent.Record)
+	return records, nil
 }
 
 func (c *ConsentService) ListConsentRecords(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) (*structuredMongo.ListResult[consent.Record], error) {
@@ -126,42 +169,104 @@ func (c *ConsentService) ListConsentRecords(ctx context.Context, userID string, 
 }
 
 func (c *ConsentService) RevokeConsentRecord(ctx context.Context, userID string, revoke *consent.RecordRevoke) error {
+	if revoke == nil {
+		return errors.New("revoke is missing")
+	}
 	record, err := c.consentRecordRepository.GetConsentRecord(ctx, userID, revoke.ID)
 	if err != nil {
 		return errors.Wrapf(err, "consent record doesn't exist")
 	}
 
-	consents, err := c.ListConsents(ctx, &consent.Filter{
-		Type:    pointer.FromAny(record.Type),
-		Version: pointer.FromAny(record.Version),
-	}, page.NewPagination())
-	if err != nil {
-		return err
+	type recordRevokeConsent struct {
+		record  consent.Record
+		revoke  *consent.RecordRevoke
+		consent *consent.Consent
+	}
+
+	toRevoke := []recordRevokeConsent{{
+		record: *record,
+		revoke: revoke,
+	}}
+
+	// Get all dependent consent records that are active
+	dependentTypes := consent.DependentConsentTypes(record.Type, record.Version)
+	for _, dependentType := range dependentTypes {
+		records, err := c.consentRecordRepository.ListConsentRecords(ctx, userID, &consent.RecordFilter{
+			Latest: pointer.FromAny(true),
+			Status: pointer.FromAny(consent.RecordStatusActive),
+			Type:   pointer.FromAny(dependentType),
+		}, page.NewPaginationMinimum())
+		if err != nil {
+			return errors.Wrapf(err, "unable to list dependent consent records for type %s", dependentType)
+		}
+		if len(records.Data) > 0 {
+			dependentRevoke := consent.NewRecordRevoke()
+			dependentRevoke.ID = records.Data[0].ID
+			dependentRevoke.RevocationTime = revoke.RevocationTime // Use the same revocation time as the original revoke
+
+			toRevoke = append(toRevoke, recordRevokeConsent{
+				record: records.Data[0],
+				revoke: dependentRevoke,
+			})
+		}
+	}
+
+	unshareBDDP := false
+	for i := range toRevoke {
+		if toRevoke[i].record.Type == consent.TypeBigDataDonationProject {
+			unshareBDDP = true
+		}
+
+		// Get the corresponding consent so we can send the email notification
+		consents, err := c.ListConsents(ctx, &consent.Filter{
+			Type:    pointer.FromAny(toRevoke[i].record.Type),
+			Version: pointer.FromAny(toRevoke[i].record.Version),
+		}, page.NewPaginationMinimum())
+		if err != nil {
+			return errors.Wrapf(err, "unable to list consents for type %s", toRevoke[i].record.Type)
+		}
+		if len(consents.Data) == 0 {
+			continue
+		}
+		toRevoke[i].consent = pointer.FromAny(consents.Data[0])
 	}
 
 	_, err = structuredMongo.WithTransaction(ctx, c.dbClient, func(sessCtx mongoDriver.SessionContext) (any, error) {
-		if err := c.consentRecordRepository.RevokeConsentRecord(sessCtx, userID, revoke); err != nil {
-			return nil, err
+		for _, r := range toRevoke {
+			if err := c.consentRecordRepository.RevokeConsentRecord(sessCtx, userID, r.revoke); err != nil {
+				return nil, err
+			}
+
+			if r.consent == nil {
+				c.logger.
+					WithFields(log.Fields{"user": userID, "type": r.record.Type, "version": r.record.Version}).
+					Warn("revoked consent record for an unknown consent type and version")
+			}
 		}
-		if record.Type == consent.TypeBigDataDonationProject {
+
+		// Unshare the data if BDDP was revoked. If this fails, the transaction will be reverted.
+		if unshareBDDP {
 			err = c.bddpSharer.Unshare(sessCtx, userID)
 			if err != nil {
 				return nil, errors.New("could not unshare data with bddp account after revoking consent")
 			}
 		}
+
 		return nil, nil
 	})
 
-	if len(consents.Data) == 0 {
-		c.logger.WithField("user", userID).Warn("revoking record for missing consent type and version")
-		return nil
-	}
+	// Filter out any revoked consent records that don't have a corresponding consent content
+	toRevoke = slices.DeleteFunc(toRevoke, func(r recordRevokeConsent) bool {
+		return r.consent == nil
+	})
 
 	// Sending an email is executed outside the transaction to prevent a failure from reverting the consent record
 	// revocation
-	if err := c.consentMailer.SendConsentRevokedEmailNotification(ctx, consents.Data[0], *record); err != nil {
-		// Just log the error, there's no need to fail the request
-		c.logger.WithError(err).WithField("user", userID).Warn("unable to send email notification")
+	for _, r := range toRevoke {
+		if err := c.consentMailer.SendConsentRevokedEmailNotification(ctx, *r.consent, r.record); err != nil {
+			// Just log the error, there's no need to fail the entire request
+			c.logger.WithError(err).WithField("user", userID).Warn("unable to send email notification")
+		}
 	}
 
 	return nil

--- a/consent/service/consent.go
+++ b/consent/service/consent.go
@@ -86,16 +86,9 @@ func (c *ConsentService) CreateConsentRecords(ctx context.Context, userID string
 			consent: consents.Data[0],
 		}
 
-		records, err := c.consentRecordRepository.ListConsentRecords(ctx, userID, &consent.RecordFilter{
-			Latest: pointer.FromAny(true),
-			Status: pointer.FromAny(consent.RecordStatusActive),
-			Type:   pointer.FromAny(create.Type),
-		}, pagination)
+		createWithConsent.record, err = c.GetActiveConsentRecord(ctx, userID, create.Type)
 		if err != nil {
-			return nil, err
-		}
-		if len(records.Data) > 0 {
-			createWithConsent.record = pointer.FromAny(records.Data[0])
+			return nil, errors.Wrap(err, "unable to get active consent record")
 		}
 		toCreate = append(toCreate, createWithConsent)
 	}
@@ -110,9 +103,9 @@ func (c *ConsentService) CreateConsentRecords(ctx context.Context, userID string
 			if createWithConsent.record != nil {
 				existing := createWithConsent.record
 
-				if existing.Version == createWithConsent.create.Version {
+				if existing.Version == create.Version {
 					return nil, errors.Newf("consent record for the same type and version already exists: %s v%d", create.Type, create.Version)
-				} else if existing.Version > createWithConsent.create.Version {
+				} else if existing.Version > create.Version {
 					return nil, errors.Newf("consent record for a greater version already exists: %s", create.Type)
 				}
 
@@ -164,6 +157,10 @@ func (c *ConsentService) CreateConsentRecords(ctx context.Context, userID string
 	return records, nil
 }
 
+func (c *ConsentService) GetActiveConsentRecord(ctx context.Context, userID string, typ string) (*consent.Record, error) {
+	return c.consentRecordRepository.GetActiveConsentRecord(ctx, userID, typ)
+}
+
 func (c *ConsentService) ListConsentRecords(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) (*structuredMongo.ListResult[consent.Record], error) {
 	return c.consentRecordRepository.ListConsentRecords(ctx, userID, filter, pagination)
 }
@@ -191,24 +188,22 @@ func (c *ConsentService) RevokeConsentRecord(ctx context.Context, userID string,
 	// Get all dependent consent records that are active
 	dependentTypes := consent.DependentConsentTypes(record.Type, record.Version)
 	for _, dependentType := range dependentTypes {
-		records, err := c.consentRecordRepository.ListConsentRecords(ctx, userID, &consent.RecordFilter{
-			Latest: pointer.FromAny(true),
-			Status: pointer.FromAny(consent.RecordStatusActive),
-			Type:   pointer.FromAny(dependentType),
-		}, page.NewPaginationMinimum())
+		dependent, err := c.GetActiveConsentRecord(ctx, userID, dependentType)
 		if err != nil {
-			return errors.Wrapf(err, "unable to list dependent consent records for type %s", dependentType)
+			return errors.Wrapf(err, "unable to get active consent record for dependent type %s", dependentType)
 		}
-		if len(records.Data) > 0 {
-			dependentRevoke := consent.NewRecordRevoke()
-			dependentRevoke.ID = records.Data[0].ID
-			dependentRevoke.RevocationTime = revoke.RevocationTime // Use the same revocation time as the original revoke
+		if dependent == nil {
+			continue
+		}
 
-			toRevoke = append(toRevoke, recordRevokeConsent{
-				record: records.Data[0],
-				revoke: dependentRevoke,
-			})
-		}
+		dependentRevoke := consent.NewRecordRevoke()
+		dependentRevoke.ID = dependent.ID
+		dependentRevoke.RevocationTime = revoke.RevocationTime // Use the same revocation time as the original revoke
+
+		toRevoke = append(toRevoke, recordRevokeConsent{
+			record: *dependent,
+			revoke: dependentRevoke,
+		})
 	}
 
 	unshareBDDP := false

--- a/consent/service/consent_test.go
+++ b/consent/service/consent_test.go
@@ -282,6 +282,48 @@ var _ = Describe("ConsentService", func() {
 		})
 	})
 
+	Describe("GetActiveConsentRecord", func() {
+		var userID string
+
+		BeforeEach(func() {
+			usr := userTest.RandomUser()
+			userID = *usr.UserID
+
+			creates := []*consent.RecordCreate{
+				test.RandomRecordCreateForConsent(test.ConsentV1),
+				test.RandomRecordCreateForConsent(test.ConsentV2),
+				test.RandomRecordCreateForConsent(test.AnotherConsentV1),
+			}
+			for i, create := range creates {
+				SetConsentGrantedMailerExpectations(mailer, userClient, usr, create)
+
+				create.CreatedTime = create.CreatedTime.Add(-time.Duration(len(creates)-i) * time.Second)
+				created, err := consentService.CreateConsentRecord(ctx(), userID, create)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).ToNot(BeNil())
+			}
+		})
+
+		It("should return latest consent record for each type", func() {
+			type expectedVersion struct {
+				typ     string
+				version int
+			}
+			expectations := []expectedVersion{
+				{test.ConsentV2.Type, test.ConsentV2.Version},
+				{test.AnotherConsentV1.Type, test.AnotherConsentV1.Version},
+			}
+
+			for _, expectation := range expectations {
+				record, err := consentService.GetActiveConsentRecord(ctx(), userID, expectation.typ)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(record).ToNot(BeNil())
+				Expect(record.Type).To(Equal(expectation.typ))
+				Expect(record.Version).To(Equal(expectation.version))
+			}
+		})
+	})
+
 	Describe("ListConsentRecords", func() {
 		var userID string
 

--- a/consent/service/consent_test.go
+++ b/consent/service/consent_test.go
@@ -81,6 +81,8 @@ var _ = Describe("ConsentService", func() {
 		Expect(consentService.EnsureConsent(ctx(), test.ConsentV2)).To(Succeed())
 		Expect(consentService.EnsureConsent(ctx(), test.AnotherConsentV1)).To(Succeed())
 		Expect(consentService.EnsureConsent(ctx(), test.MockBDDPConsentV1)).To(Succeed())
+		Expect(consentService.EnsureConsent(ctx(), test.MockBDDPConsentV2)).To(Succeed())
+		Expect(consentService.EnsureConsent(ctx(), test.MockRippleConsentV1)).To(Succeed())
 	})
 
 	AfterEach(func() {
@@ -124,13 +126,15 @@ var _ = Describe("ConsentService", func() {
 		It("should return all consents with an empty filter", func() {
 			result, err := consentService.ListConsents(ctx(), &consent.Filter{}, page.NewPagination())
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(result.Count).To(Equal(4))
-			Expect(result.Data).To(HaveLen(4))
+			Expect(result.Count).To(Equal(6))
+			Expect(result.Data).To(HaveLen(6))
 			Expect(result.Data).To(ConsistOf(
 				test.MatchConsent(*test.ConsentV2),
 				test.MatchConsent(*test.ConsentV1),
 				test.MatchConsent(*test.AnotherConsentV1),
 				test.MatchConsent(*test.MockBDDPConsentV1),
+				test.MatchConsent(*test.MockBDDPConsentV2),
+				test.MatchConsent(*test.MockRippleConsentV1),
 			))
 		})
 
@@ -139,9 +143,11 @@ var _ = Describe("ConsentService", func() {
 			pagination.Page = 1
 			pagination.Size = 1
 
-			result, err := consentService.ListConsents(ctx(), &consent.Filter{}, pagination)
+			result, err := consentService.ListConsents(ctx(), &consent.Filter{
+				Type: pointer.FromAny("test_consent"),
+			}, pagination)
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(result.Count).To(Equal(4))
+			Expect(result.Count).To(Equal(2))
 			Expect(result.Data).To(HaveLen(1))
 			Expect(result.Data).To(ConsistOf(test.MatchConsent(*test.ConsentV1)))
 		})
@@ -235,7 +241,7 @@ var _ = Describe("ConsentService", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = consentService.CreateConsentRecord(ctx(), userID, create)
-			Expect(err).To(MatchError("consent record for the same type and version already exists"))
+			Expect(err).To(MatchError("consent record for the same type and version already exists: test_consent v2"))
 		})
 
 		It("should return an error if consent with a greater version already exists", func() {
@@ -248,7 +254,7 @@ var _ = Describe("ConsentService", func() {
 
 			create.Version = test.ConsentV1.Version
 			_, err = consentService.CreateConsentRecord(ctx(), userID, create)
-			Expect(err).To(MatchError("consent record for a greater version already exists"))
+			Expect(err).To(MatchError("consent record for a greater version already exists: test_consent"))
 		})
 
 		It("should revoke consents with a lower version of the same type", func() {
@@ -542,6 +548,171 @@ var _ = Describe("ConsentService", func() {
 			Expect(revoked.Status).To(Equal(consent.RecordStatusRevoked))
 			Expect(revoked.RevocationTime).To(PointTo(BeTemporally("~", time.Now(), time.Minute)))
 			Expect(revoked.ModifiedTime).To(BeTemporally("~", time.Now(), time.Minute))
+		})
+	})
+
+	Describe("CreateConsentRecords", func() {
+		var userID string
+		var usr *user.User
+
+		BeforeEach(func() {
+			usr = userTest.RandomUser()
+			userID = *usr.UserID
+		})
+
+		It("should create multiple consent records atomically", func() {
+			bddpCreate := test.RandomRecordCreateForConsent(test.MockBDDPConsentV2)
+			rippleCreate := test.RandomRecordCreateForConsent(test.MockRippleConsentV1)
+
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, bddpCreate)
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, rippleCreate)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			records, err := consentService.CreateConsentRecords(ctx(), userID, []*consent.RecordCreate{bddpCreate, rippleCreate})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(records).To(HaveLen(2))
+			Expect(records[0].Type).To(Equal(consent.TypeBigDataDonationProject))
+			Expect(records[0].Version).To(Equal(2))
+			Expect(records[1].Type).To(Equal(consent.TypeRipple))
+			Expect(records[1].Version).To(Equal(1))
+		})
+
+		It("should revoke BDDP v1 when creating BDDP v2 as part of batch", func() {
+			v1Create := test.RandomRecordCreateForConsent(test.MockBDDPConsentV1)
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, v1Create)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			v1, err := consentService.CreateConsentRecord(ctx(), userID, v1Create)
+			Expect(err).ToNot(HaveOccurred())
+
+			bddpCreate := test.RandomRecordCreateForConsent(test.MockBDDPConsentV2)
+			rippleCreate := test.RandomRecordCreateForConsent(test.MockRippleConsentV1)
+
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, bddpCreate)
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, rippleCreate)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			records, err := consentService.CreateConsentRecords(ctx(), userID, []*consent.RecordCreate{bddpCreate, rippleCreate})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(records).To(HaveLen(2))
+
+			revoked, err := consentService.GetConsentRecord(ctx(), userID, v1.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(revoked.Status).To(Equal(consent.RecordStatusRevoked))
+		})
+
+		It("should return an error if consent type is invalid", func() {
+			create := test.RandomRecordCreateForConsent(test.MockBDDPConsentV2)
+			create.Type = "invalid"
+
+			_, err := consentService.CreateConsentRecords(ctx(), userID, []*consent.RecordCreate{create})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("RevokeConsentRecord - cascade", func() {
+		var userID string
+		var usr *user.User
+
+		BeforeEach(func() {
+			usr = userTest.RandomUser()
+			userID = *usr.UserID
+		})
+
+		It("should cascade revoke RIPPLE when BDDP v2 is revoked", func() {
+			bddpCreate := test.RandomRecordCreateForConsent(test.MockBDDPConsentV2)
+			rippleCreate := test.RandomRecordCreateForConsent(test.MockRippleConsentV1)
+
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, bddpCreate)
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, rippleCreate)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			records, err := consentService.CreateConsentRecords(ctx(), userID, []*consent.RecordCreate{bddpCreate, rippleCreate})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(records).To(HaveLen(2))
+
+			bddpRecord := records[0]
+			rippleRecord := records[1]
+
+			revoke := consent.NewRecordRevoke()
+			revoke.ID = bddpRecord.ID
+
+			SetConsentRevokedMailerExpectations(mailer, userClient, usr, bddpRecord)
+			SetConsentRevokedMailerExpectations(mailer, userClient, usr, rippleRecord)
+			bddp.EXPECT().Unshare(gomock.Any(), userID).Return(nil)
+
+			Expect(consentService.RevokeConsentRecord(ctx(), userID, revoke)).To(Succeed())
+
+			revokedBDDP, err := consentService.GetConsentRecord(ctx(), userID, bddpRecord.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(revokedBDDP.Status).To(Equal(consent.RecordStatusRevoked))
+
+			revokedRipple, err := consentService.GetConsentRecord(ctx(), userID, rippleRecord.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(revokedRipple.Status).To(Equal(consent.RecordStatusRevoked))
+		})
+
+		It("should succeed when revoking BDDP v2 with no active RIPPLE", func() {
+			bddpCreate := test.RandomRecordCreateForConsent(test.MockBDDPConsentV2)
+
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, bddpCreate)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			bddpRecord, err := consentService.CreateConsentRecord(ctx(), userID, bddpCreate)
+			Expect(err).ToNot(HaveOccurred())
+
+			revoke := consent.NewRecordRevoke()
+			revoke.ID = bddpRecord.ID
+
+			SetConsentRevokedMailerExpectations(mailer, userClient, usr, bddpRecord)
+			bddp.EXPECT().Unshare(gomock.Any(), userID).Return(nil)
+
+			Expect(consentService.RevokeConsentRecord(ctx(), userID, revoke)).To(Succeed())
+		})
+
+		It("should not cascade when revoking RIPPLE alone", func() {
+			bddpCreate := test.RandomRecordCreateForConsent(test.MockBDDPConsentV2)
+			rippleCreate := test.RandomRecordCreateForConsent(test.MockRippleConsentV1)
+
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, bddpCreate)
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, rippleCreate)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			records, err := consentService.CreateConsentRecords(ctx(), userID, []*consent.RecordCreate{bddpCreate, rippleCreate})
+			Expect(err).ToNot(HaveOccurred())
+
+			bddpRecord := records[0]
+			rippleRecord := records[1]
+
+			revoke := consent.NewRecordRevoke()
+			revoke.ID = rippleRecord.ID
+
+			SetConsentRevokedMailerExpectations(mailer, userClient, usr, rippleRecord)
+
+			Expect(consentService.RevokeConsentRecord(ctx(), userID, revoke)).To(Succeed())
+
+			// BDDP should still be active
+			activeBDDP, err := consentService.GetConsentRecord(ctx(), userID, bddpRecord.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(activeBDDP.Status).To(Equal(consent.RecordStatusActive))
+		})
+
+		It("should not cascade when revoking BDDP v1", func() {
+			bddpCreate := test.RandomRecordCreateForConsent(test.MockBDDPConsentV1)
+
+			SetConsentGrantedMailerExpectations(mailer, userClient, usr, bddpCreate)
+			bddp.EXPECT().Share(gomock.Any(), userID).Return(nil)
+
+			bddpRecord, err := consentService.CreateConsentRecord(ctx(), userID, bddpCreate)
+			Expect(err).ToNot(HaveOccurred())
+
+			revoke := consent.NewRecordRevoke()
+			revoke.ID = bddpRecord.ID
+
+			SetConsentRevokedMailerExpectations(mailer, userClient, usr, bddpRecord)
+			bddp.EXPECT().Unshare(gomock.Any(), userID).Return(nil)
+
+			Expect(consentService.RevokeConsentRecord(ctx(), userID, revoke)).To(Succeed())
 		})
 	})
 })

--- a/consent/service/test/consent.go
+++ b/consent/service/test/consent.go
@@ -47,6 +47,22 @@ var MockBDDPConsentV1 = &consent.Consent{
 	CreatedTime: time.Now().UTC(),
 }
 
+var MockBDDPConsentV2 = &consent.Consent{
+	Type:        "big_data_donation_project",
+	Version:     2,
+	Content:     "# Tidepool BDDP Consent - version 2",
+	ContentType: "markdown",
+	CreatedTime: time.Now().UTC(),
+}
+
+var MockRippleConsentV1 = &consent.Consent{
+	Type:        "ripple",
+	Version:     1,
+	Content:     "# RIPPLE Consent - version 1",
+	ContentType: "markdown",
+	CreatedTime: time.Now().UTC(),
+}
+
 func MatchConsent(cons consent.Consent) types.GomegaMatcher {
 	return MatchFields(IgnoreExtras, Fields{
 		"Type":        Equal(cons.Type),

--- a/consent/store/mongo/consent_record_repository.go
+++ b/consent/store/mongo/consent_record_repository.go
@@ -22,8 +22,8 @@ type ConsentRecordRepository struct {
 	*storeStructuredMongo.Repository
 }
 
-func (p *ConsentRecordRepository) EnsureIndexes() error {
-	return p.CreateAllIndexes(context.Background(), []mongo.IndexModel{
+func (c *ConsentRecordRepository) EnsureIndexes() error {
+	return c.CreateAllIndexes(context.Background(), []mongo.IndexModel{
 		{
 			Keys: bson.D{
 				{Key: "userId", Value: 1},
@@ -57,14 +57,14 @@ func (p *ConsentRecordRepository) EnsureIndexes() error {
 	})
 }
 
-func (p *ConsentRecordRepository) GetConsentRecord(ctx context.Context, userID string, id string) (*consent.Record, error) {
+func (c *ConsentRecordRepository) GetConsentRecord(ctx context.Context, userID string, id string) (*consent.Record, error) {
 	selector := bson.M{
 		"userId": userID,
 		"id":     id,
 	}
 
 	consentRecord := &consent.Record{}
-	err := p.FindOne(ctx, selector).Decode(consentRecord)
+	err := c.FindOne(ctx, selector).Decode(consentRecord)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, nil
 	} else if err != nil {
@@ -74,7 +74,7 @@ func (p *ConsentRecordRepository) GetConsentRecord(ctx context.Context, userID s
 	return consentRecord, nil
 }
 
-func (p *ConsentRecordRepository) ListConsentRecords(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) (*storeStructuredMongo.ListResult[consent.Record], error) {
+func (c *ConsentRecordRepository) ListConsentRecords(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) (*storeStructuredMongo.ListResult[consent.Record], error) {
 	if filter == nil {
 		filter = consent.NewRecordFilter()
 	} else if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(filter); err != nil {
@@ -117,7 +117,7 @@ func (p *ConsentRecordRepository) ListConsentRecords(ctx context.Context, userID
 		pipeline = listAllConsentRecordsPipeline(selector, sort, *pagination)
 	}
 
-	cursor, err := p.Aggregate(ctx, pipeline)
+	cursor, err := c.Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list consent records")
 	}
@@ -134,7 +134,7 @@ func (p *ConsentRecordRepository) ListConsentRecords(ctx context.Context, userID
 	return &result, nil
 }
 
-func (p *ConsentRecordRepository) CreateConsentRecord(ctx context.Context, userID string, create *consent.RecordCreate) (*consent.Record, error) {
+func (c *ConsentRecordRepository) CreateConsentRecord(ctx context.Context, userID string, create *consent.RecordCreate) (*consent.Record, error) {
 	consentRecord, err := consent.NewRecord(ctx, userID, create)
 	if err != nil {
 		return nil, err
@@ -144,25 +144,38 @@ func (p *ConsentRecordRepository) CreateConsentRecord(ctx context.Context, userI
 
 	logger := log.LoggerFromContext(ctx).WithFields(log.Fields{"userId": userID, "create": create})
 
-	result, err := p.ListConsentRecords(ctx, userID, &consent.RecordFilter{
-		Type:   pointer.FromAny(create.Type),
+	existing, err := c.GetActiveConsentRecord(ctx, userID, consentRecord.Type)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get existing active consent record")
+	} else if existing != nil {
+		return nil, errors.Newf("active consent record with type %s already exists", consentRecord.Type)
+	}
+
+	_, err = c.InsertOne(ctx, consentRecord)
+	logger.WithFields(log.Fields{"id": consentRecord.ID}).WithError(err).Debug("CreateConsentRecord")
+
+	return consentRecord, err
+}
+
+func (c *ConsentRecordRepository) GetActiveConsentRecord(ctx context.Context, userID string, typ string) (*consent.Record, error) {
+	records, err := c.ListConsentRecords(ctx, userID, &consent.RecordFilter{
+		Type:   pointer.FromAny(typ),
 		Latest: pointer.FromAny(true),
 		Status: pointer.FromAny(consent.RecordStatusActive),
 	}, &page.Pagination{Page: 0, Size: 1})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list existing active consent records for type")
 	}
-	if len(result.Data) > 0 {
-		return nil, errors.Newf("active consent record with type %s already exists", consentRecord.Type)
+
+	var record *consent.Record
+	if records.Count > 0 {
+		record = &records.Data[0]
 	}
 
-	_, err = p.InsertOne(ctx, consentRecord)
-	logger.WithFields(log.Fields{"id": consentRecord.ID}).WithError(err).Debug("CreateConsentRecord")
-
-	return consentRecord, err
+	return record, nil
 }
 
-func (p *ConsentRecordRepository) RevokeConsentRecord(ctx context.Context, userID string, revoke *consent.RecordRevoke) error {
+func (c *ConsentRecordRepository) RevokeConsentRecord(ctx context.Context, userID string, revoke *consent.RecordRevoke) error {
 	if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(revoke); err != nil {
 		return errors.Wrap(err, "revoke is invalid")
 	}
@@ -185,7 +198,7 @@ func (p *ConsentRecordRepository) RevokeConsentRecord(ctx context.Context, userI
 		},
 	}
 
-	result, err := p.UpdateOne(ctx, selector, update)
+	result, err := c.UpdateOne(ctx, selector, update)
 	if err != nil {
 		return errors.Wrap(err, "unable to revoke existing consent record")
 	}
@@ -197,7 +210,7 @@ func (p *ConsentRecordRepository) RevokeConsentRecord(ctx context.Context, userI
 	return nil
 }
 
-func (p *ConsentRecordRepository) UpdateConsentRecord(ctx context.Context, consentRecord *consent.Record) (*consent.Record, error) {
+func (c *ConsentRecordRepository) UpdateConsentRecord(ctx context.Context, consentRecord *consent.Record) (*consent.Record, error) {
 	if err := structureValidator.New(log.LoggerFromContext(ctx)).Validate(consentRecord); err != nil {
 		return nil, errors.Wrap(err, "consent record is invalid")
 	}
@@ -213,7 +226,7 @@ func (p *ConsentRecordRepository) UpdateConsentRecord(ctx context.Context, conse
 		"$set": consentRecord,
 	}
 
-	result, err := p.UpdateOne(ctx, selector, update)
+	result, err := c.UpdateOne(ctx, selector, update)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update existing consent record")
 	}

--- a/consent/test/service_mocks.go
+++ b/consent/test/service_mocks.go
@@ -88,6 +88,21 @@ func (mr *MockServiceMockRecorder) EnsureConsent(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureConsent", reflect.TypeOf((*MockService)(nil).EnsureConsent), arg0, arg1)
 }
 
+// GetActiveConsentRecord mocks base method.
+func (m *MockService) GetActiveConsentRecord(arg0 context.Context, arg1, arg2 string) (*consent.Record, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveConsentRecord", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*consent.Record)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActiveConsentRecord indicates an expected call of GetActiveConsentRecord.
+func (mr *MockServiceMockRecorder) GetActiveConsentRecord(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveConsentRecord", reflect.TypeOf((*MockService)(nil).GetActiveConsentRecord), arg0, arg1, arg2)
+}
+
 // GetConsentRecord mocks base method.
 func (m *MockService) GetConsentRecord(arg0 context.Context, arg1, arg2 string) (*consent.Record, error) {
 	m.ctrl.T.Helper()

--- a/consent/test/service_mocks.go
+++ b/consent/test/service_mocks.go
@@ -59,6 +59,21 @@ func (mr *MockServiceMockRecorder) CreateConsentRecord(arg0, arg1, arg2 any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConsentRecord", reflect.TypeOf((*MockService)(nil).CreateConsentRecord), arg0, arg1, arg2)
 }
 
+// CreateConsentRecords mocks base method.
+func (m *MockService) CreateConsentRecords(arg0 context.Context, arg1 string, arg2 []*consent.RecordCreate) ([]*consent.Record, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateConsentRecords", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*consent.Record)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateConsentRecords indicates an expected call of CreateConsentRecords.
+func (mr *MockServiceMockRecorder) CreateConsentRecords(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateConsentRecords", reflect.TypeOf((*MockService)(nil).CreateConsentRecords), arg0, arg1, arg2)
+}
+
 // EnsureConsent mocks base method.
 func (m *MockService) EnsureConsent(arg0 context.Context, arg1 *consent.Consent) error {
 	m.ctrl.T.Helper()

--- a/oura/jotform/processor.go
+++ b/oura/jotform/processor.go
@@ -300,7 +300,7 @@ func (s *SubmissionProcessor) ensureConsentRecordExists(ctx context.Context, use
 	if err != nil {
 		return errors.Wrap(err, "unable to get active ripple consent record")
 	}
-	if rippleRecord != nil && rippleRecord.Version <= consent.RippleVersionForJotform {
+	if rippleRecord != nil && rippleRecord.Version >= consent.RippleVersionForJotform {
 		// If RIPPLE already exists, BDDP must also exist - nothing to do
 		logger.WithField("userId", userID).Info("ripple consent record already exists")
 		return nil

--- a/oura/jotform/processor.go
+++ b/oura/jotform/processor.go
@@ -296,33 +296,21 @@ func (s *SubmissionProcessor) ensureConsentRecordExists(ctx context.Context, use
 
 	creates := make([]*consent.RecordCreate, 0)
 
-	rippleFilter := consent.NewRecordFilter()
-	rippleFilter.Latest = pointer.FromAny(true)
-	rippleFilter.Status = pointer.FromAny(consent.RecordStatusActive)
-	rippleFilter.Type = pointer.FromAny(consent.TypeRipple)
-	rippleFilter.Version = pointer.FromAny(consent.RippleVersionForJotform)
-
-	rippleRecords, err := s.consentService.ListConsentRecords(ctx, userID, rippleFilter, page.NewPaginationMinimum())
+	rippleRecord, err := s.consentService.GetActiveConsentRecord(ctx, userID, consent.TypeRipple)
 	if err != nil {
-		return errors.Wrap(err, "unable to list ripple consent records")
+		return errors.Wrap(err, "unable to get active ripple consent record")
 	}
-	if rippleRecords.Count > 0 {
-		// If RIPPLE v1 already exists, BDDP v2 must also exist - nothing to do
+	if rippleRecord != nil && rippleRecord.Version <= consent.RippleVersionForJotform {
+		// If RIPPLE already exists, BDDP must also exist - nothing to do
 		logger.WithField("userId", userID).Info("ripple consent record already exists")
 		return nil
 	}
 
-	bddpFilter := consent.NewRecordFilter()
-	bddpFilter.Latest = pointer.FromAny(true)
-	bddpFilter.Status = pointer.FromAny(consent.RecordStatusActive)
-	bddpFilter.Type = pointer.FromAny(consent.TypeBigDataDonationProject)
-
-	bddpRecords, err := s.consentService.ListConsentRecords(ctx, userID, bddpFilter, page.NewPaginationMinimum())
+	bddpRecord, err := s.consentService.GetActiveConsentRecord(ctx, userID, consent.TypeBigDataDonationProject)
 	if err != nil {
-		return errors.Wrap(err, "unable to list bddp consent records")
+		return errors.Wrap(err, "unable to get active bddp consent record")
 	}
-
-	if bddpRecords.Count == 0 || (bddpRecords.Data[0]).Version < consent.MinimumBDDPVersionForRipple {
+	if bddpRecord == nil || bddpRecord.Version < consent.MinimumBDDPVersionForRipple {
 		latestBDDP, err := s.consentService.ListConsents(ctx, &consent.Filter{
 			Type:   pointer.FromAny(consent.TypeBigDataDonationProject),
 			Latest: pointer.FromAny(true),

--- a/oura/jotform/processor.go
+++ b/oura/jotform/processor.go
@@ -294,34 +294,63 @@ func (s *SubmissionProcessor) ensureConsentRecordExists(ctx context.Context, use
 		return nil
 	}
 
-	filter := consent.NewRecordFilter()
-	filter.Latest = pointer.FromAny(true)
-	filter.Status = pointer.FromAny(consent.RecordStatusActive)
-	filter.Type = pointer.FromAny(consent.TypeBigDataDonationProject)
-	filter.Version = pointer.FromAny(1)
+	creates := make([]*consent.RecordCreate, 0)
 
-	pagination := page.NewPaginationMinimum()
+	rippleFilter := consent.NewRecordFilter()
+	rippleFilter.Latest = pointer.FromAny(true)
+	rippleFilter.Status = pointer.FromAny(consent.RecordStatusActive)
+	rippleFilter.Type = pointer.FromAny(consent.TypeRipple)
+	rippleFilter.Version = pointer.FromAny(1)
 
-	records, err := s.consentService.ListConsentRecords(ctx, userID, filter, pagination)
+	rippleRecords, err := s.consentService.ListConsentRecords(ctx, userID, rippleFilter, page.NewPaginationMinimum())
 	if err != nil {
-		return errors.Wrap(err, "unable to list consent records")
+		return errors.Wrap(err, "unable to list ripple consent records")
 	}
-
-	if records.Count > 0 {
-		logger.WithField("userId", userID).Info("consent record already exists")
+	if rippleRecords.Count > 0 {
+		// If RIPPLE v1 already exists, BDDP v2 must also exist - nothing to do
+		logger.WithField("userId", userID).Info("ripple consent record already exists")
 		return nil
 	}
 
-	create := consent.NewRecordCreate()
-	create.AgeGroup = consent.AgeGroupEighteenOrOver
-	create.GrantorType = consent.GrantorTypeOwner
-	create.OwnerName = survey.Name
-	create.Type = consent.TypeBigDataDonationProject
-	create.Version = 1
+	bddpFilter := consent.NewRecordFilter()
+	bddpFilter.Latest = pointer.FromAny(true)
+	bddpFilter.Status = pointer.FromAny(consent.RecordStatusActive)
+	bddpFilter.Type = pointer.FromAny(consent.TypeBigDataDonationProject)
 
-	_, err = s.consentService.CreateConsentRecord(ctx, userID, create)
+	bddpRecords, err := s.consentService.ListConsentRecords(ctx, userID, bddpFilter, page.NewPaginationMinimum())
 	if err != nil {
-		return errors.Wrap(err, "unable to create consent record")
+		return errors.Wrap(err, "unable to list bddp consent records")
+	}
+
+	if bddpRecords.Count == 0 || (bddpRecords.Data[0]).Version < consent.MinimumBDDPVersionForRipple {
+		latestBDDP, err := s.consentService.ListConsents(ctx, &consent.Filter{
+			Type:   pointer.FromAny(consent.TypeBigDataDonationProject),
+			Latest: pointer.FromAny(true),
+		}, page.NewPaginationMinimum())
+		if err != nil || latestBDDP.Count == 0 {
+			return errors.Wrap(err, "unable to find latest BDDP version")
+		}
+
+		bddpCreate := consent.NewRecordCreate()
+		bddpCreate.AgeGroup = consent.AgeGroupEighteenOrOver
+		bddpCreate.GrantorType = consent.GrantorTypeOwner
+		bddpCreate.OwnerName = survey.Name
+		bddpCreate.Type = consent.TypeBigDataDonationProject
+		bddpCreate.Version = latestBDDP.Data[0].Version
+		creates = append(creates, bddpCreate)
+	}
+
+	rippleCreate := consent.NewRecordCreate()
+	rippleCreate.AgeGroup = consent.AgeGroupEighteenOrOver
+	rippleCreate.GrantorType = consent.GrantorTypeOwner
+	rippleCreate.OwnerName = survey.Name
+	rippleCreate.Type = consent.TypeRipple
+	rippleCreate.Version = 1
+	creates = append(creates, rippleCreate)
+
+	_, err = s.consentService.CreateConsentRecords(ctx, userID, creates)
+	if err != nil {
+		return errors.Wrap(err, "unable to create consent records")
 	}
 
 	return nil

--- a/oura/jotform/processor.go
+++ b/oura/jotform/processor.go
@@ -300,7 +300,7 @@ func (s *SubmissionProcessor) ensureConsentRecordExists(ctx context.Context, use
 	rippleFilter.Latest = pointer.FromAny(true)
 	rippleFilter.Status = pointer.FromAny(consent.RecordStatusActive)
 	rippleFilter.Type = pointer.FromAny(consent.TypeRipple)
-	rippleFilter.Version = pointer.FromAny(1)
+	rippleFilter.Version = pointer.FromAny(consent.RippleVersionForJotform)
 
 	rippleRecords, err := s.consentService.ListConsentRecords(ctx, userID, rippleFilter, page.NewPaginationMinimum())
 	if err != nil {
@@ -345,7 +345,7 @@ func (s *SubmissionProcessor) ensureConsentRecordExists(ctx context.Context, use
 	rippleCreate.GrantorType = consent.GrantorTypeOwner
 	rippleCreate.OwnerName = survey.Name
 	rippleCreate.Type = consent.TypeRipple
-	rippleCreate.Version = 1
+	rippleCreate.Version = consent.RippleVersionForJotform
 	creates = append(creates, rippleCreate)
 
 	_, err = s.consentService.CreateConsentRecords(ctx, userID, creates)

--- a/oura/jotform/processor_test.go
+++ b/oura/jotform/processor_test.go
@@ -114,7 +114,7 @@ var _ = Describe("SubmissionProcessor", func() {
 	})
 
 	Context("ProcessSubmission", func() {
-		It("should successfully process an eligible submission and create consent record", func() {
+		It("should successfully process an eligible submission and create consent records", func() {
 			submissionID := "6410095903544943563"
 			userID := "1aacb960-430c-4081-8b3b-a32688807dc5"
 
@@ -141,34 +141,75 @@ var _ = Describe("SubmissionProcessor", func() {
 			usr := &user.User{UserID: &userID}
 			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
+			// First call checks for RIPPLE
 			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-					Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
-					Expect(filter.Version).To(PointTo(Equal(1)))
+					Expect(filter.Type).To(PointTo(Equal("ripple")))
 					Expect(filter.Latest).To(PointTo(Equal(true)))
 				}).
 				Return(&storeStructuredMongo.ListResult[consent.Record]{
 					Count: 0,
 				}, nil)
 
-			consentService.EXPECT().CreateConsentRecord(gomock.Any(), userID, gomock.Any()).
-				Do(func(ctx context.Context, userID string, create *consent.RecordCreate) {
-					Expect(create).ToNot(BeNil())
-					Expect(create.Type).To(Equal("big_data_donation_project"))
-					Expect(create.Version).To(Equal(1))
-					Expect(create.OwnerName).To(Equal("James Jellyfish"))
-					Expect(create.AgeGroup).To(Equal(consent.AgeGroupEighteenOrOver))
-					Expect(create.GrantorType).To(Equal(consent.GrantorTypeOwner))
+			// Second call checks for the latest active BDDP
+			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
+					Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
+					Expect(filter.Latest).To(PointTo(Equal(true)))
+					Expect(filter.Status).To(PointTo(Equal(consent.RecordStatusActive)))
 				}).
-				Return(&consent.Record{
-					ID:          "1234567890",
-					UserID:      userID,
-					Status:      consent.RecordStatusActive,
-					AgeGroup:    consent.AgeGroupEighteenOrOver,
-					OwnerName:   "James Jellyfish",
-					GrantorType: "owner",
-					Type:        "big_data_donation_project",
-					Version:     1,
+				Return(&storeStructuredMongo.ListResult[consent.Record]{
+					Count: 0,
+				}, nil)
+
+			consentService.EXPECT().ListConsents(ctx, gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, filter *consent.Filter, pagination *page.Pagination) {
+					Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
+					Expect(filter.Latest).To(PointTo(Equal(true)))
+				}).
+				Return(&storeStructuredMongo.ListResult[consent.Consent]{
+					Count: 1,
+					Data: []consent.Consent{{
+						Type:    "big_data_donation_project",
+						Version: 2,
+					}},
+				}, nil)
+
+			consentService.EXPECT().CreateConsentRecords(gomock.Any(), userID, gomock.Any()).
+				Do(func(ctx context.Context, userID string, creates []*consent.RecordCreate) {
+					Expect(creates).To(HaveLen(2))
+					Expect(creates[0].Type).To(Equal("big_data_donation_project"))
+					Expect(creates[0].Version).To(Equal(2))
+					Expect(creates[0].OwnerName).To(Equal("James Jellyfish"))
+					Expect(creates[0].AgeGroup).To(Equal(consent.AgeGroupEighteenOrOver))
+					Expect(creates[0].GrantorType).To(Equal(consent.GrantorTypeOwner))
+					Expect(creates[1].Type).To(Equal("ripple"))
+					Expect(creates[1].Version).To(Equal(1))
+					Expect(creates[1].OwnerName).To(Equal("James Jellyfish"))
+					Expect(creates[1].AgeGroup).To(Equal(consent.AgeGroupEighteenOrOver))
+					Expect(creates[1].GrantorType).To(Equal(consent.GrantorTypeOwner))
+				}).
+				Return([]*consent.Record{
+					{
+						ID:          "1234567890",
+						UserID:      userID,
+						Status:      consent.RecordStatusActive,
+						AgeGroup:    consent.AgeGroupEighteenOrOver,
+						OwnerName:   "James Jellyfish",
+						GrantorType: "owner",
+						Type:        "big_data_donation_project",
+						Version:     2,
+					},
+					{
+						ID:          "1234567891",
+						UserID:      userID,
+						Status:      consent.RecordStatusActive,
+						AgeGroup:    consent.AgeGroupEighteenOrOver,
+						OwnerName:   "James Jellyfish",
+						GrantorType: "owner",
+						Type:        "ripple",
+						Version:     1,
+					},
 				}, nil)
 
 			shopifyClnt.EXPECT().
@@ -176,7 +217,7 @@ var _ = Describe("SubmissionProcessor", func() {
 				Do(func(ctx context.Context, input shopify.DiscountCodeInput) error {
 					Expect(input.Title).To(Equal("Oura Sizing Kit Discount Code"))
 					Expect(len(input.Code)).To(BeNumerically(">=", 12))
-					//Expect(input.ProductID).To(Equal("9122899853526"))
+					Expect(input.ProductID).To(Equal("9122899853526"))
 					return nil
 				})
 
@@ -184,7 +225,7 @@ var _ = Describe("SubmissionProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should successfully process an eligible submission and not attempt to create consent record if one already exists", func() {
+		It("should not create consent records if RIPPLE already exists", func() {
 			submissionID := "6410095903544943563"
 			userID := "1aacb960-430c-4081-8b3b-a32688807dc5"
 
@@ -211,11 +252,78 @@ var _ = Describe("SubmissionProcessor", func() {
 			usr := &user.User{UserID: &userID}
 			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
+			// RIPPLE already exists - no further consent calls expected
+			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
+					Expect(filter.Type).To(PointTo(Equal("ripple")))
+					Expect(filter.Latest).To(PointTo(Equal(true)))
+				}).
+				Return(&storeStructuredMongo.ListResult[consent.Record]{
+					Count: 1,
+					Data: []consent.Record{{
+						ID:          "1234567891",
+						UserID:      userID,
+						Status:      consent.RecordStatusActive,
+						AgeGroup:    consent.AgeGroupEighteenOrOver,
+						OwnerName:   "James Jellyfish",
+						GrantorType: "owner",
+						Type:        "ripple",
+						Version:     1,
+					}},
+				}, nil)
+
+			shopifyClnt.EXPECT().
+				CreateDiscountCode(gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, input shopify.DiscountCodeInput) error {
+					Expect(input.Title).To(Equal("Oura Sizing Kit Discount Code"))
+					Expect(len(input.Code)).To(BeNumerically(">=", 12))
+					return nil
+				})
+
+			err = processor.ProcessSubmission(ctx, submissionID)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create only RIPPLE when BDDP v2 already exists", func() {
+			submissionID := "6410095903544943563"
+			userID := "1aacb960-430c-4081-8b3b-a32688807dc5"
+
+			submission, err := ouraTest.LoadFixture("./test/fixtures/submission.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			jotformResponses.AddResponse(
+				[]ouraTest.RequestMatcher{ouraTest.NewRequestMethodAndPathMatcher(http.MethodGet, "/v1/submission/"+submissionID)},
+				ouraTest.Response{StatusCode: http.StatusOK, Body: submission},
+			)
+
+			customer, err := ouraTest.LoadFixture("./test/fixtures/customer.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			appAPIResponses.AddResponse(
+				[]ouraTest.RequestMatcher{ouraTest.NewRequestMethodAndPathMatcher(http.MethodGet, "/v1/customers/"+userID+"/attributes")},
+				ouraTest.Response{StatusCode: http.StatusOK, Body: customer},
+			)
+			trackAPIResponses.AddResponse(
+				[]ouraTest.RequestMatcher{ouraTest.NewRequestMethodAndPathMatcher(http.MethodPost, "/api/v1/customers/"+userID+"/events")},
+				ouraTest.Response{StatusCode: http.StatusOK, Body: "{}"},
+			)
+
+			usr := &user.User{UserID: &userID}
+			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
+
+			// First call: no RIPPLE
+			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
+					Expect(filter.Type).To(PointTo(Equal("ripple")))
+				}).
+				Return(&storeStructuredMongo.ListResult[consent.Record]{Count: 0}, nil)
+
+			// Second call checks for the latest active BDDP
 			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
 					Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
-					Expect(filter.Version).To(PointTo(Equal(1)))
 					Expect(filter.Latest).To(PointTo(Equal(true)))
+					Expect(filter.Status).To(PointTo(Equal(consent.RecordStatusActive)))
 				}).
 				Return(&storeStructuredMongo.ListResult[consent.Record]{
 					Count: 1,
@@ -227,8 +335,31 @@ var _ = Describe("SubmissionProcessor", func() {
 						OwnerName:   "James Jellyfish",
 						GrantorType: "owner",
 						Type:        "big_data_donation_project",
-						Version:     1,
+						Version:     2,
 					}},
+				}, nil)
+
+			// Should create only RIPPLE
+			consentService.EXPECT().CreateConsentRecords(gomock.Any(), userID, gomock.Any()).
+				Do(func(ctx context.Context, userID string, creates []*consent.RecordCreate) {
+					Expect(creates).To(HaveLen(1))
+					Expect(creates[0].Type).To(Equal("ripple"))
+					Expect(creates[0].Version).To(Equal(1))
+					Expect(creates[0].OwnerName).To(Equal("James Jellyfish"))
+					Expect(creates[0].AgeGroup).To(Equal(consent.AgeGroupEighteenOrOver))
+					Expect(creates[0].GrantorType).To(Equal(consent.GrantorTypeOwner))
+				}).
+				Return([]*consent.Record{
+					{
+						ID:          "1234567891",
+						UserID:      userID,
+						Status:      consent.RecordStatusActive,
+						AgeGroup:    consent.AgeGroupEighteenOrOver,
+						OwnerName:   "James Jellyfish",
+						GrantorType: "owner",
+						Type:        "ripple",
+						Version:     1,
+					},
 				}, nil)
 
 			shopifyClnt.EXPECT().
@@ -236,7 +367,6 @@ var _ = Describe("SubmissionProcessor", func() {
 				Do(func(ctx context.Context, input shopify.DiscountCodeInput) error {
 					Expect(input.Title).To(Equal("Oura Sizing Kit Discount Code"))
 					Expect(len(input.Code)).To(BeNumerically(">=", 12))
-					//Expect(input.ProductID).To(Equal("9122899853526"))
 					return nil
 				})
 
@@ -365,34 +495,73 @@ var _ = Describe("SubmissionProcessor", func() {
 				usr := &user.User{UserID: &userID}
 				userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
+				// First call: check for RIPPLE
 				consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
 					Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-						Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
-						Expect(filter.Version).To(PointTo(Equal(1)))
+						Expect(filter.Type).To(PointTo(Equal("ripple")))
 						Expect(filter.Latest).To(PointTo(Equal(true)))
 					}).
 					Return(&storeStructuredMongo.ListResult[consent.Record]{
 						Count: 0,
 					}, nil)
 
-				consentService.EXPECT().CreateConsentRecord(gomock.Any(), userID, gomock.Any()).
-					Do(func(ctx context.Context, userID string, create *consent.RecordCreate) {
-						Expect(create).ToNot(BeNil())
-						Expect(create.Type).To(Equal("big_data_donation_project"))
-						Expect(create.Version).To(Equal(1))
-						Expect(create.OwnerName).To(Equal(name))
-						Expect(create.AgeGroup).To(Equal(consent.AgeGroupEighteenOrOver))
-						Expect(create.GrantorType).To(Equal(consent.GrantorTypeOwner))
+				// Second call checks for the latest active BDDP
+				consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+					Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
+						Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
+						Expect(filter.Latest).To(PointTo(Equal(true)))
+						Expect(filter.Status).To(PointTo(Equal(consent.RecordStatusActive)))
 					}).
-					Return(&consent.Record{
-						ID:          "1234567890",
-						UserID:      userID,
-						Status:      consent.RecordStatusActive,
-						AgeGroup:    consent.AgeGroupEighteenOrOver,
-						OwnerName:   name,
-						GrantorType: "owner",
-						Type:        "big_data_donation_project",
-						Version:     1,
+					Return(&storeStructuredMongo.ListResult[consent.Record]{
+						Count: 0,
+					}, nil)
+
+				consentService.EXPECT().ListConsents(ctx, gomock.Any(), gomock.Any()).
+					Do(func(ctx context.Context, filter *consent.Filter, pagination *page.Pagination) {
+						Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
+						Expect(filter.Latest).To(PointTo(Equal(true)))
+					}).
+					Return(&storeStructuredMongo.ListResult[consent.Consent]{
+						Count: 1,
+						Data: []consent.Consent{{
+							Type:    "big_data_donation_project",
+							Version: 2,
+						}},
+					}, nil)
+
+				consentService.EXPECT().CreateConsentRecords(gomock.Any(), userID, gomock.Any()).
+					Do(func(ctx context.Context, userID string, creates []*consent.RecordCreate) {
+						Expect(creates).To(HaveLen(2))
+						Expect(creates[0].Type).To(Equal("big_data_donation_project"))
+						Expect(creates[0].Version).To(Equal(2))
+						Expect(creates[0].OwnerName).To(Equal(name))
+						Expect(creates[0].AgeGroup).To(Equal(consent.AgeGroupEighteenOrOver))
+						Expect(creates[0].GrantorType).To(Equal(consent.GrantorTypeOwner))
+						Expect(creates[1].Type).To(Equal("ripple"))
+						Expect(creates[1].Version).To(Equal(1))
+						Expect(creates[1].OwnerName).To(Equal(name))
+					}).
+					Return([]*consent.Record{
+						{
+							ID:          "1234567890",
+							UserID:      userID,
+							Status:      consent.RecordStatusActive,
+							AgeGroup:    consent.AgeGroupEighteenOrOver,
+							OwnerName:   name,
+							GrantorType: "owner",
+							Type:        "big_data_donation_project",
+							Version:     2,
+						},
+						{
+							ID:          "1234567891",
+							UserID:      userID,
+							Status:      consent.RecordStatusActive,
+							AgeGroup:    consent.AgeGroupEighteenOrOver,
+							OwnerName:   name,
+							GrantorType: "owner",
+							Type:        "ripple",
+							Version:     1,
+						},
 					}, nil)
 
 				shopifyClnt.EXPECT().

--- a/oura/jotform/processor_test.go
+++ b/oura/jotform/processor_test.go
@@ -141,26 +141,13 @@ var _ = Describe("SubmissionProcessor", func() {
 			usr := &user.User{UserID: &userID}
 			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
-			// First call checks for RIPPLE
-			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-					Expect(filter.Type).To(PointTo(Equal("ripple")))
-					Expect(filter.Latest).To(PointTo(Equal(true)))
-				}).
-				Return(&storeStructuredMongo.ListResult[consent.Record]{
-					Count: 0,
-				}, nil)
+			// First call: no RIPPLE
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "ripple").
+				Return(nil, nil)
 
 			// Second call checks for the latest active BDDP
-			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-					Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
-					Expect(filter.Latest).To(PointTo(Equal(true)))
-					Expect(filter.Status).To(PointTo(Equal(consent.RecordStatusActive)))
-				}).
-				Return(&storeStructuredMongo.ListResult[consent.Record]{
-					Count: 0,
-				}, nil)
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "big_data_donation_project").
+				Return(nil, nil)
 
 			consentService.EXPECT().ListConsents(ctx, gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, filter *consent.Filter, pagination *page.Pagination) {
@@ -253,23 +240,16 @@ var _ = Describe("SubmissionProcessor", func() {
 			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
 			// RIPPLE already exists - no further consent calls expected
-			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-					Expect(filter.Type).To(PointTo(Equal("ripple")))
-					Expect(filter.Latest).To(PointTo(Equal(true)))
-				}).
-				Return(&storeStructuredMongo.ListResult[consent.Record]{
-					Count: 1,
-					Data: []consent.Record{{
-						ID:          "1234567891",
-						UserID:      userID,
-						Status:      consent.RecordStatusActive,
-						AgeGroup:    consent.AgeGroupEighteenOrOver,
-						OwnerName:   "James Jellyfish",
-						GrantorType: "owner",
-						Type:        "ripple",
-						Version:     1,
-					}},
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "ripple").
+				Return(&consent.Record{
+					ID:          "1234567891",
+					UserID:      userID,
+					Status:      consent.RecordStatusActive,
+					AgeGroup:    consent.AgeGroupEighteenOrOver,
+					OwnerName:   "James Jellyfish",
+					GrantorType: "owner",
+					Type:        "ripple",
+					Version:     1,
 				}, nil)
 
 			shopifyClnt.EXPECT().
@@ -312,31 +292,20 @@ var _ = Describe("SubmissionProcessor", func() {
 			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
 			// First call: no RIPPLE
-			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-					Expect(filter.Type).To(PointTo(Equal("ripple")))
-				}).
-				Return(&storeStructuredMongo.ListResult[consent.Record]{Count: 0}, nil)
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "ripple").
+				Return(nil, nil)
 
 			// Second call checks for the latest active BDDP
-			consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-					Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
-					Expect(filter.Latest).To(PointTo(Equal(true)))
-					Expect(filter.Status).To(PointTo(Equal(consent.RecordStatusActive)))
-				}).
-				Return(&storeStructuredMongo.ListResult[consent.Record]{
-					Count: 1,
-					Data: []consent.Record{{
-						ID:          "1234567890",
-						UserID:      userID,
-						Status:      consent.RecordStatusActive,
-						AgeGroup:    consent.AgeGroupEighteenOrOver,
-						OwnerName:   "James Jellyfish",
-						GrantorType: "owner",
-						Type:        "big_data_donation_project",
-						Version:     2,
-					}},
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "big_data_donation_project").
+				Return(&consent.Record{
+					ID:          "1234567890",
+					UserID:      userID,
+					Status:      consent.RecordStatusActive,
+					AgeGroup:    consent.AgeGroupEighteenOrOver,
+					OwnerName:   "James Jellyfish",
+					GrantorType: "owner",
+					Type:        "big_data_donation_project",
+					Version:     2,
 				}, nil)
 
 			// Should create only RIPPLE
@@ -495,26 +464,13 @@ var _ = Describe("SubmissionProcessor", func() {
 				usr := &user.User{UserID: &userID}
 				userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
 
-				// First call: check for RIPPLE
-				consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-					Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-						Expect(filter.Type).To(PointTo(Equal("ripple")))
-						Expect(filter.Latest).To(PointTo(Equal(true)))
-					}).
-					Return(&storeStructuredMongo.ListResult[consent.Record]{
-						Count: 0,
-					}, nil)
+				// First call: no RIPPLE
+				consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "ripple").
+					Return(nil, nil)
 
 				// Second call checks for the latest active BDDP
-				consentService.EXPECT().ListConsentRecords(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-					Do(func(ctx context.Context, userID string, filter *consent.RecordFilter, pagination *page.Pagination) {
-						Expect(filter.Type).To(PointTo(Equal("big_data_donation_project")))
-						Expect(filter.Latest).To(PointTo(Equal(true)))
-						Expect(filter.Status).To(PointTo(Equal(consent.RecordStatusActive)))
-					}).
-					Return(&storeStructuredMongo.ListResult[consent.Record]{
-						Count: 0,
-					}, nil)
+				consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "big_data_donation_project").
+					Return(nil, nil)
 
 				consentService.EXPECT().ListConsents(ctx, gomock.Any(), gomock.Any()).
 					Do(func(ctx context.Context, filter *consent.Filter, pagination *page.Pagination) {


### PR DESCRIPTION
- Add new consent types for BDDP v2 and RIPPLE v1 (placeholder content - final copy is pending legal approval)
- RIPPLE is a sub-consent of BDDP version 2 and above
- Eligible OURA participants consent to both RIPPLE v1 and BDDP version 2 or higher
- Revoking BDDP v2 or above also revokes RIPPLE
- Re-consenting to BDDP v2 does not automatically re-add consent for RIPPLE