### PR TITLE
[BACK-3938] Add has data method to data client.

### DIFF
--- a/data/client/client.go
+++ b/data/client/client.go
@@ -121,6 +121,22 @@ func (c *ClientImpl) GetDataSet(ctx context.Context, id string) (*data.DataSet, 
 	return dataSet, nil
 }
 
+func (c *ClientImpl) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	if ctx == nil {
+		return false, errors.New("context is missing")
+	}
+
+	url := c.client.ConstructURL("v1", "users", userID, "data", "exists")
+	if err := c.client.RequestData(ctx, http.MethodGet, url, nil, nil, nil); err != nil {
+		if request.IsErrorResourceNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (c *ClientImpl) GetCGMSummary(ctx context.Context, userId string) (*types.Summary[*types.CGMPeriods, *types.GlucoseBucket, types.CGMPeriods, types.GlucoseBucket], error) {
 	if ctx == nil {
 		return nil, errors.New("context is missing")

--- a/data/data_set.go
+++ b/data/data_set.go
@@ -26,6 +26,7 @@ type DataSetAccessor interface {
 	GetDataSet(ctx context.Context, id string) (*DataSet, error)
 	UpdateDataSet(ctx context.Context, id string, update *DataSetUpdate) (*DataSet, error)
 	DeleteDataSet(ctx context.Context, id string) error
+	HasAnyData(ctx context.Context, userID string) (has bool, err error)
 }
 
 const (

--- a/data/service/api/v1/users_data_exists.go
+++ b/data/service/api/v1/users_data_exists.go
@@ -1,0 +1,38 @@
+package v1
+
+import (
+	"net/http"
+
+	dataService "github.com/tidepool-org/platform/data/service"
+	"github.com/tidepool-org/platform/request"
+)
+
+func GetHasAnyData(dataServiceContext dataService.Context) {
+	res := dataServiceContext.Response()
+	req := dataServiceContext.Request()
+	responder := request.MustNewResponder(res, req)
+	dataClient := dataServiceContext.DataClient()
+	userID := req.PathParam("userId")
+
+	has, err := dataClient.HasAnyData(req.Context(), userID)
+	if err != nil {
+		responder.Error(http.StatusInternalServerError, err)
+		return
+	}
+	if has {
+		responder.Empty(http.StatusCreated)
+		return
+	}
+
+	dataSourceClient := dataServiceContext.DataSourceClient()
+	has, err = dataSourceClient.HasAnyData(req.Context(), userID)
+	if err != nil {
+		responder.Error(http.StatusInternalServerError, err)
+		return
+	}
+	if has {
+		responder.Empty(http.StatusCreated)
+		return
+	}
+	responder.Error(http.StatusNotFound, request.ErrorResourceNotFoundWithID(userID))
+}

--- a/data/service/api/v1/v1.go
+++ b/data/service/api/v1/v1.go
@@ -23,6 +23,8 @@ func Routes() []service.Route {
 		service.Get("/v1/time", TimeGet),
 		service.Post("/v1/users/:userId/data_sets", UsersDataSetsCreate, api.RequireAuth),
 
+		service.Get("/v1/users/:userId/data/exists", GetHasAnyData, api.RequireServer),
+
 		service.Get("/v1/partners/:partner/sector/:environment", PartnersSector),
 		service.Get("/v1/partners/:partner/sector", PartnersSector), // DEPRECATED: Remove once Abbott sandbox client uses environment in path
 

--- a/data/service/service/client.go
+++ b/data/service/service/client.go
@@ -36,6 +36,11 @@ func (c *Client) ListUserDataSets(ctx context.Context, userID string, filter *da
 	return repository.ListUserDataSets(ctx, userID, filter, pagination)
 }
 
+func (c *Client) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	repository := c.dataStore.NewDataRepository()
+	return repository.HasAnyData(ctx, userID)
+}
+
 func (c *Client) CreateUserDataSet(ctx context.Context, userID string, create *data.DataSetCreate) (*data.DataSet, error) {
 	repository := c.dataStore.NewDataRepository()
 

--- a/data/source/service/client.go
+++ b/data/source/service/client.go
@@ -11,4 +11,5 @@ type Client interface {
 	dataSource.Client
 
 	ListAll(ctx context.Context, filter *dataSource.Filter, pagination *page.Pagination) (dataSource.SourceArray, error)
+	HasAnyData(ctx context.Context, userID string) (has bool, err error)
 }

--- a/data/source/service/client/client.go
+++ b/data/source/service/client/client.go
@@ -60,3 +60,7 @@ func (c *Client) Delete(ctx context.Context, id string, condition *request.Condi
 func (c *Client) ListAll(ctx context.Context, filter *dataSource.Filter, pagination *page.Pagination) (dataSource.SourceArray, error) {
 	return c.DataSourceStructuredStore().NewDataSourcesRepository().ListAll(ctx, filter, pagination)
 }
+
+func (c *Client) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	return c.DataSourceStructuredStore().NewDataSourcesRepository().HasAnyData(ctx, userID)
+}

--- a/data/source/store/structured/mongo/mongo.go
+++ b/data/source/store/structured/mongo/mongo.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -333,6 +334,24 @@ func (c *DataSourcesRepository) ListAll(ctx context.Context, filter *dataSource.
 
 	lgr.WithFields(log.Fields{"count": len(result), "duration": time.Since(now) / time.Microsecond}).Debug("ListAll")
 	return result, nil
+}
+
+func (c *DataSourcesRepository) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	selector := bson.M{
+		"userId": userID,
+	}
+	opts := options.FindOne().SetProjection(bson.M{"_id": 1})
+	var doc struct {
+		ID primitive.ObjectID `bson:"_id"`
+	}
+	err = c.FindOne(ctx, selector, opts).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (c *DataSourcesRepository) list(ctx context.Context, userID *string, filter *dataSource.Filter, pagination *page.Pagination) (dataSource.SourceArray, error) {

--- a/data/source/store/structured/structured.go
+++ b/data/source/store/structured/structured.go
@@ -22,4 +22,5 @@ type DataSourcesRepository interface {
 	Destroy(ctx context.Context, id string, condition *request.Condition) (bool, error)
 
 	ListAll(ctx context.Context, filter *dataSource.Filter, pagination *page.Pagination) (dataSource.SourceArray, error)
+	HasAnyData(ctx context.Context, userID string) (has bool, err error)
 }

--- a/data/source/store/structured/test/data_sources_repository.go
+++ b/data/source/store/structured/test/data_sources_repository.go
@@ -235,6 +235,10 @@ func (d *DataRepository) ListAll(ctx context.Context, filter *dataSource.Filter,
 	panic("ListAll has no output")
 }
 
+func (d *DataRepository) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	return false, nil
+}
+
 func (d *DataRepository) AssertOutputsEmpty() {
 	d.Closer.AssertOutputsEmpty()
 	if len(d.ListOutputs) > 0 {

--- a/data/store/mongo/mongo_data.go
+++ b/data/store/mongo/mongo_data.go
@@ -37,6 +37,10 @@ func (d *DataRepository) ListUserDataSets(ctx context.Context, userID string, fi
 	return d.DataSetRepository.ListUserDataSets(ctx, userID, filter, pagination)
 }
 
+func (d *DataRepository) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	return d.DataSetRepository.HasAnyData(ctx, userID)
+}
+
 func (d *DataRepository) GetDataSet(ctx context.Context, dataSetID string) (*data.DataSet, error) {
 	return d.DataSetRepository.GetDataSet(ctx, dataSetID)
 }

--- a/data/store/mongo/mongo_data_set.go
+++ b/data/store/mongo/mongo_data_set.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -125,6 +126,24 @@ func (d *DataSetRepository) createDataSet(ctx context.Context, dataSet *data.Dat
 	}
 
 	return d.GetDataSet(ctx, *dataSet.ID)
+}
+
+func (d *DataSetRepository) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	selector := bson.M{
+		"_userId": userID,
+	}
+	opts := options.FindOne().SetProjection(bson.M{"_id": 1})
+	var doc struct {
+		ID primitive.ObjectID `bson:"_id"`
+	}
+	err = d.FindOne(ctx, selector, opts).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (d *DataSetRepository) updateDataSet(ctx context.Context, id string, update *data.DataSetUpdate, now time.Time) (*data.DataSet, error) {

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -42,6 +42,7 @@ type DataSetRepository interface {
 	ListUserDataSets(ctx context.Context, userID string, filter *data.DataSetFilter, pagination *page.Pagination) (data.DataSets, error)
 	CreateUserDataSet(ctx context.Context, userID string, create *data.DataSetCreate) (*data.DataSet, error)
 	GetDataSet(ctx context.Context, dataSetID string) (*data.DataSet, error)
+	HasAnyData(ctx context.Context, userID string) (has bool, err error)
 }
 
 // DatumRepository is the interface for interacting and modifying

--- a/data/store/test/data_repository.go
+++ b/data/store/test/data_repository.go
@@ -546,6 +546,10 @@ func (d *DataRepository) GetAlertableData(ctx context.Context, params dataStore.
 	return output.Response, output.Error
 }
 
+func (d *DataRepository) HasAnyData(ctx context.Context, userID string) (has bool, err error) {
+	return false, nil
+}
+
 func (d *DataRepository) Expectations() {
 	d.Closer.AssertOutputsEmpty()
 	gomega.Expect(d.GetDataSetsForUserByIDOutputs).To(gomega.BeEmpty())


### PR DESCRIPTION
Add HasAnyData for platform-data clients and corresponding route for use by clinic-worker to query for before potentially deleting a user.