### PR TITLE
fix for sparse data showing up in the wrong summaries

### DIFF
--- a/consent/store/mongo/consent_record_repository.go
+++ b/consent/store/mongo/consent_record_repository.go
@@ -121,12 +121,16 @@ func (c *ConsentRecordRepository) ListConsentRecords(ctx context.Context, userID
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list consent records")
 	}
+	defer cursor.Close(ctx)
 
 	result := storeStructuredMongo.ListResult[consent.Record]{}
 	if cursor.Next(ctx) {
 		if err = cursor.Decode(&result); err != nil {
 			return nil, errors.Wrap(err, "unable to decode consent records")
 		}
+	}
+	if err = cursor.Err(); err != nil {
+		return nil, errors.Wrap(err, "unable to iterate consent records")
 	}
 
 	logger.WithFields(log.Fields{"count": len(result.Data), "duration": time.Since(now) / time.Microsecond}).WithError(err).Debug("ListConsentRecords")

--- a/consent/store/mongo/consent_repository.go
+++ b/consent/store/mongo/consent_repository.go
@@ -85,12 +85,16 @@ func (p *ConsentRepository) List(ctx context.Context, filter *consent.Filter, pa
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list consents")
 	}
+	defer cursor.Close(ctx)
 
 	result := storeStructuredMongo.ListResult[consent.Consent]{}
 	if cursor.Next(ctx) {
 		if err = cursor.Decode(&result); err != nil {
 			return nil, errors.Wrap(err, "unable to decode consents")
 		}
+	}
+	if err = cursor.Err(); err != nil {
+		return nil, errors.Wrap(err, "unable to iterate consents")
 	}
 
 	logger.WithFields(log.Fields{"count": result.Count, "duration": time.Since(now) / time.Microsecond}).WithError(err).Debug("ListConsents")

--- a/consent/store/mongo/cursor_error_test.go
+++ b/consent/store/mongo/cursor_error_test.go
@@ -1,0 +1,62 @@
+package mongo_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+
+	consentStoreMongo "github.com/tidepool-org/platform/consent/store/mongo"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
+	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
+)
+
+func TestListWithFailingCursor(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("returns the cursor error instead of an empty result", func(mt *mtest.T) {
+		g := NewWithT(mt.T)
+		ctx := log.NewContextWithLogger(context.Background(), logTest.NewLogger())
+		repo := &consentStoreMongo.ConsentRepository{
+			Repository: storeStructuredMongo.NewRepository(mt.Coll),
+		}
+
+		ns := mt.DB.Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(
+			// the aggregation cursor fails before delivering its single result document
+			mtest.CreateCursorResponse(1, ns, mtest.FirstBatch),
+			mtest.CreateCommandErrorResponse(mtest.CommandError{
+				Code:    43,
+				Message: "cursor killed mid-iteration",
+			}),
+		)
+
+		_, err := repo.List(ctx, nil, nil)
+		g.Expect(err).To(MatchError(ContainSubstring("cursor killed mid-iteration")))
+	})
+}
+
+func TestListConsentRecordsWithFailingCursor(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("returns the cursor error instead of an empty result", func(mt *mtest.T) {
+		g := NewWithT(mt.T)
+		ctx := log.NewContextWithLogger(context.Background(), logTest.NewLogger())
+		repo := &consentStoreMongo.ConsentRecordRepository{
+			Repository: storeStructuredMongo.NewRepository(mt.Coll),
+		}
+
+		ns := mt.DB.Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(
+			// the aggregation cursor fails before delivering its single result document
+			mtest.CreateCursorResponse(1, ns, mtest.FirstBatch),
+			mtest.CreateCommandErrorResponse(mtest.CommandError{
+				Code:    43,
+				Message: "cursor killed mid-iteration",
+			}),
+		)
+
+		_, err := repo.ListConsentRecords(ctx, "user-1", nil, nil)
+		g.Expect(err).To(MatchError(ContainSubstring("cursor killed mid-iteration")))
+	})
+}

--- a/data/service/api/v1/datasets_data_create.go
+++ b/data/service/api/v1/datasets_data_create.go
@@ -147,9 +147,7 @@ func CollectProvenanceInfo(ctx context.Context, req *rest.Request, authDetails r
 
 	if token != "" && shouldHaveJWT(authDetails) {
 		claims := &TokenClaims{}
-		if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
-			lgr.WithError(err).Warn("Unable to parse access token for provenance")
-		} else {
+		if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err == nil {
 			provenance.ClientID = claims.ClientID
 		}
 	} else if !authDetails.IsService() {

--- a/data/store/mongo/cursor_error_test.go
+++ b/data/store/mongo/cursor_error_test.go
@@ -1,0 +1,41 @@
+package mongo_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+
+	"github.com/tidepool-org/platform/data"
+	dataStoreMongo "github.com/tidepool-org/platform/data/store/mongo"
+	"github.com/tidepool-org/platform/log"
+	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/pointer"
+	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
+)
+
+func TestUnarchiveDeviceDataWithFailingAggregate(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("returns the aggregate error instead of panicking", func(mt *mtest.T) {
+		g := NewWithT(mt.T)
+		ctx := log.NewContextWithLogger(context.Background(), logTest.NewLogger())
+		repo := &dataStoreMongo.DatumRepository{
+			Repository: storeStructuredMongo.NewRepository(mt.Coll),
+		}
+
+		dataSet := &data.DataSet{
+			UserID:   pointer.FromString("user-1"),
+			UploadID: pointer.FromString("upload-1"),
+			DeviceID: pointer.FromString("device-1"),
+		}
+
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(mtest.CommandError{
+			Code:    43,
+			Message: "aggregate failed",
+		}))
+
+		err := repo.UnarchiveDeviceDataUsingHashesFromDataSet(ctx, dataSet)
+		g.Expect(err).To(MatchError(ContainSubstring("aggregate failed")))
+	})
+}

--- a/data/store/mongo/mongo_datum.go
+++ b/data/store/mongo/mongo_datum.go
@@ -504,7 +504,10 @@ func (d *DatumRepository) UnarchiveDeviceDataUsingHashesFromDataSet(ctx context.
 			},
 		},
 	}
-	cursor, _ := d.Aggregate(ctx, pipeline)
+	cursor, err := d.Aggregate(ctx, pipeline)
+	if err != nil {
+		return fmt.Errorf("unable to aggregate archived device data: %w", err)
+	}
 
 	var overallUpdateInfo mongo.UpdateResult
 	var overallErr error

--- a/summary/reporters/realtime.go
+++ b/summary/reporters/realtime.go
@@ -143,6 +143,9 @@ func (r *PatientRealtimeDaysReporter) GetNumberOfDaysWithRealtimeData(ctx contex
 				tomorrow.Hour(), tomorrow.Minute(), tomorrow.Second(), tomorrow.Nanosecond(), tomorrow.Location())
 		}
 	}
+	if err = buckets.Err(); err != nil {
+		return 0, err
+	}
 
 	return count, nil
 }

--- a/summary/reporters/realtime_test.go
+++ b/summary/reporters/realtime_test.go
@@ -2,6 +2,7 @@ package reporters_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -65,6 +66,20 @@ var _ = Describe("Reporters", func() {
 
 			count, err := realtimeReporter.GetNumberOfDaysWithRealtimeData(ctx, bucketsCursor)
 			Expect(count).To(Equal(15))
+		})
+
+		It("with a cursor that fails mid-iteration", func() {
+			endTime := time.Now().UTC().Truncate(time.Hour * 24)
+			startTime := endTime.AddDate(0, 0, -30)
+
+			buckets := NewRealtimeBuckets(userId, startTime, endTime, 15)
+
+			bucketsCursor, err := mongo.NewCursorFromDocuments(ConvertToIntArray(buckets),
+				fmt.Errorf("batch fetch failed"), nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = realtimeReporter.GetNumberOfDaysWithRealtimeData(ctx, bucketsCursor)
+			Expect(err).To(MatchError("batch fetch failed"))
 		})
 
 		It("with no realtime data", func() {

--- a/summary/store/cursor_error_test.go
+++ b/summary/store/cursor_error_test.go
@@ -1,0 +1,51 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+
+	"github.com/tidepool-org/platform/page"
+	storeStructuredMongo "github.com/tidepool-org/platform/store/structured/mongo"
+	summaryStore "github.com/tidepool-org/platform/summary/store"
+	"github.com/tidepool-org/platform/summary/types"
+)
+
+func TestGetOutdatedUserIDsWithFailingCursor(t *testing.T) {
+	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
+	mt.Run("returns the cursor error instead of a truncated response", func(mt *mtest.T) {
+		g := NewWithT(mt.T)
+		summaries := summaryStore.NewSummaries[*types.CGMPeriods,
+			*types.GlucoseBucket](storeStructuredMongo.NewRepository(mt.Coll))
+
+		ns := mt.DB.Name() + "." + mt.Coll.Name()
+		mt.AddMockResponses(
+			// one outdated summary arrives before the cursor fails mid-iteration
+			mtest.CreateCursorResponse(1, ns, mtest.FirstBatch, bson.D{
+				{
+					Key: "userId", Value: "user-1",
+				},
+				{
+					Key: "dates",
+					Value: bson.D{
+						{
+							Key:   "outdatedSince",
+							Value: time.Now().UTC().Truncate(time.Millisecond),
+						},
+					},
+				}}),
+			mtest.CreateCommandErrorResponse(mtest.CommandError{
+				Code: 43, Message: "cursor killed mid-iteration"}),
+			mtest.CreateCursorResponse(0, ns, mtest.FirstBatch, bson.D{
+				{Key: "n", Value: int32(3)},
+			}),
+		)
+
+		_, err := summaries.GetOutdatedUserIDs(context.Background(), page.NewPagination())
+		g.Expect(err).To(MatchError(ContainSubstring("cursor killed mid-iteration")))
+	})
+}

--- a/summary/store/summary.go
+++ b/summary/store/summary.go
@@ -259,6 +259,7 @@ func (r *Summaries[PP, PB, P, B]) GetOutdatedUserIDs(ctx context.Context, page *
 	if err != nil {
 		return nil, fmt.Errorf("unable to get outdated summaries: %w", err)
 	}
+	defer cursor.Close(ctx)
 
 	response := &types.OutdatedSummariesResponse{
 		UserIds: make([]string, 0, cursor.RemainingBatchLength()),
@@ -275,6 +276,9 @@ func (r *Summaries[PP, PB, P, B]) GetOutdatedUserIDs(ctx context.Context, page *
 		if response.Start.IsZero() {
 			response.Start = *userSummary.Dates.OutdatedSince
 		}
+	}
+	if err = cursor.Err(); err != nil {
+		return nil, fmt.Errorf("unable to iterate outdated summaries: %w", err)
 	}
 
 	// if we saw at least one summary

--- a/summary/types/continuous.go
+++ b/summary/types/continuous.go
@@ -151,7 +151,10 @@ func (s *ContinuousPeriods) Update(ctx context.Context, bucketsCursor *mongo.Cur
 			panic("bucket exists with 0 records")
 		}
 
-		if len(stopPoints) > nextStopPoint && bucket.Time.Compare(stopPoints[nextStopPoint]) <= 0 {
+		// Close off every period boundary this bucket has crossed. A single bucket can be
+		// past multiple boundaries at once when there is a large gap between buckets, so
+		// this must be a loop, not a single check.
+		for len(stopPoints) > nextStopPoint && bucket.Time.Compare(stopPoints[nextStopPoint]) <= 0 {
 			s.CalculatePeriod(periodLengths[nextStopPoint], false, period)
 			nextStopPoint++
 		}

--- a/summary/types/continuous.go
+++ b/summary/types/continuous.go
@@ -166,6 +166,9 @@ func (s *ContinuousPeriods) Update(ctx context.Context, bucketsCursor *mongo.Cur
 			}
 		}
 	}
+	if err := bucketsCursor.Err(); err != nil {
+		return err
+	}
 
 	// fill in periods we never reached
 	for i := nextStopPoint; i < len(stopPoints); i++ {

--- a/summary/types/continuous_test.go
+++ b/summary/types/continuous_test.go
@@ -371,6 +371,35 @@ var _ = Describe("Continuous", func() {
 				Expect(s["14d"].Total.Records).To(Equal(24 * 14))
 				Expect(s["30d"].Total.Records).To(Equal(24 * 30))
 			})
+
+			It("isolates a bucket separated by a large gap to the correct period", func() {
+				// 24 dense hourly buckets near the newest time, then a gap, then a single
+				// bucket at ~20 days old. The gapped bucket sits strictly between the 14d
+				// and 30d boundaries, so it belongs to the 30d period only. A single bucket
+				// must close off every boundary it has crossed before being counted,
+				// otherwise it leaks into 7d/14d.
+				//
+				// This is a fix for BACK-4510, if it's failing, this could be a regression.
+				s := ContinuousPeriods{}
+				s.Init()
+
+				recent := CreateContinuousBuckets(bucketTime, 24, 1)
+				t0 := bucketTime.Add(24 * time.Hour)
+				oldStart := t0.AddDate(0, 0, -20).Add(-time.Hour)
+				old := CreateContinuousBuckets(oldStart, 1, 1)
+				buckets := append(recent, old...)
+
+				bucketsCursor, err := mongo.NewCursorFromDocuments(ConvertToIntArray(buckets), nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, bucketsCursor)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(s["1d"].Total.Records).To(Equal(24))
+				Expect(s["7d"].Total.Records).To(Equal(24))
+				Expect(s["14d"].Total.Records).To(Equal(24))
+				Expect(s["30d"].Total.Records).To(Equal(25))
+			})
 		})
 	})
 })

--- a/summary/types/continuous_test.go
+++ b/summary/types/continuous_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -281,6 +282,19 @@ var _ = Describe("Continuous", func() {
 		})
 
 		Context("Update", func() {
+
+			It("handles cursors that fail mid-iteration", func() {
+				s := ContinuousPeriods{}
+				s.Init()
+
+				buckets := CreateContinuousBuckets(bucketTime, 24, 1)
+				bucketsCursor, err := mongo.NewCursorFromDocuments(
+					ConvertToIntArray(buckets), fmt.Errorf("batch fetch failed"), nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, bucketsCursor)
+				Expect(err).To(MatchError("batch fetch failed"))
+			})
 
 			It("Update 1d", func() {
 				s := ContinuousPeriods{}

--- a/summary/types/glucose.go
+++ b/summary/types/glucose.go
@@ -565,6 +565,13 @@ func (st *GlucosePeriods) Update(ctx context.Context, bucketsCursor *mongo.Curso
 		}
 	}
 
+	// the cursor was empty, all buckets may have been invalidated since the last update,
+	// any previously calculated periods are no longer backed by data
+	if stopPoints == nil {
+		st.Init()
+		return nil
+	}
+
 	// fill in periods we never reached
 	for i := nextStopPoint; i < len(stopPoints); i++ {
 		st.CalculatePeriod(periodLengths[i], period)

--- a/summary/types/glucose.go
+++ b/summary/types/glucose.go
@@ -536,12 +536,15 @@ func (st *GlucosePeriods) Update(ctx context.Context, bucketsCursor *mongo.Curso
 			panic("bucket exists with 0 records")
 		}
 
-		if len(stopPoints) > nextStopPoint && bucket.Time.Compare(stopPoints[nextStopPoint]) <= 0 {
+		// Close off every period boundary this bucket has crossed. A single bucket can be
+		// past multiple boundaries at once when there is a large gap between buckets, so
+		// this must be a loop, not a single check.
+		for len(stopPoints) > nextStopPoint && bucket.Time.Compare(stopPoints[nextStopPoint]) <= 0 {
 			st.CalculatePeriod(periodLengths[nextStopPoint], period)
 			nextStopPoint++
 		}
 
-		if len(offsetStopPoints) > nextOffsetStopPoint && bucket.Time.Compare(offsetStopPoints[nextOffsetStopPoint]) <= 0 {
+		for len(offsetStopPoints) > nextOffsetStopPoint && bucket.Time.Compare(offsetStopPoints[nextOffsetStopPoint]) <= 0 {
 			CalculateOffsetPeriod(offsetPeriods, periodLengths[nextOffsetStopPoint], offsetPeriod)
 			offsetPeriod = GlucosePeriod{}
 			nextOffsetStopPoint++

--- a/summary/types/glucose.go
+++ b/summary/types/glucose.go
@@ -564,6 +564,9 @@ func (st *GlucosePeriods) Update(ctx context.Context, bucketsCursor *mongo.Curso
 			}
 		}
 	}
+	if err := bucketsCursor.Err(); err != nil {
+		return err
+	}
 
 	// the cursor was empty, all buckets may have been invalidated since the last update,
 	// any previously calculated periods are no longer backed by data

--- a/summary/types/glucose_test.go
+++ b/summary/types/glucose_test.go
@@ -1388,6 +1388,19 @@ var _ = Describe("Glucose", func() {
 				Expect(s).To(BeEmpty())
 			})
 
+			It("handles cursors that fail mid-iteration", func() {
+				s := GlucosePeriods{}
+				s.Init()
+
+				buckets := CreateGlucoseBuckets(bucketTime, 24, 1, true)
+				bucketsCursor, err := mongo.NewCursorFromDocuments(
+					ConvertToIntArray(buckets), fmt.Errorf("batch fetch failed"), nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, bucketsCursor)
+				Expect(err).To(MatchError("batch fetch failed"))
+			})
+
 			It("CalculateSummary 2d", func() {
 				s := GlucosePeriods{}
 				s.Init()

--- a/summary/types/glucose_test.go
+++ b/summary/types/glucose_test.go
@@ -1366,6 +1366,28 @@ var _ = Describe("Glucose", func() {
 				Expect(s["30d"].Total.Records).To(Equal(24))
 			})
 
+			It("Update with pre-existing periods and an empty buckets cursor", func() {
+				s := GlucosePeriods{}
+				s.Init()
+
+				// populate the periods map, as an incremental update on a stored summary would see
+				buckets := CreateGlucoseBuckets(bucketTime, 24, 1, true)
+				bucketsCursor, err := mongo.NewCursorFromDocuments(ConvertToIntArray(buckets), nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, bucketsCursor)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s).ToNot(BeEmpty())
+
+				// all buckets have since been invalidated, the next update sees an empty cursor
+				emptyCursor, err := mongo.NewCursorFromDocuments([]interface{}{}, nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, emptyCursor)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s).To(BeEmpty())
+			})
+
 			It("CalculateSummary 2d", func() {
 				s := GlucosePeriods{}
 				s.Init()

--- a/summary/types/glucose_test.go
+++ b/summary/types/glucose_test.go
@@ -1484,6 +1484,66 @@ var _ = Describe("Glucose", func() {
 				Expect(s["14d"].Total.Records).To(Equal(24 * 14))
 				Expect(s["30d"].Total.Records).To(Equal(24 * 30))
 			})
+
+			It("isolates a bucket separated by a large gap to the correct period", func() {
+				// 24 dense hourly buckets near the newest time, then a gap, then a single
+				// bucket at ~20 days old. The gapped bucket sits strictly between the 14d
+				// and 30d boundaries, so it belongs to the 30d period only. A single bucket
+				// must close off every boundary it has crossed before being counted,
+				// otherwise it leaks into 7d/14d.
+				//
+				// This is a fix for BACK-4510, if it's failing, this could be a regression.
+				s := GlucosePeriods{}
+				s.Init()
+
+				recent := CreateGlucoseBuckets(bucketTime, 24, 1, true)
+				t0 := bucketTime.Add(24 * time.Hour)
+				oldStart := t0.AddDate(0, 0, -20).Add(-time.Hour)
+				old := CreateGlucoseBuckets(oldStart, 1, 1, true)
+				buckets := append(recent, old...)
+
+				bucketsCursor, err := mongo.NewCursorFromDocuments(ConvertToIntArray(buckets), nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, bucketsCursor)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(s["1d"].Total.Records).To(Equal(24))
+				Expect(s["7d"].Total.Records).To(Equal(24))
+				Expect(s["14d"].Total.Records).To(Equal(24))
+				Expect(s["30d"].Total.Records).To(Equal(25))
+			})
+
+			It("isolates a gapped bucket to the correct offset period", func() {
+				// Same setup as the regular-period test above: 24 dense hourly buckets near
+				// the newest time, then a gap, then a single bucket ~20 days old. That
+				// gapped bucket falls in the 14d *offset* window (t0-28d, t0-14d], so it
+				// must be counted only into the 14d offset period. The offset loop must
+				// close every offset boundary the bucket has crossed before counting it,
+				// otherwise it leaks into the 7d offset window. Offset periods are only
+				// observable through the delta (delta = current - offset).
+				//
+				// This is a fix for BACK-4510, if it's failing, this could be a regression.
+				s := GlucosePeriods{}
+				s.Init()
+
+				recent := CreateGlucoseBuckets(bucketTime, 24, 1, true)
+				t0 := bucketTime.Add(24 * time.Hour)
+				oldStart := t0.AddDate(0, 0, -20).Add(-time.Hour)
+				old := CreateGlucoseBuckets(oldStart, 1, 1, true)
+				buckets := append(recent, old...)
+
+				bucketsCursor, err := mongo.NewCursorFromDocuments(ConvertToIntArray(buckets), nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = s.Update(ctx, bucketsCursor)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(s["1d"].Delta.Total.Records).To(Equal(24))
+				Expect(s["7d"].Delta.Total.Records).To(Equal(24))
+				Expect(s["14d"].Delta.Total.Records).To(Equal(23))
+				Expect(s["30d"].Delta.Total.Records).To(Equal(25))
+			})
 		})
 
 		Context("CalculateDelta", func() {

--- a/task/queue/queue.go
+++ b/task/queue/queue.go
@@ -306,6 +306,9 @@ func (q *queue) dispatchTasks(ctx context.Context) time.Duration {
 			}
 			q.dispatchTask(ctx, tsk)
 		} else {
+			if err := iter.Err(); err != nil {
+				q.logger.WithError(err).Error("Failure iterating pending tasks")
+			}
 			return q.delay
 		}
 	}

--- a/task/queue/queue_internal_test.go
+++ b/task/queue/queue_internal_test.go
@@ -1,0 +1,51 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	logTest "github.com/tidepool-org/platform/log/test"
+	"github.com/tidepool-org/platform/task/store"
+)
+
+type failingIteratorStore struct {
+	store.Store
+}
+
+func (f *failingIteratorStore) NewTaskRepository() store.TaskRepository {
+	return &failingIteratorRepository{}
+}
+
+type failingIteratorRepository struct {
+	store.TaskRepository
+}
+
+func (f *failingIteratorRepository) IteratePending(ctx context.Context) (
+	*mongo.Cursor, error) {
+
+	return mongo.NewCursorFromDocuments([]interface{}{bson.D{}},
+		fmt.Errorf("batch fetch failed"), nil)
+}
+
+var _ = Describe("Queue", func() {
+	Context("dispatchTasks", func() {
+		It("logs an error when the pending iterator fails mid-iteration", func() {
+			logger := logTest.NewLogger()
+			q := &queue{
+				logger:           logger,
+				store:            &failingIteratorStore{},
+				workersAvailable: 1,
+				delay:            time.Minute,
+			}
+
+			Expect(q.dispatchTasks(context.Background())).To(Equal(time.Minute))
+			logger.AssertError("Failure iterating pending tasks")
+		})
+	})
+})


### PR DESCRIPTION
The change fixes a bucketing bug in the newest-first summary walk. Previously the period-boundary check was a single if, so each hourly bucket could advance nextStopPoint by at most one. When a large time gap sits between two buckets, one bucket can be past several period boundaries (1d/7d/14d/30d) at once, but only one got closed off, so the gapped bucket leaked into shorter periods it doesn't belong to.

BACK-4510

BACK-4525 is also included in this PR for ease of QA testing