### PR TITLE
[BACK-4462] [BACK-4463] Add final BDDP and RIPPLE informed consent and add the ability to skip the sizing kit campaign

### DIFF
--- a/consent/loader/content/big_data_donation_project.v2.md
+++ b/consent/loader/content/big_data_donation_project.v2.md
@@ -1,14 +1,296 @@
 ### Tidepool Big Data Donation Project
 
-# Informed Consent Form - Version 2
+# Informed Consent Information Sheet
 
 **TITLE:**    Tidepool Big Data Donation Project Study Protocol
 
-**PROTOCOL NO.:**    None
+**PROTOCOL NO.:**    None   
+WCG IRB Protocol #20243599
 
 **SPONSOR:**    Tidepool Project
 
-**STUDY-RELATED**
+**INVESTIGATOR:**    Saira Khan-Gallo, MPH  
+555 Bryant St. #429  
+Palo Alto, California 94301  
+United States
+
+**STUDY-RELATED**  
 **EMAIL ADDRESS:**    bigdataofficer@tidepool.org
 
 Your participation in this study is voluntary. You may decide not to participate or you may leave the study at any time.
+Your decision will not result in any penalty or loss of benefits to which you are otherwise entitled.
+
+If you have questions, concerns, or complaints, or think this research has hurt you, talk to the research team at the
+phone number(s) listed in this document.
+
+## Research Consent Summary
+
+### How long will I be in this research?
+
+This is a long-term project. Your participation will last as long as you choose to keep donating data, and the project
+may continue for years.
+
+### Why is this research being done?
+
+The purpose of this project is to collect data from your Tidepool account that can be shared with approved researchers
+to support research and innovation in diabetes and related conditions. Your Tidepool account data, which includes
+demographics, data from your connected health and/or wearable devices, and surveys, will have directly identifying
+information removed before they are shared.
+
+### What happens to me if I agree to take part in this research?
+
+If you decide to take part, you will
+
+* Create or use an existing Tidepool account
+* Set up data storage
+* Periodically upload data from your devices/apps and complete surveys)
+
+### Could being in this research hurt me?
+
+The main risks are potential loss of privacy and confidentiality. These are described in more detail below.
+
+### Will being in this research benefit me?
+
+It is not expected that you will personally benefit from this project. However, information learned may help people
+with diabetes and other related conditions in the future by supporting research and innovation.
+
+### What other choices do I have besides taking part in this research?
+
+Your alternative is not to participate. You may continue to use Tidepool without donating data to this project.
+
+## Detailed Research Information
+
+### Introduction
+
+You are being asked if you would like to participate in the Tidepool Big Data Donation Project which is being conducted
+entirely online by Tidepool and its partners (the "**Project**"). Participation in this Project is completely
+voluntary. It is your choice whether you would like to participate or not. Before agreeing to participate in this
+Project, you must read and understand this consent form. This consent document describes the purpose, procedures,
+benefits, risks, and precautions of the Project. It also describes the information that may be collected from you as
+part of this Project, how your information will be used or disclosed, and your right to withdraw from the Project at
+any time. No guarantees or assurances are made to you about the Project results and your participation. If you have any
+questions about this form or the Project, please contact bigdataofficer@tidepool.org. When all of your questions have
+been answered, you can decide if you want to take part in this Project.
+
+### Background and Purpose
+
+The purpose of this Project is to help drive and expand the boundaries of diabetes research and innovation from helping
+to improve early detection, diagnosis, and treatment, to learning more about interactions with other conditions, and
+beyond. This Project is an opt-in program designed to help communities, academics, and industry researchers innovate
+faster and expand the boundaries of knowledge about diabetes and related conditions. These researchers range from
+individuals to large research teams who work across industries at non-profit and for-profit, commercial companies like
+medical device companies, technology companies developing wearable devices or applications for consumers, and
+pharmaceutical manufacturers.
+
+Users of Tidepool's software tools may choose to donate their data, which can include any and all of the types of data
+that may be included in a Tidepool member's account. Data included in this Project will be provided to approved
+researchers and research teams allowing them access to real-world patient data. These researchers, many of whom possess
+cutting-edge skills and experience in diabetes and/or advanced, state-of-the-art machine learning techniques, may use
+this Project data that has had directly identifiable information removed in simulations to build models. These models
+can be used, for example, in the development of new strategies for diabetes management, to improve dosing algorithms,
+or in general to uncover novel real-world insights into how to better treat people with certain medical conditions like
+diabetes. Some have a specific focus on certain areas like next-generation automated insulin delivery techniques and
+others have broader backgrounds on diet, nutrition, health, and wellness. This Project aims to support bona fide
+research that uses systematic methods to gain new knowledge, help develop new products, or solve problems, while
+adhering to ethical standards and contributing to generalizable knowledge and potentially supporting other individuals
+like Tidepool members.
+
+### Eligible Participants
+
+Participation in this Project is open to all Tidepool members in the US with a Tidepool account and are over the age of
+18 years old. If you are under the age of 18 and would like to participate your parent or legal guardian must provide
+their consent by signing this form. You can participate in this Project for as long as you are interested in
+participating. This is a longitudinal research project and we hope to continue this Project for years to come.
+
+### Project Procedures
+
+If you choose to participate in the Project, you will need to create, or have already created, a Tidepool account,
+follow the instructions to verify your account and set up Data Storage. During this process you will need to indicate
+your interest in participating in the Project, review this form, and give your consent. You can select a nonprofit
+diabetes organization to support; Tidepool will share some of the revenue generated by licensing datasets with these
+organizations. You will then be asked to start uploading your data. We recommend setting a reminder to upload your
+data, or checking your data connections, at least once a month to make sure you don't have any data gaps.
+
+Tidepool will create a copy of the Tidepool member data about you (e.g., information you provided when using your
+Tidepool account). Tidepool will remove directly identifying information, including your name, email address, custom
+labeled profiles, and device identifiers, associated with this information and assign a unique identifier to the data
+before including the data in the pool of datasets that are made available to data partners and researchers. In this
+consent form, the term "Project data" refers to this dataset after directly identifying information has been removed
+and a unique identifier has been assigned.
+
+Information that will be included in the pool of datasets available to researchers, includes:
+
+* **Demographic Information**: such as your age, biological sex, race/ethnicity, socioeconomic status, education level,
+  and general geographic location.
+* **Health and Device Information**: such as diabetes type, diagnosis month and year, insulin delivery data, carb
+  entries, events tracked by the continuous glucose meters ("CGM") including estimated glucose values, meals, exercise,
+  blood glucose ("BG") readings and log, trends, basal rates, insulin to carb ratios, insulin sensitivity factors,
+  device generated alerts and alarms, device component changes, and upload history. If you choose to connect another
+  device like a wearable device, we may also collect information provided by that device, such as heart rate, sleep
+  stages and duration, physical activity (steps, movement, activity intensity), recovery or readiness scores, menstrual
+  cycle and pregnancy stage data, and other health and wellness metrics measured or estimated by the device.
+* **Survey Information**: such as your responses to how your experience in the Project is, questions about your health
+  habits and wellness, and other information you may choose to provide in response to surveys that may be provided from
+  time to time as part of the Project. This may include information related to your diabetes diagnosis, symptoms,
+  management, and treatment, medications and supplements taken, other health conditions you have been diagnosed with,
+  reproductive health management and status, diet, and physical activity levels.
+
+The specific types of information included may vary slightly depending on your devices and how you use Tidepool
+software. Providing wearable data, such as sleep, lifestyle habits, and menstrual cycle data, and survey responses
+better enables Tidepool and its research partners to understand how other health and lifestyle factors influence
+diabetes management. **Information provided from wearable devices or surveys may include sensitive information,
+including information about your reproductive, mental health, and substance use**.
+
+By participating in this Project, you can support other diabetes non-profit organizations. When an industry partner
+engages Tidepool to receive Tidepool's paid dataset qualification services, Tidepool may donate a portion of the
+proceeds from its paid dataset qualification services to a non-profit organization chosen by Project participants. You
+can review the list of non-profit organizations that may receive funds by
+visiting: [https://www.tidepool.org/bigdata#nonprofit_partners](https://www.tidepool.org/bigdata#nonprofit_partners).
+After completing this informed consent, you will be able to select the organization you would like to support during
+your account creation. You can also select or change your selection from your account settings.
+
+### Risks
+
+There are risks, discomforts, and inconveniences associated with any research study. These deserve careful thought.
+There may be risks to your privacy. Your privacy is important to us and we will take precautions to protect your
+privacy, but we cannot guarantee that your identity will never become known. Despite the precautions we take, it is
+possible that there could be security breaches of the computer systems used to store your information or the identifiers
+linking your Project data to you. If you post a subset of your data online, a researcher may be able to match data
+within the Project to the data you've posted online, and re-identify your dataset. Also, if Tidepool shares Project data
+with a Partner for research purposes and this Partner's device was used for generating data you donated (or if the
+Partner otherwise maintains data about you), they may be able to match data within the Project and re-identify your
+dataset. Any re-identification would be in violation of the terms of use of the Project data set license; however, it
+is a risk given the types of data that may be collected as part of this Project. There may also be other privacy risks
+that we have not foreseen.
+
+If you choose to connect another device (such as a wearable device), link other applications to your Tidepool account,
+or participate in surveys, there may be risks associated with third-party collection of certain types of data like
+menstrual cycle, pregnancy stage, and other sensitive data. Please consider the laws governing reproductive health and
+similar types of sensitive data in your jurisdiction before consenting to this research and providing Tidepool with
+such data.
+
+There is also a possibility of risks that we do not know about. If you have any questions or concerns, you should speak
+with the Tidepool's Big Data Donation Project officer [bigdataofficer@tidepool.org](mailto:bigdataofficer@tidepool.org).
+
+By agreeing to this consent form, you do not give up any of your legal rights against the researchers, sponsor or
+involved institutions, nor does this form relieve the researchers, sponsor or involved institutions of their legal and
+professional responsibilities.
+
+### Benefits and Alternatives
+
+You will not be paid for taking part in this Project and you may not receive direct benefit from being in this Project.
+This Project is for research and innovation purposes only. The only alternative is to not participate in this Project.
+You may continue to use Tidepool without participating in this Project. If you choose to not take part in this Project,
+you will not lose any benefits or medical care to which you are otherwise entitled. You do not have to agree to this
+consent form, but if you do not, you will not be able to participate in this Project.
+
+Information learned in this Project may help people with diabetes in the future, but individual or aggregate research
+results may not be reported back to you. If the Project or related research leads to the development of new or the
+improvement of existing diagnostic tests, treatments, patents, therapies, or other commercial products, you will not
+receive any part of the profits generated from such products. Your information will be used to conduct future research
+without your further consent.
+
+### Withdrawal from the Project
+
+You can decide to leave the Project at any time. You can opt out of this Project by logging into your account, clicking
+on the account name at the top of the page to navigate to your profile settings, clicking the link to 'Stop sharing
+data', and confirming your decision.
+
+If you decide to opt out of the Project, the information that was collected before you left the Project will still be
+used to support this Project, and the previously donated data cannot be removed. No new information will be collected
+without your permission.
+
+You may be asked to leave the Project early for reasons such as:
+
+* the Project team does not believe that this Project is in your best interest;
+* it is discovered that you do not meet the Project eligibility requirements;
+* the Project is canceled for any reason; or
+* for administrative reasons.
+
+### Data Use, Sharing, Retention, and Confidentiality
+
+The records related to this Project will be handled and safeguarded according to the applicable state and federal laws
+governing the confidentiality of personal information and health information. The Project Team takes steps to keep your
+information confidential.
+
+Your personal information will be kept secure by the Project Team and will only be used as outlined in this consent
+form for the purposes of this Project. It will be shared with other institutions only as necessary to support the
+Project, for regulatory reporting, for oversight over the Project, or as described in this consent form. Your records
+of being in this Project will be kept private except as described in this consent form or when otherwise ordered
+required to be released by applicable law.
+
+The Project team may also share Project data with the following:
+
+* Tidepool, its representatives, or others working on its behalf;
+* Partner companies and research institutions [including monitor(s) and auditor(s)] or designees who have entered into
+  agreements with Tidepool to conduct research on Project data;
+* The U.S. Food and Drug Administration ("FDA");
+* The U.S. Department of Health and Human Services ("HHS");
+* Other U.S. state or federal regulatory or law enforcement agencies, only with valid subpoena;
+* Institutional Review Boards ("IRB");
+* Outside individuals and companies, such as laboratories and data storage companies, that work with the Project team
+  and Tidepool and need to access your information to support this Project;
+* Other research personnel and institutions participating in this Project who have been approved by Tidepool and entered
+  into agreements as appropriate; and
+* A data safety monitoring board which oversees this Project, if applicable.
+
+Before sharing project data with others, the Project Team will seek to remove any directly identifiable information to
+the extent possible and permitted by applicable law and legal obligations.
+
+Your information will be used and disclosed to conduct and oversee the Project, including for example:
+
+* To support and carry out the Project and future research.
+* To contact you about the Project or other research opportunities you may be interested in or eligible for.
+* To compare or combine the Project data with other studies and design or improve future studies.
+* To analyze Project data and publish results related to the Project.
+* To obtain regulatory approvals and comply with applicable legal obligations.
+* To check if the Project is being done properly and safely.
+* To help Tidepool develop, design, approve, improve, production, publication, or support of health and wellness
+  products, technologies, processes, and services, including to develop a better understanding of and new ways to
+  identify, prevent, or otherwise address certain health conditions or wellness issues, including algorithm development.
+* To help researchers:
+    * identify better insights and discoveries in a range of health and wellness areas, including diabetes management,
+    * build better algorithms for closed loop systems,
+    * bring safer or more innovative products to market, and/or
+    * enable Tidepool and other diabetes nonprofits to become stronger, more impactful organizations.
+
+Once your information has been shared with authorized researchers, it may no longer be protected by federal privacy law
+and could possibly be further used or disclosed in ways other than those listed here.
+
+Your permission to use and share information about you, including your health information, will expire in 50 years from
+the date you sign below, unless you revoke it (take it back) sooner. Your Project data will only be retained for as
+long as needed for the purposes of this Project.
+
+Your information will be assigned a unique code before being included in the larger data repository. Prior to including
+your information in the dataset that may be shared with researchers. Tidepool replaces your Tidepool user identifier
+with this unique code. These identifiers cannot be decoded into their original form, but they allow researchers to
+correlate datasets over time from the same user. This hash value will be used to identify, evaluate, and report your
+information in the Project.
+
+Information from the Project may be published or presented at meetings; however, you will not be identified by name.
+Your identity will remain confidential unless applicable law requires disclosure.
+
+### Questions
+
+If you have any questions, concerns, or would like to speak to the Project Team for any reason, please contact them
+at: [bigdataofficer@tidepool.org](mailto:bigdataofficer@tidepool.org).
+
+This research is being overseen by WCG IRB. An IRB is a group of people who perform independent review of research
+studies. You may talk to them at 855-818-2289 or clientcare@wcgclinical.com if:
+
+* You have questions, concerns, or complaints that are not being answered by the research team.
+* You are not getting answers from the research team.
+* You cannot reach the research team.
+* You want to talk to someone else about the research.
+* You have questions about your rights as a research subject.
+
+### Consent
+
+Assent of children is not required. Documentation of assent is not required.
+
+By checking the box below and clicking 'Submit' I am placing my electronic signature on this informed consent form. I
+acknowledge that I have read and understand the information in this consent form. I have had an opportunity to ask
+questions and all of my questions have been answered to my satisfaction. I voluntarily agree to participate in this
+Project until I decide otherwise. I do not give up any of my legal rights by signing and dating this consent form. I
+can receive a copy of this consent form. I hereby authorize the use and disclosure of my personal information,
+including information about my physical, mental, and reproductive health, as described in this consent form.

--- a/consent/loader/content/big_data_donation_project.v2.md
+++ b/consent/loader/content/big_data_donation_project.v2.md
@@ -7,6 +7,9 @@
 **PROTOCOL NO.:**    None   
 WCG IRB Protocol #20243599
 
+**IRB APPROVED**  
+**AS MODIFIED:**    May 13, 2026
+
 **SPONSOR:**    Tidepool Project
 
 **INVESTIGATOR:**    Saira Khan-Gallo, MPH  

--- a/consent/loader/content/ripple.v1.md
+++ b/consent/loader/content/ripple.v1.md
@@ -7,6 +7,8 @@
 **PROTOCOL NO.:**    None   
 WCG IRB Protocol #20243599
 
+**IRB APPROVED:**    May 13, 2026
+
 **SPONSOR:**    Tidepool Project
 
 **INVESTIGATOR:**    Saira Khan-Gallo, MPH  

--- a/consent/loader/content/ripple.v1.md
+++ b/consent/loader/content/ripple.v1.md
@@ -1,12 +1,303 @@
-### RIPPLE Study
+### Tidepool Big Data Donation Project
 
-# Informed Consent Form
+# RIPPLE Study Informed Consent Information Sheet
 
-**TITLE:**    RIPPLE Study Consent
+**TITLE:**    Tidepool Big Data Donation Project Study Protocol
+
+**PROTOCOL NO.:**    None   
+WCG IRB Protocol #20243599
 
 **SPONSOR:**    Tidepool Project
 
-**STUDY-RELATED**
+**INVESTIGATOR:**    Saira Khan-Gallo, MPH  
+555 Bryant St. #429  
+Palo Alto, California 94301  
+United States
+
+**STUDY-RELATED**  
 **EMAIL ADDRESS:**    bigdataofficer@tidepool.org
 
 Your participation in this study is voluntary. You may decide not to participate or you may leave the study at any time.
+Your decision will not result in any penalty or loss of benefits to which you are otherwise entitled.
+
+If you have questions, concerns, or complaints, or think this research has hurt you, talk to the research team at the
+phone number(s) listed in this document.
+
+## Research Consent Summary
+
+You are being asked for your consent to take part in a research study. This document provides a concise summary of this
+research. It describes the key information that we believe most people need to decide whether to take part in this
+research. Later sections of this document will provide all relevant details.
+
+### How long will I be in this research?
+
+We expect that your taking part in this research will last 1 year. If you wish to renew Oura membership at your own
+expense after 1 year, you may continue donating data for as long as the project continues, which may be years.
+
+### Why is this research being done?
+
+The purpose of RIPPLE is to support observational research examining how sleep, physical activity, and physiological
+patterns measured by wearable devices, such as the Oura Ring, relate to diabetes and pre-diabetes management in
+real-world settings.
+
+### What happens to me if I agree to take part in this research?
+
+If you decide to take part in this research study, the general procedures include, completing a health data survey,
+creating or using an existing Oura account, connecting your Oura account to your Tidepool account, wearing the Oura
+Ring most of the time.
+
+### Could being in this research hurt me?
+
+The most important risks or discomforts that you may expect from taking part in this research include an increased
+possibility that a research partner could match wearable data included in a research dataset with other information
+they hold and potentially re-identify your data
+
+### Will being in this research benefit me?
+
+It is not expected that you will personally benefit from this research. Information learned in this study may help
+people with diabetes in the future.
+
+### What other choices do I have besides taking part in this research?
+
+The only alternative is to not participate in this study.
+
+### What else should I know about this research?
+
+Other information that may be important for you to consider so you can decide whether to take part in this research is
+you are responsible for a one-time $20 shipping fee to receive the ring and sizing kit
+
+There is a possibility that your deidentified information or biospecimens may be used or distributed for future
+research studies without your additional informed consent.
+
+## Detailed Research Information
+
+You are invited to take part in **RIPPLE (Real-world Insights into Physiology, Patterns, and Lived Experiences in
+Diabetes)**, an **optional substudy** of the Tidepool Big Data Donation Project (TBDDP).
+
+This form applies **only** to the RIPPLE substudy and does **not** replace or change the TBDDP consent. Your TBDDP
+consent will be emailed to you for your reference.
+
+Participation in RIPPLE is voluntary. You may choose not to participate or may withdraw at any time without penalty.
+Choosing not to join RIPPLE will not affect your participation in TBDDP or your ability to use Tidepool products and
+services.
+
+### Background and Purpose
+
+The purpose of RIPPLE is to support observational research examining how sleep, physical activity, and physiological
+patterns measured by wearable devices relate to diabetes and pre-diabetes management in real-world settings.
+
+RIPPLE links wearable data collected through the Oura Ring with diabetes device data already donated to the TBDDP. This
+study does **not** involve any clinical intervention, diagnosis, treatment, or medical decision-making.
+
+Oura is not the sponsor or operator of this study. Oura's role is limited to donating devices and limited technical
+support related to account setup and activation. Oura is not responsible for the design, conduct, or oversight of
+RIPPLE or the TBDDP.
+
+### Eligible Participants
+
+You may participate in RIPPLE if you:
+
+* Are 18 years of age or older
+* Reside in the United States
+* Have a Tidepool account
+* Have the ability to upload your diabetes device data
+* Have completed the TBDDP informed consent
+* Have been diagnosed with a form of diabetes or pre-diabetes
+* Are willing to wear an Oura Ring most of the time
+* Are willing to complete one or more health data surveys
+
+### Project Procedures
+
+If you choose to participate:
+
+* You will receive a refurbished Oura Ring Gen 3, subject to availability
+* You will be asked to:
+    * Complete a health data survey
+    * Order a ring sizing kit and ring
+    * Create or use an existing Oura account
+    * Connect your Oura account to your Tidepool account
+
+You are responsible for a one-time $20 shipping fee to receive the ring and sizing kit. The ring and sizing kit will be
+no additional cost. No other costs are required. The Oura Ring is provided as part of a research program and is not
+being sold to you by Oura.
+
+After one year, your Oura membership will expire. You may choose to continue the membership at your own expense.
+
+Tidepool is responsible for all study-related, ordering, shipping, and participant support. Oura does not provide
+product warranty, replacements, or general customer support for devices provided through this study.
+
+#### Data Collection
+
+In addition to data already contributed to the TBDDP, RIPPLE includes:
+
+* Wearable data collected via the Oura Ring (such as sleep, activity, heart rate, temperature trends, and other
+  physiological metrics), and
+* Responses to a health data survey.
+
+Wearable and survey data will be linked with your existing TBDDP data and used for research purposes consistent with
+the goals of the TBDDP. No individualized feedback, clinical recommendations, or medical advice will be provided as
+part of this study.
+
+Wearable data is collected by Oura under Oura's Terms of Use and Privacy Policy. Oura processes such data independently
+of Tidepool. Tidepool only receives data from Oura that you choose to share with Tidepool for purposes of this study.
+Tidepool will use and disclose any such data according to the authorizations you provide by signing this consent form
+and the TBDDP consent form.
+
+### Risks
+
+In addition to the risks described in the TBDDP informed consent, participation in RIPPLE involves **additional privacy
+risks**.
+
+Because you are receiving a wearable device through this study:
+
+* Some research partners who receive TBDDP datasets may manufacture or support wearable devices and may already hold
+  information about you (for example, through device registration, account data, or device fulfillment).
+* This increases the possibility that a partner could match wearable data included in a research dataset with other
+  information they hold and potentially re-identify your data.
+
+Any attempt to re-identify participants is **strictly prohibited** by Tidepool's data use agreements. However, the risk
+of re-identification **cannot be completely eliminated**.
+
+Additional considerations include:
+
+* Your **name, email address, shipping address, and payment information** will be shared with fulfillment partners
+  **only as necessary** to ship the device and activate your membership. Oura is not a fulfillment partner.
+* Wearable data are collected by Oura in accordance with Oura's Terms of Use and Privacy Policy. Tidepool does not
+  control how Oura collects or uses data. Tidepool only controls data after it is shared with Tidepool for this study.
+  Oura collects and uses your data under its own terms and privacy policy; Tidepool only receives a subset of Oura data
+  specifically authorized for this study.
+* The Oura Ring is not a medical device and should not be used to diagnose, treat, cure, or prevent any medical disease
+  or medical condition. The services provided by Oura are for informational purposes only and cannot replace the
+  services of physicians or medical professionals. See Oura's Terms of Use for more information.
+
+Oura Ring devices are provided as-is and may not be replaced in the event of loss, damage, or sizing issues.
+
+There is also a possibility of risks that we do not know about. If you have any questions or concerns, you should speak
+with the Tidepool's Big Data Donation Project officer bigdataofficer@tidepool.org.
+
+By agreeing to this consent form, you do not give up any of your legal rights against the researchers, sponsor or
+involved institutions, nor does this form relieve the researchers, sponsor or involved institutions of their legal and
+professional responsibilities.
+
+### Benefits and Alternatives
+
+You will not be paid for taking part in this Project and you may not receive direct benefit from being in this Project.
+You will be able to keep the Oura Ring provided to you. This Project is for research and innovation purposes only. The
+only alternative is to not participate in this Project. You may continue to use Tidepool without participating in this
+Project. If you choose to not take part in this Project, you will not lose any benefits or medical care to which you
+are otherwise entitled. You do not have to agree to this consent form, but if you do not, you will not be able to
+participate in this Project.
+
+Information learned in this Project may help people with diabetes in the future, but individual or aggregate research
+results may not be reported back to you. If the Project or related research leads to the development of new or the
+improvement of existing diagnostic tests, treatments, patents, therapies, or other commercial products, you will not
+receive any part of the profits generated from such products. Your information will be used to conduct future research
+without your further consent.
+
+### Withdrawal from the Project
+
+You can decide to leave the Project at any time. You can opt out of this Project by logging into your account, clicking
+on the account name at the top of the page to navigate to your profile settings, clicking the link to 'Stop sharing
+data', and confirming your decision.
+
+If you decide to opt out of the Project, the information that was collected before you left the Project will still be
+used to support this Project, and the previously donated/anonymized data cannot be removed. No new information will be
+collected without your permission.
+
+You may be asked to leave the Project early for reasons such as:
+
+* the Project team does not believe that this Project is in your best interest;
+* it is discovered that you do not meet the Project eligibility requirements;
+* the Project is canceled for any reason; or
+* for administrative reasons.
+
+### Data Use, Sharing, Retention, and Confidentiality
+
+The records related to this Project will be handled and safeguarded according to the applicable state and federal laws
+governing the confidentiality of personal information and health information. The Project Team takes steps to keep your
+information confidential.
+
+Your personal information will be kept secure by the Project Team and will only be used as outlined in this consent
+form for the purposes of this Project. It will be shared with other institutions only as necessary to support the
+Project, for regulatory reporting, for oversight over the Project, or as described in this consent form. Your records
+of being in this Project will be kept private except as described in this consent form or when otherwise ordered
+required to be released by applicable law.  You may control what data from Oura is shared with Tidepool through
+available account settings.
+
+The Project team may also share Project data with the following:
+
+* Tidepool, its representatives, or others working on its behalf;
+* Partner companies and research institutions including monitor(s) and auditor(s) or designees who have entered into
+  agreements with Tidepool to conduct research on Project data;
+* The U.S. Food and Drug Administration ("FDA");
+* The U.S. Department of Health and Human Services ("HHS");
+* Other U.S. state or federal regulatory or law enforcement agencies, only with valid subpoena;
+* Institutional Review Boards ("IRB");
+* Outside individuals and companies, such as laboratories and data storage companies, that work with the Project team
+  and Tidepool and need to access your information to support this Project;
+* Other research personnel and institutions participating in this Project, including Oura, who have been approved by
+  Tidepool and entered into agreements as appropriate; and
+* A data safety monitoring board which oversees this Project, if applicable.
+
+Before sharing project data with others, the Project Team will seek to remove any directly identifiable information to
+the extent possible and permitted by applicable law and legal obligations.
+
+Your information will be assigned a unique code before being included in the larger data repository. Prior to including
+your information in the dataset that may be shared with authorized researchers, Tidepool replaces your Tidepool user
+identifier with this unique code. These identifiers cannot be decoded into their original form, but they allow
+researchers to correlate datasets over time from the same user. This hash value will be used to identify, evaluate, and
+report your information in the Project.
+
+Your information will be used and disclosed to conduct and oversee the Project, including for example:
+
+* To support and carry out the Project and future research.
+* To contact you about the Project or other research opportunities you may be interested in or eligible for.
+* To compare or combine the Project data with other studies and design or improve future studies.
+* To analyze Project data and publish results related to the Project.
+* To obtain regulatory approvals and comply with applicable legal obligations.
+* To check if the Project is being done properly and safely.
+* To help Tidepool develop, design, approve, improve, production, publication, or support of health and wellness
+  products, technologies, processes, and services, including to develop a better understanding of and new ways to
+  identify, prevent, or otherwise address certain health conditions or wellness issues, including algorithm development.
+* To help researchers:
+    * identify better insights and discoveries in a range of health and wellness areas, including diabetes management,
+    * build better algorithms for closed loop systems,
+    * bring safer or more innovative products to market, and/or
+    * enable Tidepool and other diabetes nonprofits to become stronger, more impactful organizations.
+
+Once the Project data has been shared with authorized researchers, it may no longer be protected by federal privacy law
+and could possibly be further used or disclosed in ways other than those listed here.
+
+Your permission to use and share information about you, including your health information, will expire in 50 years from
+the date you sign below, unless you, your estate, or legal representative revoke it (take it back) sooner. Your Project
+data will only be retained for as long as needed for the purposes of this Project.
+
+Information from the Project may be published or presented at meetings; however, you will not be identified by name.
+Your identity will remain confidential unless applicable law requires disclosure.
+
+Oura's Terms of Use and Privacy Policy may include provisions regarding use of your data and restrictions on liability
+that differ from the language included in this consent. Please ensure you read this information when agreeing to use
+Oura.
+
+### Questions
+
+If you have any questions, concerns, or would like to speak to the Project Team for any reason, please contact them at:
+bigdataofficer@tidepool.org.
+
+This research is being overseen by WCG IRB. An IRB (Institutional Review Board) is a group of people who perform
+independent review of research studies. You may talk to them at 855-818-2289 or clientcare@wcgclinical.com if:
+
+* You have questions, concerns, or complaints that are not being answered by the research team.
+* You are not getting answers from the research team.
+* You cannot reach the research team.
+* You want to talk to someone else about the research.
+* You have questions about your rights as a research subject.
+
+### Consent
+
+By checking the box below and clicking 'Submit' I am placing my electronic signature on this informed consent form. I
+acknowledge that I have read and understand the information in this consent form. I have had an opportunity to ask
+questions and all of my questions have been answered to my satisfaction. I voluntarily agree to participate in this
+Project until I decide otherwise. I do not give up any of my legal rights by signing and dating this consent form. I
+can receive a copy of this consent form. I hereby authorize the use and disclosure of my personal information,
+including information about my health, as described in this consent form.

--- a/customerio/customer.go
+++ b/customerio/customer.go
@@ -27,8 +27,13 @@ type Attributes struct {
 	OuraSizingKitDiscountCode string `json:"oura_sizing_kit_discount_code,omitempty"`
 	OuraRingDiscountCode      string `json:"oura_ring_discount_code,omitempty"`
 	OuraParticipantID         string `json:"oura_participant_id,omitempty"`
+	OuraSkipSizingKit         string `json:"oura_skip_sizing_kit,omitempty"`
 
 	Update bool `json:"_update,omitempty"`
+}
+
+func (a Attributes) ShouldSkipSizingKitCampaign() bool {
+	return a.OuraSkipSizingKit == "true"
 }
 
 type customerResponse struct {

--- a/oura/events.go
+++ b/oura/events.go
@@ -12,6 +12,7 @@ type OuraEligibilitySurveyCompletedData struct {
 	OuraEligibilitySurveyID       string `json:"oura_eligibility_survey_id"`
 	OuraEligibilitySurveyEligible bool   `json:"oura_eligibility_survey_eligible"`
 	OuraSizingKitDiscountCode     string `json:"oura_sizing_kit_discount_code,omitempty"`
+	OuraRingDiscountCode          string `json:"oura_ring_discount_code,omitempty"`
 }
 
 type OuraSizingKitOrderedData struct {

--- a/oura/jotform/processor.go
+++ b/oura/jotform/processor.go
@@ -263,17 +263,35 @@ func (s *SubmissionProcessor) handleSurveyCompleted(ctx context.Context, custome
 			return err
 		}
 
-		surveyCompletedData.OuraSizingKitDiscountCode = shopify.RandomDiscountCode()
-		err := s.shopifyClient.CreateDiscountCode(ctx, shopify.DiscountCodeInput{
-			Title:     shopify.OuraSizingKitDiscountCodeTitle,
-			Code:      surveyCompletedData.OuraSizingKitDiscountCode,
-			ProductID: shopify.OuraSizingKitProductID,
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to create oura ring discount code")
+		// Generate a sizing kit discount code if the user must order a sizing kit first
+		if !customer.ShouldSkipSizingKitCampaign() {
+			surveyCompletedData.OuraSizingKitDiscountCode = shopify.RandomDiscountCode()
+			err := s.shopifyClient.CreateDiscountCode(ctx, shopify.DiscountCodeInput{
+				Title:     shopify.OuraSizingKitDiscountCodeTitle,
+				Code:      surveyCompletedData.OuraSizingKitDiscountCode,
+				ProductID: shopify.OuraSizingKitProductID,
+			})
+			if err != nil {
+				return errors.Wrap(err, "unable to create oura sizing kit discount code")
+			}
 		}
 	}
 
+	if err := s.sendSurveyCompleted(ctx, customer, surveyCompletedData); err != nil {
+		return errors.Wrap(err, "unable to send survey completed event")
+	}
+
+	// Send a "fake" sizing kit delivered event with a ring discount code to advance the user straight to the ring campaign
+	if customer.ShouldSkipSizingKitCampaign() {
+		if err := s.sendSizingKitDeliveredEvent(ctx, customer); err != nil {
+			return errors.Wrap(err, "unable to send sizing kit delivered event")
+		}
+	}
+
+	return nil
+}
+
+func (s *SubmissionProcessor) sendSurveyCompleted(ctx context.Context, customer customerio.Customer, surveyCompletedData oura.OuraEligibilitySurveyCompletedData) error {
 	surveyCompleted := &customerio.Event{
 		Name: oura.OuraEligibilitySurveyCompletedEventType,
 		Data: surveyCompletedData,
@@ -291,6 +309,31 @@ func (s *SubmissionProcessor) handleSurveyCompleted(ctx context.Context, custome
 	}
 
 	return nil
+}
+
+func (s *SubmissionProcessor) sendSizingKitDeliveredEvent(ctx context.Context, customer customerio.Customer) error {
+	discountCode := shopify.RandomDiscountCode()
+	err := s.shopifyClient.CreateDiscountCode(ctx, shopify.DiscountCodeInput{
+		Title:     shopify.OuraRingDiscountCodeTitle,
+		Code:      discountCode,
+		ProductID: shopify.OuraRingProductID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to create oura ring discount code")
+	}
+
+	sizingKitDelivered := &customerio.Event{
+		Name: oura.OuraSizingKitDeliveredEventType,
+		Data: oura.OuraSizingKitDeliveredData{
+			OuraRingDiscountCode: discountCode,
+		},
+	}
+
+	if err = sizingKitDelivered.SetDeduplicationID(nil, customer.OuraParticipantID); err != nil {
+		return err
+	}
+
+	return s.customerIOClient.SendEvent(ctx, customer.Identifiers.ID, sizingKitDelivered)
 }
 
 func (s *SubmissionProcessor) ensureConsentRecordExists(ctx context.Context, userID string, submission *SubmissionResponse, survey OuraEligibilitySurvey) error {

--- a/oura/jotform/processor_test.go
+++ b/oura/jotform/processor_test.go
@@ -1,9 +1,11 @@
 package jotform_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -213,6 +215,98 @@ var _ = Describe("SubmissionProcessor", func() {
 
 			err = processor.ProcessSubmission(ctx, submissionID)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create a ring discount code instead of a sizing kit discount code when the customer has oura_skip_sizing_kit set", func() {
+			submissionID := "6410095903544943563"
+			userID := "1aacb960-430c-4081-8b3b-a32688807dc5"
+
+			submission, err := ouraTest.LoadFixture("./test/fixtures/submission.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			jotformResponses.AddResponse(
+				[]ouraTest.RequestMatcher{ouraTest.NewRequestMethodAndPathMatcher(http.MethodGet, "/v1/submission/"+submissionID)},
+				ouraTest.Response{StatusCode: http.StatusOK, Body: submission},
+			)
+
+			customer, err := ouraTest.LoadFixture("./test/fixtures/customer_skip_sizing_kit.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			appAPIResponses.AddResponse(
+				[]ouraTest.RequestMatcher{ouraTest.NewRequestMethodAndPathMatcher(http.MethodGet, "/v1/customers/"+userID+"/attributes")},
+				ouraTest.Response{StatusCode: http.StatusOK, Body: customer},
+			)
+
+			var ringDiscountCode string
+			shopifyClnt.EXPECT().
+				CreateDiscountCode(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, input shopify.DiscountCodeInput) error {
+					Expect(input.Title).To(Equal(shopify.OuraRingDiscountCodeTitle))
+					Expect(len(input.Code)).To(BeNumerically(">=", 12))
+					Expect(input.ProductID).To(Equal(shopify.OuraRingProductID))
+					ringDiscountCode = input.Code
+					return nil
+				})
+
+			// Capture every customer.io event so we can assert that the survey completed
+			// event carries no discount codes and that a separate sizing kit delivered
+			// event is sent with the generated ring discount code.
+			var eventBodies [][]byte
+			trackAPIResponses.AddResponse(
+				[]ouraTest.RequestMatcher{
+					ouraTest.NewRequestMethodAndPathMatcher(http.MethodPost, "/api/v1/customers/"+userID+"/events"),
+					func(r *http.Request) bool {
+						body, readErr := io.ReadAll(r.Body)
+						if readErr != nil {
+							return false
+						}
+						eventBodies = append(eventBodies, body)
+						r.Body = io.NopCloser(bytes.NewReader(body))
+						return true
+					},
+				},
+				ouraTest.Response{StatusCode: http.StatusOK, Body: "{}"},
+			)
+
+			usr := &user.User{UserID: &userID}
+			userClient.EXPECT().Get(gomock.Any(), userID).Return(usr, nil)
+
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "ripple").
+				Return(nil, nil)
+			consentService.EXPECT().GetActiveConsentRecord(gomock.Any(), userID, "big_data_donation_project").
+				Return(nil, nil)
+			consentService.EXPECT().ListConsents(ctx, gomock.Any(), gomock.Any()).
+				Return(&storeStructuredMongo.ListResult[consent.Consent]{
+					Count: 1,
+					Data: []consent.Consent{{
+						Type:    "big_data_donation_project",
+						Version: 2,
+					}},
+				}, nil)
+			consentService.EXPECT().CreateConsentRecords(gomock.Any(), userID, gomock.Any()).
+				Return([]*consent.Record{}, nil)
+
+			err = processor.ProcessSubmission(ctx, submissionID)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(ringDiscountCode).ToNot(BeEmpty())
+			Expect(eventBodies).To(HaveLen(2))
+
+			type capturedEvent struct {
+				Name string         `json:"name"`
+				Data map[string]any `json:"data"`
+			}
+
+			var surveyCompleted capturedEvent
+			Expect(json.Unmarshal(eventBodies[0], &surveyCompleted)).To(Succeed())
+			Expect(surveyCompleted.Name).To(Equal(oura.OuraEligibilitySurveyCompletedEventType))
+			Expect(surveyCompleted.Data).ToNot(HaveKey("oura_sizing_kit_discount_code"))
+			Expect(surveyCompleted.Data).ToNot(HaveKey("oura_ring_discount_code"))
+
+			var sizingKitDelivered capturedEvent
+			Expect(json.Unmarshal(eventBodies[1], &sizingKitDelivered)).To(Succeed())
+			Expect(sizingKitDelivered.Name).To(Equal(oura.OuraSizingKitDeliveredEventType))
+			Expect(sizingKitDelivered.Data["oura_ring_discount_code"]).To(Equal(ringDiscountCode))
 		})
 
 		It("should mark the survey is ineligible if date of birth is missing", func() {

--- a/oura/jotform/test/fixtures/customer_skip_sizing_kit.json
+++ b/oura/jotform/test/fixtures/customer_skip_sizing_kit.json
@@ -1,0 +1,33 @@
+{
+  "customer": {
+    "id": "01234567890",
+    "identifiers": {
+      "cio_id": "cio_0987654321",
+      "email": "james.jellyfish@tidepool.org",
+      "id": "1aacb960-430c-4081-8b3b-a32688807dc5"
+    },
+    "attributes": {
+      "Opted In": "Y",
+      "Recent Data": "Y",
+      "cio_id": "cio_0987654321",
+      "created_at": "1750853383",
+      "email": "james.jellyfish@tidepool.org",
+      "id": "1aacb960-430c-4081-8b3b-a32688807dc5",
+      "oura_participant_id": "06336454-cf65-11f0-b3af-fac742a1f967",
+      "oura_skip_sizing_kit": "true"
+    },
+    "timestamps": {
+      "Opted In": 1750853452,
+      "Recent Data": 1750853452,
+      "cio_id": 1750853452,
+      "created_at": 1750853452,
+      "email": 0,
+      "id": 1750853452,
+      "oura_participant_id": 1764669325,
+      "oura_skip_sizing_kit": 1764669325,
+      "ring_submitted_date": 1750854043
+    },
+    "unsubscribed": false,
+    "devices": []
+  }
+}


### PR DESCRIPTION
- Added the finalized consent content for BDDP and Ripple
- Added a short-circuit for skipping the sizing kit campaign