### PR TITLE
don't error a task out when its availableTime is in the past

### DIFF
--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -375,8 +375,8 @@ func (q *queue) computeState(tsk *task.Task) {
 	switch tsk.State {
 	case task.TaskStatePending:
 		if tsk.AvailableTime == nil || time.Now().After(*tsk.AvailableTime) {
-			tsk.AppendError(errors.New("pending task requires future available time"))
-			tsk.SetFailed()
+			// This used to error out here, but was considered too defensive.
+			tsk.AvailableTime = pointer.FromAny(time.Now())
 		}
 	case task.TaskStateRunning:
 		if tsk.HasError() {


### PR DESCRIPTION
During the investigation of a bug, this race condition was found where
availableTime, if it were in the past would cause a task to be marked
failed and therefore not run any more.

Now we use time.Now() when we find an availableTime in the past.

BACK-4452