### PR TITLE
Updates from PR reviews and testing

### DIFF
--- a/oura/data/work/event/processor.go
+++ b/oura/data/work/event/processor.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	FailingRetryDuration       = 1 * time.Minute
-	FailingRetryDurationJitter = 5 * time.Second
+	FailingRetryDuration        = 1 * time.Minute
+	FailingRetryDurationJitter  = 5 * time.Second
+	FailingRetryDurationMaximum = 1 * time.Hour
 )
 
 type (
@@ -87,8 +88,9 @@ func NewProcessor(dependencies ouraDataWork.Dependencies) (*Processor, error) {
 
 	processResultBuilder := &workBase.ProcessResultBuilder{
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 

--- a/oura/data/work/event/processor_test.go
+++ b/oura/data/work/event/processor_test.go
@@ -54,6 +54,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraDataWorkEvent.FailingRetryDurationJitter).To(Equal(5 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraDataWorkEvent.FailingRetryDurationMaximum).To(Equal(1 * time.Hour))
+	})
+
 	Context("Metadata", func() {
 		DescribeTable("serializes the datum as expected",
 			func(mutator func(datum *ouraDataWorkEvent.Metadata)) {
@@ -271,6 +275,16 @@ var _ = Describe("processor", func() {
 								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchFailedProcessResultError(MatchError("data source data set id is missing")))
 							})
 
+							It("with missing scope returns delete process result if successful", func() {
+								providerSession.OAuthToken.Scope = nil
+								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchDeleteProcessResult())
+							})
+
+							It("with empty scope returns delete process result if successful", func() {
+								providerSession.OAuthToken.Scope = pointer.From([]string{})
+								Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchDeleteProcessResult())
+							})
+
 							It("returns successfully if event data type is not in scope", func() {
 								providerSession.OAuthToken.Scope = pointer.From(slices.DeleteFunc(oura.Scopes(), func(scope string) bool {
 									return oura.DataTypeInScope(*event.DataType, scope)
@@ -362,16 +376,6 @@ var _ = Describe("processor", func() {
 												BeforeEach(func() {
 													updatedDataSource := dataSourceTest.RandomSource(test.AllowOptionals())
 													mockDataSourceClient.EXPECT().Update(gomock.Not(gomock.Nil()), dataSourceID, nil, expectedDataSourceUpdate).Return(updatedDataSource, nil)
-												})
-
-												It("with missing scope returns delete process result if successful", func() {
-													providerSession.OAuthToken.Scope = nil
-													Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchDeleteProcessResult())
-												})
-
-												It("with empty scope returns delete process result if successful", func() {
-													providerSession.OAuthToken.Scope = pointer.From([]string{})
-													Expect(processor.Process(ctx, wrk, mockProcessingUpdater)).To(workTest.MatchDeleteProcessResult())
 												})
 
 												It("with existing scope returns delete process result if successful", func() {

--- a/oura/data/work/historic/processor.go
+++ b/oura/data/work/historic/processor.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	FailingRetryDuration       = 1 * time.Minute
-	FailingRetryDurationJitter = 5 * time.Second
+	FailingRetryDuration        = 1 * time.Minute
+	FailingRetryDurationJitter  = 5 * time.Second
+	FailingRetryDurationMaximum = 1 * time.Hour
 )
 
 func DataTypes() []string {
@@ -102,8 +103,9 @@ func NewProcessor(dependencies ouraDataWork.Dependencies) (*Processor, error) {
 
 	processResultBuilder := &workBase.ProcessResultBuilder{
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 
@@ -187,7 +189,8 @@ func (p *Processor) fetchData() *work.ProcessResult {
 
 		for {
 			// Fetch page of data for data type
-			dataResponse, err := p.GetData(ctx, dataType, p.Metadata().TimeRange, &pagination, p.TokenSource())
+			timeRange := p.Metadata().TimeRange
+			dataResponse, err := p.GetData(ctx, dataType, timeRange, &pagination, p.TokenSource())
 			if err != nil {
 				return p.Failing(errors.Wrapf(err, "unable to get data for data type %q", dataType))
 			} else if dataResponse == nil {
@@ -198,7 +201,7 @@ func (p *Processor) fetchData() *work.ProcessResult {
 			// large data responses, so this is not a current issue
 
 			// Persist data
-			if result := p.createDataRaw(dataType, p.Metadata().TimeRange, dataResponse.Data); result != nil {
+			if result := p.createDataRaw(dataType, timeRange, dataResponse.Data); result != nil {
 				return result
 			}
 

--- a/oura/data/work/historic/processor_test.go
+++ b/oura/data/work/historic/processor_test.go
@@ -58,6 +58,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraDataWorkHistoric.FailingRetryDurationJitter).To(Equal(5 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraDataWorkHistoric.FailingRetryDurationMaximum).To(Equal(1 * time.Hour))
+	})
+
 	Context("DataTypes", func() {
 		It("returns expected data types", func() {
 			Expect(ouraDataWorkHistoric.DataTypes()).To(Equal(oura.EventDataTypes()))

--- a/oura/data/work/periodic/processor.go
+++ b/oura/data/work/periodic/processor.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	PendingAvailableDuration   = 12 * time.Hour // Data returned is for previous 24 hours, using 12 hours ensures we do not miss data
-	FailingRetryDuration       = 1 * time.Minute
-	FailingRetryDurationJitter = 5 * time.Second
+	PendingAvailableDuration    = 12 * time.Hour // Data returned is for previous 24 hours, using 12 hours ensures we do not miss data
+	FailingRetryDuration        = 1 * time.Minute
+	FailingRetryDurationJitter  = 5 * time.Second
+	FailingRetryDurationMaximum = 12 * time.Hour
 )
 
 func DataTypes() []string {
@@ -111,8 +112,9 @@ func NewProcessor(dependencies ouraDataWork.Dependencies) (*Processor, error) {
 			Duration: PendingAvailableDuration,
 		},
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 

--- a/oura/data/work/periodic/processor_test.go
+++ b/oura/data/work/periodic/processor_test.go
@@ -62,6 +62,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraDataWorkPeriodic.FailingRetryDurationJitter).To(Equal(5 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraDataWorkPeriodic.FailingRetryDurationMaximum).To(Equal(12 * time.Hour))
+	})
+
 	Context("DataTypes", func() {
 		It("returns expected data types", func() {
 			Expect(ouraDataWorkPeriodic.DataTypes()).To(Equal([]string{

--- a/oura/data/work/personal/processor.go
+++ b/oura/data/work/personal/processor.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	PendingAvailableDuration   = 12 * time.Hour // Data returned is for previous 24 hours, using 12 hours ensures we do not miss data
-	FailingRetryDuration       = 1 * time.Minute
-	FailingRetryDurationJitter = 5 * time.Second
+	PendingAvailableDuration    = 12 * time.Hour // Data returned is for previous 24 hours, using 12 hours ensures we do not miss data
+	FailingRetryDuration        = 1 * time.Minute
+	FailingRetryDurationJitter  = 5 * time.Second
+	FailingRetryDurationMaximum = 12 * time.Hour
 )
 
 const MetadataKeyPreviousHash = "previousHash"
@@ -87,8 +88,9 @@ func NewProcessor(dependencies ouraDataWork.Dependencies) (*Processor, error) {
 			Duration: PendingAvailableDuration,
 		},
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 
@@ -159,21 +161,22 @@ func (p *Processor) fetchData() *work.ProcessResult {
 	// If hash matches previous, then skip
 	hash, err := personalInfo.Hash()
 	if err != nil {
-		return p.Failed(errors.Wrap(err, "unable to compute hash of datum"))
+		return p.Failed(errors.Wrap(err, "unable to compute hash of personal info"))
 	}
 	if previousHash := p.Metadata().PreviousHash; previousHash != nil && hash == *previousHash {
-		log.LoggerFromContext(p.Context()).Debug("skipping datum with matching hash")
+		log.LoggerFromContext(p.Context()).Debug("skipping personal info with matching hash")
 		return nil
 	}
 
 	// Convert to datum
 	datum, err := metadata.Encode(personalInfo)
 	if err != nil {
-		return p.Failed(errors.Wrap(err, "unable to encode datum"))
+		return p.Failed(errors.Wrap(err, "unable to encode personal info"))
 	}
 
 	// Create data raw
-	if result := p.createDataRaw(oura.DataTypePersonalInfo, &times.TimeRange{To: pointer.From(p.Now())}, oura.Data{datum}); result != nil {
+	timeRange := &times.TimeRange{To: pointer.From(p.Now())}
+	if result := p.createDataRaw(oura.DataTypePersonalInfo, timeRange, oura.Data{datum}); result != nil {
 		return result
 	}
 

--- a/oura/data/work/personal/processor_test.go
+++ b/oura/data/work/personal/processor_test.go
@@ -60,6 +60,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraDataWorkPersonal.FailingRetryDurationJitter).To(Equal(5 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraDataWorkPersonal.FailingRetryDurationMaximum).To(Equal(12 * time.Hour))
+	})
+
 	It("MetadataKeyPreviousHash is expected", func() {
 		Expect(ouraDataWorkPersonal.MetadataKeyPreviousHash).To(Equal("previousHash"))
 	})

--- a/oura/oura.go
+++ b/oura/oura.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gowebpki/jcs"
+
 	"github.com/tidepool-org/platform/auth"
 	"github.com/tidepool-org/platform/crypto"
 	"github.com/tidepool-org/platform/data"
@@ -202,12 +204,11 @@ func ScopesForDataType(dataType string) []string {
 }
 
 func DataTypeInScopes(dataType string, scopes *[]string) bool {
-	if scopes == nil || len(*scopes) == 0 {
-		return true
-	}
-	for _, scope := range *scopes {
-		if DataTypeInScope(dataType, scope) {
-			return true
+	if scopes != nil {
+		for _, scope := range *scopes {
+			if DataTypeInScope(dataType, scope) {
+				return true
+			}
 		}
 	}
 	return false
@@ -385,6 +386,8 @@ func (e *Event) Validate(validator structure.Validator) {
 func (e *Event) Hash() (string, error) {
 	if bites, err := json.Marshal(e); err != nil {
 		return "", errors.Wrap(err, "unable to generate hash")
+	} else if bites, err = jcs.Transform(bites); err != nil {
+		return "", errors.Wrap(err, "unable to canonicalize hash")
 	} else {
 		return crypto.Base64EncodedSHA256Hash(bites), nil
 	}
@@ -440,6 +443,8 @@ func (p *PersonalInfo) Validate(validator structure.Validator) {
 func (p *PersonalInfo) Hash() (string, error) {
 	if bites, err := json.Marshal(p); err != nil {
 		return "", errors.Wrap(err, "unable to generate hash")
+	} else if bites, err = jcs.Transform(bites); err != nil {
+		return "", errors.Wrap(err, "unable to canonicalize hash")
 	} else {
 		return crypto.Base64EncodedSHA256Hash(bites), nil
 	}

--- a/oura/oura.go
+++ b/oura/oura.go
@@ -385,9 +385,9 @@ func (e *Event) Validate(validator structure.Validator) {
 
 func (e *Event) Hash() (string, error) {
 	if bites, err := json.Marshal(e); err != nil {
-		return "", errors.Wrap(err, "unable to generate hash")
+		return "", errors.Wrap(err, "unable to generate JSON for hash")
 	} else if bites, err = jcs.Transform(bites); err != nil {
-		return "", errors.Wrap(err, "unable to canonicalize hash")
+		return "", errors.Wrap(err, "unable to canonicalize JSON for hash")
 	} else {
 		return crypto.Base64EncodedSHA256Hash(bites), nil
 	}
@@ -442,9 +442,9 @@ func (p *PersonalInfo) Validate(validator structure.Validator) {
 
 func (p *PersonalInfo) Hash() (string, error) {
 	if bites, err := json.Marshal(p); err != nil {
-		return "", errors.Wrap(err, "unable to generate hash")
+		return "", errors.Wrap(err, "unable to generate JSON for hash")
 	} else if bites, err = jcs.Transform(bites); err != nil {
-		return "", errors.Wrap(err, "unable to canonicalize hash")
+		return "", errors.Wrap(err, "unable to canonicalize JSON for hash")
 	} else {
 		return crypto.Base64EncodedSHA256Hash(bites), nil
 	}

--- a/oura/oura_test.go
+++ b/oura/oura_test.go
@@ -330,12 +330,12 @@ var _ = Describe("oura", func() {
 	})
 
 	Context("DataTypeInScopes", func() {
-		It("returns true if scopes is nil", func() {
-			Expect(oura.DataTypeInScopes(oura.DataTypeDailyActivity, nil)).To(BeTrue())
+		It("returns false if scopes is nil", func() {
+			Expect(oura.DataTypeInScopes(oura.DataTypeDailyActivity, nil)).To(BeFalse())
 		})
 
-		It("returns true if scopes is empty", func() {
-			Expect(oura.DataTypeInScopes(oura.DataTypeDailyActivity, &[]string{})).To(BeTrue())
+		It("returns false if scopes is empty", func() {
+			Expect(oura.DataTypeInScopes(oura.DataTypeDailyActivity, &[]string{})).To(BeFalse())
 		})
 
 		It("returns false if scopes does not include data type", func() {
@@ -1226,27 +1226,29 @@ var _ = Describe("oura", func() {
 		})
 
 		Context("with event", func() {
-			var eventTime, _ = time.ParseInLocation(time.RFC3339Nano, "2026-01-15T20:15:42.123Z", time.UTC)
+			Context("Hash", func() {
+				var eventTime, _ = time.ParseInLocation(time.RFC3339Nano, "2026-01-15T20:15:42.123Z", time.UTC)
 
-			DescribeTable("Hash returns expected string",
-				func(eventTime *time.Time, eventType *string, userID *string, objectID *string, dataType *string, expectedHash string) {
-					datum := &oura.Event{
-						EventTime: eventTime,
-						EventType: eventType,
-						UserID:    userID,
-						ObjectID:  objectID,
-						DataType:  dataType,
-					}
-					Expect(datum.Hash()).To(Equal(expectedHash))
-				},
-				Entry("all", pointer.From(eventTime), pointer.From("alpha"), pointer.From("beta"), pointer.From("charlie"), pointer.From("delta"), "r6tSfxM7nHw3VapPUw9I/LtnjFBzd+5NOfCBsUd9yM0="),
-				Entry("event_time missing", nil, pointer.From("alpha"), pointer.From("beta"), pointer.From("charlie"), pointer.From("delta"), "pfx/tnsxL/JWx1T/WZC6NIqTWwlIMJoLiAvRtK+B4vY="),
-				Entry("event_type missing", pointer.From(eventTime), nil, pointer.From("beta"), pointer.From("charlie"), pointer.From("delta"), "sUkvKDFwLh28pjcVnt8VJY9CTjTwjoxqsRme4GX/PQE="),
-				Entry("user_id missing", pointer.From(eventTime), pointer.From("alpha"), nil, pointer.From("charlie"), pointer.From("delta"), "9lke8eMWiEZQ8ayKVlEqoeSdACnjR8PMpC8iWNQF7Os="),
-				Entry("object_id missing", pointer.From(eventTime), pointer.From("alpha"), pointer.From("beta"), nil, pointer.From("delta"), "QJ7dEqDastXbeO3LW1ZMVEygeU9tm+wOCLqVqWdAA44="),
-				Entry("data_type missing", pointer.From(eventTime), pointer.From("alpha"), pointer.From("beta"), pointer.From("charlie"), nil, "ANvEmvnT7mSQuT+UoVdOIvSz2cEXg7geGU/lFq08vjc="),
-				Entry("all missing", nil, nil, nil, nil, nil, "RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o="),
-			)
+				DescribeTable("Hash returns expected string",
+					func(eventTime *time.Time, eventType *string, userID *string, objectID *string, dataType *string, expectedHash string) {
+						datum := &oura.Event{
+							EventTime: eventTime,
+							EventType: eventType,
+							UserID:    userID,
+							ObjectID:  objectID,
+							DataType:  dataType,
+						}
+						Expect(datum.Hash()).To(Equal(expectedHash))
+					},
+					Entry("all", pointer.From(eventTime), pointer.From("alpha"), pointer.From("beta"), pointer.From("charlie"), pointer.From("delta"), "WmARF+uCoGr7pgiFYrJszYy3c/7IiZJsNuOwL/ufGas="),
+					Entry("event_time missing", nil, pointer.From("alpha"), pointer.From("beta"), pointer.From("charlie"), pointer.From("delta"), "7Yer8F/5iqYHrWT6X5ygue3KsfB9o+SLvC70QgPp2E8="),
+					Entry("event_type missing", pointer.From(eventTime), nil, pointer.From("beta"), pointer.From("charlie"), pointer.From("delta"), "UoadT3+HLgJ74qdV0gcKvlolvWN5sRKpLSuaLyX43w8="),
+					Entry("user_id missing", pointer.From(eventTime), pointer.From("alpha"), nil, pointer.From("charlie"), pointer.From("delta"), "ApcWOcGez3+jAl96PQtBsrYWzdX+r/wF9bo97cczE0k="),
+					Entry("object_id missing", pointer.From(eventTime), pointer.From("alpha"), pointer.From("beta"), nil, pointer.From("delta"), "n749UjE4cGPUMCUipJrFPZC4roSuy6sEmBChfXD9J70="),
+					Entry("data_type missing", pointer.From(eventTime), pointer.From("alpha"), pointer.From("beta"), pointer.From("charlie"), nil, "BPaBo6T3TnAqHVX+4DJUN3FfZVtxnqPUkyoBMAloUE8="),
+					Entry("all missing", nil, nil, nil, nil, nil, "RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o="),
+				)
+			})
 		})
 	})
 
@@ -1466,13 +1468,13 @@ var _ = Describe("oura", func() {
 					}
 					Expect(datum.Hash()).To(Equal(expectedHash))
 				},
-				Entry("all", pointer.From("da349d70cc124d57bada133ce04f0513"), pointer.From(52), pointer.From(156.4), pointer.From(72.4), pointer.From("male"), pointer.From("bob@tidepool.io"), "yzFQ5RxZLgIzTnZxiAv3laIjSSn6+ktgVjfJDa8d/lQ="),
-				Entry("id missing", nil, pointer.From(41), pointer.From(152.7), pointer.From(64.0), pointer.From("female"), pointer.From("ann@tidepool.io"), "oTafvI7fAFUYapPCU6BI+gphl7634FLs6l+4tFYOvAs="),
-				Entry("age missing", pointer.From("e556b8b19d034cfc9f9d5b7dae9ed3c1"), nil, pointer.From(114.5), pointer.From(68.2), pointer.From(""), pointer.From("amy@tidepool.io"), "n37K1jw/lNmWF+IwmtJZgz2NrkrsGzLlmuRtbO/bOG4="),
-				Entry("weight missing", pointer.From("66249a46d97a4d409b1a7dee4be85069"), pointer.From(34), nil, pointer.From(69.2), pointer.From("other"), pointer.From("jim@tidepool.io"), "ojh/ltPFb6qyWpKgfUVKZEv32AoYuvCnLIl2bjFD5o4="),
-				Entry("height missing", pointer.From("a125b96ff4fb4c45aad383d0094d34e4"), pointer.From(45), pointer.From(179.4), nil, pointer.From("non-binary"), pointer.From("jane@tidepool.io"), "QpInH6ifkBDeCnj6fXXK0RHeET824jSupJ/P7HCONBk="),
-				Entry("biologicalSex missing", pointer.From("a9f95c54cda64041be1fbb2bfb8ce442"), pointer.From(26), pointer.From(213.2), pointer.From(56.4), nil, pointer.From("jon@tidepool.io"), "o/76T/S37K186nvqG7ZVheKU6CkC4IjQfnklETlpduI="),
-				Entry("email missing", pointer.From("a9f95c54cda64041be1fbb2bfb8ce442"), pointer.From(26), pointer.From(213.2), pointer.From(56.4), pointer.From("unspecified"), nil, "lUCGa4kv/0h02IEyM4cRAdQvE1rOGwj8OirKO/tLTQU="),
+				Entry("all", pointer.From("da349d70cc124d57bada133ce04f0513"), pointer.From(52), pointer.From(156.4), pointer.From(72.4), pointer.From("male"), pointer.From("bob@tidepool.io"), "V1kDa3hRMHNnVnSYsRuiF2Swc+Utoe8x+xwtA+uPMVA="),
+				Entry("id missing", nil, pointer.From(41), pointer.From(152.7), pointer.From(64.0), pointer.From("female"), pointer.From("ann@tidepool.io"), "ueokH1JXMnC+nbK8fx+B+vOQcquYlweF4KxYLufs1kw="),
+				Entry("age missing", pointer.From("e556b8b19d034cfc9f9d5b7dae9ed3c1"), nil, pointer.From(114.5), pointer.From(68.2), pointer.From(""), pointer.From("amy@tidepool.io"), "2sTtOYxXupS2eveyveYV/lRGCYeZ3FG3eN1FPuKXV5U="),
+				Entry("weight missing", pointer.From("66249a46d97a4d409b1a7dee4be85069"), pointer.From(34), nil, pointer.From(69.2), pointer.From("other"), pointer.From("jim@tidepool.io"), "rnCubbJI5FY1ZXQdDP4/+IXcqFMDDP2njYy0MiE3F1s="),
+				Entry("height missing", pointer.From("a125b96ff4fb4c45aad383d0094d34e4"), pointer.From(45), pointer.From(179.4), nil, pointer.From("non-binary"), pointer.From("jane@tidepool.io"), "ccmfXVVeGnJUIartDO/zWGJl+oSBtkSuOyi1aVWuCOg="),
+				Entry("biologicalSex missing", pointer.From("a9f95c54cda64041be1fbb2bfb8ce442"), pointer.From(26), pointer.From(213.2), pointer.From(56.4), nil, pointer.From("jon@tidepool.io"), "UZyxuxLcyZHEMUh0VuZ9D5o2jyJ289YFl7DFC887xow="),
+				Entry("email missing", pointer.From("a9f95c54cda64041be1fbb2bfb8ce442"), pointer.From(26), pointer.From(213.2), pointer.From(56.4), pointer.From("unspecified"), nil, "lyU9RRe+3bg6Gpqu9a9v5B3O3NECzkhBR5bFJVpKBPU="),
 				Entry("all missing", nil, nil, nil, nil, nil, nil, "RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o="),
 			)
 		})

--- a/oura/user/work/revoke/processor.go
+++ b/oura/user/work/revoke/processor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tidepool-org/platform/errors"
 	oauthWork "github.com/tidepool-org/platform/oauth/work"
+	"github.com/tidepool-org/platform/pointer"
 	"github.com/tidepool-org/platform/structure"
 	structureValidator "github.com/tidepool-org/platform/structure/validator"
 	"github.com/tidepool-org/platform/work"
@@ -13,8 +14,9 @@ import (
 )
 
 const (
-	FailingRetryDuration       = 1 * time.Minute
-	FailingRetryDurationJitter = 5 * time.Second
+	FailingRetryDuration        = 1 * time.Minute
+	FailingRetryDurationJitter  = 5 * time.Second
+	FailingRetryDurationMaximum = 24 * time.Hour
 )
 
 type TokenMetadata = oauthWork.TokenMetadata
@@ -47,8 +49,9 @@ func NewProcessor(dependencies Dependencies) (*Processor, error) {
 
 	processResultBuilder := &workBase.ProcessResultBuilder{
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 

--- a/oura/user/work/revoke/processor_test.go
+++ b/oura/user/work/revoke/processor_test.go
@@ -36,6 +36,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraUserWorkRevoke.FailingRetryDurationJitter).To(Equal(5 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraUserWorkRevoke.FailingRetryDurationMaximum).To(Equal(24 * time.Hour))
+	})
+
 	Context("Metadata", func() {
 		DescribeTable("serializes the datum as expected",
 			func(mutator func(datum *ouraUserWorkRevoke.Metadata)) {

--- a/oura/user/work/setup/processor.go
+++ b/oura/user/work/setup/processor.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	FailingRetryDuration       = 1 * time.Minute
-	FailingRetryDurationJitter = 5 * time.Second
+	FailingRetryDuration        = 1 * time.Minute
+	FailingRetryDurationJitter  = 5 * time.Second
+	FailingRetryDurationMaximum = 24 * time.Hour
 )
 
 type ProviderSessionMetadata = providerSessionWork.Metadata
@@ -81,8 +82,9 @@ func NewProcessor(dependencies Dependencies) (*Processor, error) {
 
 	processResultBuilder := &workBase.ProcessResultBuilder{
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 

--- a/oura/user/work/setup/processor_test.go
+++ b/oura/user/work/setup/processor_test.go
@@ -51,6 +51,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraUserWorkSetup.FailingRetryDurationJitter).To(Equal(5 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraUserWorkSetup.FailingRetryDurationMaximum).To(Equal(24 * time.Hour))
+	})
+
 	Context("Metadata", func() {
 		DescribeTable("serializes the datum as expected",
 			func(mutator func(datum *ouraUserWorkSetup.Metadata)) {

--- a/oura/webhook/work/subscribe/processor.go
+++ b/oura/webhook/work/subscribe/processor.go
@@ -19,6 +19,7 @@ const (
 	PendingAvailableDuration      = 24 * time.Hour
 	FailingRetryDuration          = 1 * time.Minute
 	FailingRetryDurationJitter    = 10 * time.Second
+	FailingRetryDurationMaximum   = 24 * time.Hour
 	ExpirationTimeDurationMinimum = 7 * 24 * time.Hour // Normal expiration seems like 90 days, but this will refresh every 7
 
 	OverrideDisabled = "disabled" // Delete all existing subscriptions; data loss while subscriptions disabled, use with caution
@@ -65,8 +66,9 @@ func NewProcessor(dependencies Dependencies) (*Processor, error) {
 			Duration: PendingAvailableDuration,
 		},
 		ProcessResultFailingBuilder: &workBase.ExponentialProcessResultFailingBuilder{
-			Duration:       FailingRetryDuration,
-			DurationJitter: FailingRetryDurationJitter,
+			Duration:        FailingRetryDuration,
+			DurationJitter:  FailingRetryDurationJitter,
+			DurationMaximum: pointer.From(FailingRetryDurationMaximum),
 		},
 	}
 

--- a/oura/webhook/work/subscribe/processor_test.go
+++ b/oura/webhook/work/subscribe/processor_test.go
@@ -45,6 +45,10 @@ var _ = Describe("processor", func() {
 		Expect(ouraWebhookWorkSubscribe.FailingRetryDurationJitter).To(Equal(10 * time.Second))
 	})
 
+	It("FailingRetryDurationMaximum is expected", func() {
+		Expect(ouraWebhookWorkSubscribe.FailingRetryDurationMaximum).To(Equal(24 * time.Hour))
+	})
+
 	It("OverrideDisabled is expected", func() {
 		Expect(ouraWebhookWorkSubscribe.OverrideDisabled).To(Equal("disabled"))
 	})

--- a/times/time_range.go
+++ b/times/time_range.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gowebpki/jcs"
+
 	"github.com/tidepool-org/platform/crypto"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/pointer"
@@ -83,7 +85,9 @@ func (t TimeRange) Date() TimeRange {
 
 func (t TimeRange) Hash() (string, error) {
 	if bites, err := json.Marshal(t); err != nil {
-		return "", errors.Wrap(err, "unable to generate hash")
+		return "", errors.Wrap(err, "unable to generate JSON for hash")
+	} else if bites, err = jcs.Transform(bites); err != nil {
+		return "", errors.Wrap(err, "unable to canonicalize JSON for hash")
 	} else {
 		return crypto.Base64EncodedSHA256Hash(bites), nil
 	}

--- a/work/service/coordinator.go
+++ b/work/service/coordinator.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	CoordinatorFrequencyDefault = 5 * time.Minute
+	CoordinatorDelayInitial     = 1 * time.Minute
 	CoordinatorDelayJitter      = 0.1
 
 	FailingRetryDuration       = 1 * time.Minute
@@ -167,14 +168,19 @@ func (c *Coordinator) Stop() {
 }
 
 func (c *Coordinator) startManager() {
-	c.managerWaitGroup.Add(1)
+	c.managerWaitGroup.Go(func() {
+		// Delay before start to ensure other services available
+		select {
+		case <-c.managerContext.Done():
+			return
+		case <-time.After(durationWithJitter(CoordinatorDelayInitial, CoordinatorDelayJitter)):
+		}
 
-	go func() {
-		defer c.managerWaitGroup.Done()
-
+		// Start time to poll according to frequency
 		c.startTimer()
 		defer c.stopTimer()
 
+		// Loop until canceled
 		for {
 			select {
 			case <-c.managerContext.Done(): // Drain and complete any interrupted tasks
@@ -192,7 +198,7 @@ func (c *Coordinator) startManager() {
 				c.startTimer()
 			}
 		}
-	}()
+	})
 }
 
 func (c *Coordinator) requestAndDispatchWork() {
@@ -220,11 +226,9 @@ func (c *Coordinator) requestAndDispatchWork() {
 
 func (c *Coordinator) dispatchWork(ctx context.Context, wrk *work.Work) {
 	c.typeQuantities.Decrement(wrk.Type)
-	c.workersWaitGroup.Add(1)
-	go func() {
-		defer c.workersWaitGroup.Done()
+	c.workersWaitGroup.Go(func() {
 		c.workersCompletionChannel <- c.processWork(ctx, wrk)
-	}()
+	})
 }
 
 func (c *Coordinator) processWork(ctx context.Context, wrk *work.Work) *coordinatorProcessingCompletion {
@@ -352,8 +356,7 @@ func (c *Coordinator) completeWork(completion *coordinatorProcessingCompletion) 
 }
 
 func (c *Coordinator) startTimer() {
-	jitter := int64(float64(c.frequency) * CoordinatorDelayJitter)
-	frequencyWithJitter := c.frequency + time.Duration(crypto.RandomInt64N(jitter*2+1)-jitter)
+	frequencyWithJitter := durationWithJitter(c.frequency, CoordinatorDelayJitter)
 	if c.timer == nil {
 		c.timer = time.NewTimer(frequencyWithJitter)
 	} else {
@@ -438,4 +441,9 @@ func processResultToUpdate(processResult *work.ProcessResult) *work.Update {
 	default:
 		return nil
 	}
+}
+
+func durationWithJitter(duration time.Duration, durationJitterFactor float64) time.Duration {
+	durationJitter := int64(float64(duration) * durationJitterFactor)
+	return duration + time.Duration(crypto.RandomInt64N(durationJitter*2+1)-durationJitter)
 }

--- a/work/service/coordinator.go
+++ b/work/service/coordinator.go
@@ -169,18 +169,9 @@ func (c *Coordinator) Stop() {
 
 func (c *Coordinator) startManager() {
 	c.managerWaitGroup.Go(func() {
-		// Delay before start to ensure other services available
-		select {
-		case <-c.managerContext.Done():
-			return
-		case <-time.After(durationWithJitter(CoordinatorDelayInitial, CoordinatorDelayJitter)):
-		}
-
-		// Start time to poll according to frequency
-		c.startTimer()
+		c.startTimerWithDuration(CoordinatorDelayInitial)
 		defer c.stopTimer()
 
-		// Loop until canceled
 		for {
 			select {
 			case <-c.managerContext.Done(): // Drain and complete any interrupted tasks
@@ -188,14 +179,17 @@ func (c *Coordinator) startManager() {
 					c.completeWork(completion)
 				}
 				return
-			case completion := <-c.workersCompletionChannel:
+			case completion, ok := <-c.workersCompletionChannel:
+				if !ok {
+					return
+				}
 				c.stopTimer()
 				c.completeWork(completion)
 				c.requestAndDispatchWork()
-				c.startTimer()
+				c.startTimerWithDuration(c.frequency)
 			case <-c.timer.C:
 				c.requestAndDispatchWork()
-				c.startTimer()
+				c.startTimerWithDuration(c.frequency)
 			}
 		}
 	})
@@ -355,12 +349,12 @@ func (c *Coordinator) completeWork(completion *coordinatorProcessingCompletion) 
 	}
 }
 
-func (c *Coordinator) startTimer() {
-	frequencyWithJitter := durationWithJitter(c.frequency, CoordinatorDelayJitter)
+func (c *Coordinator) startTimerWithDuration(duration time.Duration) {
+	duration = durationWithJitter(duration, CoordinatorDelayJitter)
 	if c.timer == nil {
-		c.timer = time.NewTimer(frequencyWithJitter)
+		c.timer = time.NewTimer(duration)
 	} else {
-		c.timer.Reset(frequencyWithJitter)
+		c.timer.Reset(duration)
 	}
 }
 


### PR DESCRIPTION
- Updates from PR reviews and testing
- Add maximum failing error delay duration to Oura work processors
- Canonicalize JSON before generating hash for Oura data
- Use modern WaitGroup.Go in work coordinator
- Delay work coordinator on initial start to avoid transient deployment failures
- Other minor update
- Update tests