### PR TITLE
fixes a small validation typo in the work system

### DIFF
--- a/work/work.go
+++ b/work/work.go
@@ -525,7 +525,7 @@ func (w *Work) Validate(validator structure.Validator) {
 	failingRetryTimeValidator := validator.Time("failingRetryTime", w.FailingRetryTime)
 	failedTimeValidator := validator.Time("failedTime", w.FailedTime)
 	failedErrorValidator := validator.WithReference("failedError")
-	successTimeValidator := validator.Time("successTime", w.FailedTime)
+	successTimeValidator := validator.Time("successTime", w.SuccessTime)
 
 	switch w.State {
 	case StateProcessing:


### PR DESCRIPTION
The validation of success time was accidentally looking at the
FailedTime field instead of SuccessTime.