### PR TITLE
[BACK-4442] [BACK-4528] Ignore not parsed fields when requesting data with the http client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -141,7 +141,7 @@ func (c *Client) RequestDataWithHTTPClient(ctx context.Context, method string, u
 		return nil
 	}
 
-	return request.DecodeStream(ctx, structure.NewPointerSource(), body, responseBody)
+	return request.DecodeStream(ctx, structure.NewPointerSource(), body, responseBody, request.IgnoreNotParsed())
 }
 
 func (c *Client) createRequest(ctx context.Context, method string, url string, mutators []request.RequestMutator, requestBody interface{}) (*http.Request, error) {

--- a/user/client/client_test.go
+++ b/user/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	logTest "github.com/tidepool-org/platform/log/test"
 	"github.com/tidepool-org/platform/platform"
 	"github.com/tidepool-org/platform/request"
+	"github.com/tidepool-org/platform/test"
 	testHttp "github.com/tidepool-org/platform/test/http"
 	"github.com/tidepool-org/platform/user"
 	userClient "github.com/tidepool-org/platform/user/client"
@@ -169,6 +170,22 @@ var _ = Describe("Client", func() {
 							BeforeEach(func() {
 								responseResult = userTest.RandomUser()
 								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseResult, responseHeaders))
+							})
+
+							It("returns successfully with result", func() {
+								Expect(client.Get(ctx, id)).To(userTest.MatchUser(responseResult))
+							})
+						})
+
+						When("the server responds with the result including unrecognized fields", func() {
+							var responseResult *user.User
+
+							BeforeEach(func() {
+								responseResult = userTest.RandomUser()
+								responseObject := userTest.NewObjectFromUser(responseResult, test.ObjectFormatJSON)
+								responseObject["passwordExists"] = true
+								responseObject["securityProfile"] = map[string]interface{}{"securityQuestionsSetup": false}
+								requestHandlers = append(requestHandlers, RespondWithJSONEncoded(http.StatusOK, responseObject, responseHeaders))
 							})
 
 							It("returns successfully with result", func() {


### PR DESCRIPTION
`client.Client.RequestData` now decodes response bodies with `request.IgnoreNotParsed()`, so a service returning fields a client model does not parse — or gaining fields over time — no longer fails the request for every consumer of the shared http client.

This generalizes the fix first made for `user.Client.Get` (keycloak-migrated users gained `securityProfile`, which failed the strict parse and wedged work items depending on the user fetch). The user client spec asserting tolerance of unrecognized fields moves here to pin the behavior at the shared client.

Split out of #968, which will be rebased on top of this branch.