### PR TITLE
require that tasks advance their availableTime

### DIFF
--- a/task/queue/mrucache.go
+++ b/task/queue/mrucache.go
@@ -1,0 +1,64 @@
+package queue
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultLRUCacheMaxSize is based on current-day production having 7,456 tasks in
+	// either the pending or running states.
+	DefaultLRUCacheMaxSize = 75000
+)
+
+// mruCache is a cache of most recently used key-value pairs.
+type mruCache struct {
+	// cache allows fast lookup by key.
+	cache map[string]time.Time
+	// sorted is an ordered slice of keys, such that the most recently used is last.
+	sorted  []string
+	maxSize int
+	mu      sync.Mutex
+}
+
+func NewMRUCache(maxSize int) *mruCache {
+	if maxSize < 1 {
+		maxSize = DefaultLRUCacheMaxSize
+	}
+	return &mruCache{
+		maxSize: maxSize,
+		cache:   make(map[string]time.Time, max(100, maxSize/10)),
+		sorted:  make([]string, 0, max(100, maxSize/10)),
+	}
+}
+
+func (l *mruCache) Store(key string, value time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.cache[key] = value
+	for len(l.cache) > l.maxSize {
+		delete(l.cache, l.sorted[0])
+		l.sorted = l.sorted[1:]
+	}
+	l.refresh(key)
+}
+
+// refresh the key's position in the sorted list of keys.
+func (l *mruCache) refresh(key string) {
+	l.sorted = slices.DeleteFunc(l.sorted, func(i string) bool {
+		return i == key
+	})
+	l.sorted = append(l.sorted, key)
+}
+
+func (l *mruCache) Get(key string) time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	value, found := l.cache[key]
+	if !found {
+		return time.Time{}
+	}
+	l.refresh(key)
+	return value
+}

--- a/task/queue/mrucache_test.go
+++ b/task/queue/mrucache_test.go
@@ -1,0 +1,67 @@
+package queue
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LRU Queue", func() {
+	Context("Store", func() {
+		It("has a limited size", func() {
+			maxSize := 1 + rand.IntN(1000)
+			base := time.Now()
+			c := NewMRUCache(maxSize)
+			for i := range maxSize * 2 {
+				c.Store(fmt.Sprintf("%d", i), base.Add(time.Duration(i)))
+			}
+			Expect(len(c.cache)).To(Equal(maxSize))
+			Expect(len(c.sorted)).To(Equal(maxSize))
+		})
+
+		It("deletes the oldest entry first", func() {
+			maxSize := 1 + rand.IntN(1000)
+			base := time.Now()
+			c := NewMRUCache(maxSize)
+			for i := range maxSize + 1 {
+				c.Store(fmt.Sprintf("%d", i), base.Add(time.Duration(i)))
+			}
+			Expect(len(c.cache)).To(Equal(maxSize))
+			Expect(len(c.sorted)).To(Equal(maxSize))
+			Expect(c.Get("0")).To(Equal(time.Time{}))
+			Expect(c.Get("1")).To(Equal(base.Add(1)))
+		})
+
+		It("has its last used time refreshed when stored again", func() {
+			maxSize := 1 + rand.IntN(1000)
+			base := time.Now()
+			c := NewMRUCache(maxSize)
+			for i := range maxSize {
+				c.Store(fmt.Sprintf("%d", i), base.Add(time.Duration(i)))
+			}
+			c.Store("0", base)                        // refresh "0" in the LRU
+			c.Store("too many", base)                 // bump "1" out of the LRU
+			Expect(c.Get("0")).To(Equal(base))        // "0" is still there
+			Expect(c.Get("1")).To(Equal(time.Time{})) // "1" is gone
+			Expect(c.Get("2")).To(Equal(base.Add(2))) // "2" is (still) there
+		})
+	})
+
+	Context("Get", func() {
+		It("refreshes the value's last used order", func() {
+			maxSize := 1 + rand.IntN(1000)
+			base := time.Now()
+			c := NewMRUCache(maxSize)
+			for i := range maxSize {
+				c.Store(fmt.Sprintf("%d", i), base.Add(time.Duration(i)))
+			}
+			c.Get("0")
+			c.Store("too many", base)
+			Expect(c.Get("0")).To(Equal(base))
+			Expect(c.Get("1")).To(Equal(time.Time{}))
+		})
+	})
+})

--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -112,6 +112,7 @@ type queue struct {
 	timer             *time.Timer
 	taskRepository    store.TaskRepository
 	iterator          *mongo.Cursor
+	nextAvailable     *mruCache
 }
 
 func New(cfg *Config, lgr log.Logger, str store.Store) (Queue, error) {
@@ -140,6 +141,7 @@ func New(cfg *Config, lgr log.Logger, str store.Store) (Queue, error) {
 		runners:           make(map[string]Runner),
 		dispatchChannel:   make(chan *task.Task, workers),
 		completionChannel: make(chan *task.Task, workers),
+		nextAvailable:     NewMRUCache(DefaultLRUCacheMaxSize),
 	}, nil
 }
 
@@ -371,13 +373,29 @@ func (q *queue) completeTask(ctx context.Context, tsk *task.Task) {
 	}
 }
 
+// errNoAdvancement indicates that a task ran, but didn't advance its availableTime.
+//
+// Not advancing availableTime is indicative of an unhandled error case in the task and can
+// lead to the task being run indefinitely on each task loop. It could be a simple int, but
+// a previous revision used a time.Time in a slightly different way, and this version keeps
+// that to avoid the need for a database migration.
+var errNoAdvancement = errors.New("pending task requires advancement of available time")
+
 func (q *queue) computeState(tsk *task.Task) {
 	switch tsk.State {
 	case task.TaskStatePending:
-		if tsk.AvailableTime == nil || time.Now().After(*tsk.AvailableTime) {
-			tsk.AppendError(errors.New("pending task requires future available time"))
+		if tsk.AvailableTime == nil {
+			tsk.AppendError(errNoAdvancement)
 			tsk.SetFailed()
+			return
 		}
+		availableTime := *tsk.AvailableTime
+		if q.hasAvailableTimeButNoAdvancement(tsk.ID, availableTime) {
+			tsk.AppendError(errNoAdvancement)
+			tsk.SetFailed()
+			return
+		}
+		q.nextAvailable.Store(tsk.ID, availableTime)
 	case task.TaskStateRunning:
 		if tsk.HasError() {
 			tsk.SetFailed()
@@ -389,6 +407,14 @@ func (q *queue) computeState(tsk *task.Task) {
 		tsk.AppendError(errors.New("unknown state"))
 		tsk.SetFailed()
 	}
+}
+
+func (q *queue) hasAvailableTimeButNoAdvancement(taskID string, t time.Time) bool {
+	prev := q.nextAvailable.Get(taskID)
+	if prev.IsZero() {
+		return false
+	}
+	return t.Equal(prev) || t.Before(prev)
 }
 
 func (q *queue) startTimer(delay time.Duration) {


### PR DESCRIPTION
During the investigation of a bug, this race condition was found where availableTime, if it were in the past would cause a task to be marked failed and therefore not run any more.

Now we track the previous availableTime for each task, and only when they don't advance is the task marked failed.

BACK-4452