### PR TITLE
fall back to server session token for recording metrics

### DIFF
--- a/metric/client/client.go
+++ b/metric/client/client.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/tidepool-org/platform/auth"
 	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	"github.com/tidepool-org/platform/platform"
@@ -54,6 +55,16 @@ func (c *Client) RecordMetric(ctx context.Context, metric string, data ...map[st
 	var requestURL string
 	if details := request.GetAuthDetails(ctx); details.IsService() {
 		requestURL = c.client.ConstructURL("metrics", "server", c.name, metric)
+		if !details.HasToken() {
+			// Fall back to the server session token provider, if one is available
+			if provider := auth.ServerSessionTokenProviderFromContext(ctx); provider != nil {
+				serverSessionToken, err := provider.ServerSessionToken()
+				if err != nil {
+					return errors.Wrap(err, "unable to get server session token")
+				}
+				ctx = request.NewContextWithAuthDetails(ctx, request.NewAuthDetails(request.MethodSessionToken, "", serverSessionToken))
+			}
+		}
 	} else {
 		requestURL = c.client.ConstructURL("metrics", "thisuser", metric)
 	}

--- a/metric/client/client_test.go
+++ b/metric/client/client_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/ghttp"
 
+	"github.com/tidepool-org/platform/auth"
+	"github.com/tidepool-org/platform/errors"
 	"github.com/tidepool-org/platform/log"
 	logNull "github.com/tidepool-org/platform/log/null"
 	"github.com/tidepool-org/platform/metric"
@@ -209,6 +211,62 @@ var _ = Describe("Client", func() {
 				})
 			})
 
+			Context("as service with service secret", func() {
+				var serverSessionToken string
+
+				BeforeEach(func() {
+					serverSessionToken = test.RandomStringFromRangeAndCharset(64, 64, test.CharsetAlphaNumeric)
+					ctx = log.NewContextWithLogger(ctx, logNull.NewLogger())
+					ctx = request.NewContextWithAuthDetails(ctx, request.NewAuthDetails(request.MethodServiceSecret, "", ""))
+				})
+
+				Context("with a server session token provider", func() {
+					BeforeEach(func() {
+						ctx = auth.NewContextWithServerSessionTokenProvider(ctx, &testServerSessionTokenProvider{token: serverSessionToken})
+					})
+
+					Context("with a successful response", func() {
+						BeforeEach(func() {
+							server.AppendHandlers(
+								CombineHandlers(
+									VerifyRequest("GET", "/metrics/server/"+name+"/"+metric, "left=handed&right=correct&sourceVersion=1.2.3"),
+									VerifyHeaderKV("User-Agent", userAgent),
+									VerifyHeaderKV("X-Tidepool-Session-Token", serverSessionToken),
+									VerifyBody(nil),
+									RespondWith(http.StatusOK, nil)),
+							)
+						})
+
+						It("records the metric using the server session token", func() {
+							err := clnt.RecordMetric(ctx, metric, data)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(server.ReceivedRequests()).To(HaveLen(1))
+						})
+					})
+				})
+
+				Context("with a server session token provider that returns an error", func() {
+					BeforeEach(func() {
+						ctx = auth.NewContextWithServerSessionTokenProvider(ctx, &testServerSessionTokenProvider{err: errors.New("session token unavailable")})
+					})
+
+					It("returns an error", func() {
+						err := clnt.RecordMetric(ctx, metric, data)
+						Expect(err).To(MatchError("unable to get server session token; session token unavailable"))
+						Expect(server.ReceivedRequests()).To(BeEmpty())
+					})
+				})
+
+				Context("without a server session token provider", func() {
+					It("returns an error", func() {
+						err := clnt.RecordMetric(ctx, metric, data)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(MatchRegexp("unable to mutate request to .*; session token is missing"))
+						Expect(server.ReceivedRequests()).To(BeEmpty())
+					})
+				})
+			})
+
 			Context("as server", func() {
 				var token string
 
@@ -297,3 +355,12 @@ var _ = Describe("Client", func() {
 		})
 	})
 })
+
+type testServerSessionTokenProvider struct {
+	token string
+	err   error
+}
+
+func (t *testServerSessionTokenProvider) ServerSessionToken() (string, error) {
+	return t.token, t.err
+}


### PR DESCRIPTION
Some metrics aren't being recorded, due to auth issues, and they're
spamming the logs. By falling back to using a server session token,
the metrics should be successfully posted and the logs will be
quieter.
